### PR TITLE
Snapshot: Don't report submodules

### DIFF
--- a/instana/meter.py
+++ b/instana/meter.py
@@ -196,6 +196,9 @@ class Meter(object):
             m = sys.modules
             r = {}
             for k in m:
+                # Don't report submodules (e.g. django.x, django.y, django.z)
+                if ('.' in k):
+                    continue
                 if m[k]:
                     try:
                         d = m[k].__dict__


### PR DESCRIPTION
We currently report loaded submodules (`django.x, django.y, django.z`) which provide very little value in the snapshot.  This PR assures that we only report the top level module which is far less noise and makes the loaded modules pane much easier to read.

<img width="875" alt="screen shot 2017-11-15 at 20 24 35" src="https://user-images.githubusercontent.com/395132/32855796-24c89cac-ca43-11e7-902b-0ae2d8be65d2.png">
