### PR TITLE
Better entity naming

### DIFF
--- a/example/simple.py
+++ b/example/simple.py
@@ -6,7 +6,7 @@ import instana.tracer
 import time
 import opentracing.ext.tags as ext
 
-SERVICE = "python-simple"
+SERVICE = "python-overlord"
 
 def main(argv):
     instana.tracer.init(o.Options(service=SERVICE,
@@ -17,8 +17,8 @@ def main(argv):
         simple()
 
 def simple():
-    parent_span = ot.tracer.start_span(operation_name="parent")
-    parent_span.set_tag(ext.COMPONENT, SERVICE)
+    parent_span = ot.tracer.start_span(operation_name="asteroid")
+    parent_span.set_tag(ext.COMPONENT, "Python simple example app")
     parent_span.set_tag(ext.SPAN_KIND, ext.SPAN_KIND_RPC_SERVER)
     parent_span.set_tag(ext.PEER_HOSTNAME, "localhost")
     parent_span.set_tag(ext.HTTP_URL, "/python/simple/one")
@@ -26,7 +26,7 @@ def simple():
     parent_span.set_tag(ext.HTTP_STATUS_CODE, 200)
     parent_span.log_kv({"foo": "bar"})
 
-    child_span = ot.tracer.start_span(operation_name="child", child_of=parent_span)
+    child_span = ot.tracer.start_span(operation_name="spacedust", child_of=parent_span)
     child_span.set_tag(ext.SPAN_KIND, ext.SPAN_KIND_RPC_CLIENT)
     child_span.set_tag(ext.PEER_HOSTNAME, "localhost")
     child_span.set_tag(ext.HTTP_URL, "/python/simple/two")

--- a/instana/meter.py
+++ b/instana/meter.py
@@ -148,12 +148,14 @@ class Meter(object):
 
     def collect_snapshot(self):
         try:
-            if "FLASK_APP" in os.environ:
+            if self.sensor.service_name:
+                appname = self.sensor.service_name
+            elif "FLASK_APP" in os.environ:
                 appname = os.environ["FLASK_APP"]
             elif "DJANGO_SETTINGS_MODULE" in os.environ:
                 appname = os.environ["DJANGO_SETTINGS_MODULE"].split('.')[0]
             else:
-                appname = os.path.basename(sys.executable)
+                appname = os.path.basename(sys.argv[0])
 
             s = Snapshot(name=appname,
                          version=sys.version,


### PR DESCRIPTION
This PR improves the naming of python processes.

Listed in order of precedence (highest to lowest) we use these names:

1. Tracer global service name: `instana.tracer.init(o.Options(service="ServiceName"))`
2. If a Flask or Django app, their respective configured names
3. The running python script via `sys.argv[0]`

Prior to this PR, entities would previously show up as:
![screen shot 2017-09-26 at 12 45 53](https://user-images.githubusercontent.com/395132/30956206-cb40f012-a436-11e7-864a-21e588f11c01.png)

With this fix, they now show up as:

![screen shot 2017-09-28 at 10 13 49](https://user-images.githubusercontent.com/395132/30956219-df90bee4-a436-11e7-8907-3f9a107310dc.png)

and with a tracer configured global service name:
![screen shot 2017-09-28 at 10 04 58](https://user-images.githubusercontent.com/395132/30956220-df93399e-a436-11e7-80b1-2b7c8622e156.png)

