### PR TITLE
Make sure the arg we are passing is a string

### DIFF
--- a/instana/fsm.py
+++ b/instana/fsm.py
@@ -90,7 +90,7 @@ class Fsm(object):
             return None
 
     def check_host(self, host):
-        l.debug("checking host", host)
+        l.debug("checking host", str(host))
 
         (_, h) = self.agent.request_header(
             self.agent.make_host_url(host, "/"), "GET", "Server")


### PR DESCRIPTION
This fixes a case seen on Travis where the value of `host` may be in bytes.