### PR TITLE
Fix: Custom Service Name Support

### DIFF
--- a/instana/recorder.py
+++ b/instana/recorder.py
@@ -110,9 +110,7 @@ class InstanaRecorder(SpanRecorder):
         )
 
         sdk_data.Type = self.get_span_kind(span)
-
-        data = sd.Data(service=self.get_service_name(span),
-                       sdk=sdk_data)
+        data = sd.Data(service=self.get_service_name(span), sdk=sdk_data)
 
         return sd.InstanaSpan(
                     t=span.context.trace_id,
@@ -149,14 +147,6 @@ class InstanaRecorder(SpanRecorder):
         return "localhost"
 
     def get_service_name(self, span):
-        s = self.get_string_tag(span, ext.COMPONENT)
-        if len(s) > 0:
-            return s
-
-        s = self.get_string_tag(span, ext.PEER_SERVICE)
-        if len(s) > 0:
-            return s
-
         return self.sensor.service_name
 
     def get_span_kind(self, span):

--- a/instana/sensor.py
+++ b/instana/sensor.py
@@ -29,9 +29,6 @@ class Sensor(object):
         if self.options:
             self.service_name = self.options.service
 
-        if len(self.service_name) == 0:
-            self.service_name = os.path.basename(__file__)
-
     def handle_fork(self):
         self.agent = a.Agent(self)
         self.meter = m.Meter(self)


### PR DESCRIPTION
We are currently sending a custom service name always which we should avoid doing.

This PR updates the tracer to send a custom service name only when one is configured via `instana.Options`.