### PR TITLE
Fix: Protect against byte based json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
   - "3.6"
 install: "pip install -r requirements.txt"
 script: nosetests -v

--- a/instana/__init__.py
+++ b/instana/__init__.py
@@ -6,11 +6,11 @@ Instana sensor and tracer. It consists of two modules that can be used as entry 
 """
 
 __author__ = 'Instana Inc.'
-__copyright__ = 'Copyright 2016 Instana Inc.'
-__credits__ = ['Pavlo Baron']
+__copyright__ = 'Copyright 2017 Instana Inc.'
+__credits__ = ['Pavlo Baron', 'Peter Giacomo Lombardo']
 __license__ = 'MIT'
-__version__ = '0.0.1'
-__maintainer__ = 'Pavlo Baron'
-__email__ = 'pavlo.baron@instana.com'
+__version__ = '0.6.6'
+__maintainer__ = 'Peter Giacomo Lombardo'
+__email__ = 'peter.lombardo@instana.com'
 
 __all__ = ['sensor', 'tracer']

--- a/instana/agent.py
+++ b/instana/agent.py
@@ -135,5 +135,10 @@ class Agent(object):
     def set_port(self, port):
         self.port = port
 
-    def set_from(self, from_):
-        self.from_ = From(**json.loads(from_))
+    def set_from(self, json_string):
+        if type(json_string) is bytes:
+            raw_json = json_string.decode("UTF-8")
+        else:
+            raw_json = json_string
+
+        self.from_ = From(**json.loads(raw_json))


### PR DESCRIPTION
This PR adds better handling for json strings that can show up as bytes (found in Python 3.5.2).

Also, update tests to be run against more Python versions.