### PR TITLE
Implement advanced announce for containers

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+
+COPY . ./
+RUN pip install --no-cache-dir -r requirements.txt
+ENV PYTHONPATH /usr/src/app
+ENV INSTANA_DEV true
+
+CMD [ "python", "./example/simple.py" ]

--- a/instana/agent.py
+++ b/instana/agent.py
@@ -33,6 +33,7 @@ class Put(urllib2.Request):
 class Agent(object):
     sensor = None
     host = a.AGENT_DEFAULT_HOST
+    port = a.AGENT_DEFAULT_PORT
     fsm = None
     from_ = None
 
@@ -130,6 +131,9 @@ class Agent(object):
 
     def set_host(self, host):
         self.host = host
+
+    def set_port(self, port):
+        self.port = port
 
     def set_from(self, from_):
         self.from_ = From(**json.loads(from_))

--- a/instana/agent.py
+++ b/instana/agent.py
@@ -104,7 +104,7 @@ class Agent(object):
             # No need to show the initial 404s or timeouts.  The agent
             # should handle those correctly.
             if not (type(e) is urllib2.HTTPError and e.code == 404):
-                l.error("%s: full_request_response: %s" % (threading.current_thread().name, str(e)))
+                l.debug("%s: full_request_response: %s" % (threading.current_thread().name, str(e)))
 
         return (b, h)
 

--- a/instana/fsm.py
+++ b/instana/fsm.py
@@ -124,15 +124,15 @@ class Fsm(object):
 
         (b, _) = self.agent.request_response(
             self.agent.make_url(a.AGENT_DISCOVERY_URL), "PUT", d)
-        if not b:
-            l.error("Cannot announce sensor. Scheduling retry.")
-            self.schedule_retry(self.announce_sensor, e, "announce")
-            return False
-        else:
+        if b:
             self.agent.set_from(b)
             self.fsm.ready()
-            l.warn("Host agent available. We're in business. (Announced pid: %i)" % p.pid)
+            l.warn("Host agent available. We're in business. Announced pid: %i (true pid: %i)" % (p.pid, self.agent.from_.pid))
             return True
+        else:
+            l.error("Cannot announce sensor. Scheduling retry.")
+            self.schedule_retry(self.announce_sensor, e, "announce")
+        return False
 
     def schedule_retry(self, fun, e, name):
         l.debug("Scheduling: " + name)

--- a/instana/fsm.py
+++ b/instana/fsm.py
@@ -140,7 +140,7 @@ class Fsm(object):
         self.timer.daemon = True
         self.timer.name = name
         self.timer.start()
-        l.debug('Threadlist: %s', str(t.enumerate()))
+        l.debug('Threadlist: ', str(t.enumerate()))
 
     def test_agent(self, e):
         l.debug("testing communication with the agent")

--- a/instana/meter.py
+++ b/instana/meter.py
@@ -141,7 +141,7 @@ class Meter(object):
             else:
                 md = copy.deepcopy(cm).delta_data(self.last_metrics)
 
-            ed = EntityData(pid=os.getpid(), snapshot=ss, metrics=md)
+            ed = EntityData(pid=self.sensor.agent.from_.pid, snapshot=ss, metrics=md)
             url = self.sensor.agent.make_url(a.AGENT_DATA_URL)
             self.sensor.agent.request(url, "POST", ed)
             self.last_metrics = cm.__dict__


### PR DESCRIPTION
This PR fixes the many pid == 1 issue when running inside of containers similar to what we do in other languages.

Remaining:
- [x] Don't attempt advanced announce when no `/proc` filesystem (Windows, OSX)