### PR TITLE
Better offline handling

### DIFF
--- a/instana/agent.py
+++ b/instana/agent.py
@@ -3,6 +3,7 @@ from instana import log
 import instana.fsm as f
 import instana.agent_const as a
 import threading
+from datetime import datetime
 
 try:
     import urllib.request as urllib2
@@ -36,6 +37,7 @@ class Agent(object):
     port = a.AGENT_DEFAULT_PORT
     fsm = None
     from_ = From()
+    last_seen = None
 
     def __init__(self, sensor):
         log.debug("initializing agent")
@@ -49,6 +51,13 @@ class Agent(object):
                               sort_keys=False, separators=(',', ':')).encode()
         except Exception as e:
             log.info("to_json: ", e, o)
+
+    def is_timed_out(self):
+        if self.last_seen and self.can_send:
+            diff = datetime.now() - self.last_seen
+            if diff.seconds > 60:
+                return True
+        return False
 
     def can_send(self):
         return self.fsm.fsm.current == "good2go"
@@ -90,6 +99,7 @@ class Agent(object):
                     if self.can_send():
                         self.reset()
                 else:
+                    self.last_seen = datetime.now()
                     if body:
                         b = response.read()
 
@@ -125,6 +135,7 @@ class Agent(object):
         return s
 
     def reset(self):
+        self.last_seen = None
         self.from_ = From()
         self.fsm.reset()
 

--- a/instana/meter.py
+++ b/instana/meter.py
@@ -114,7 +114,6 @@ class Meter(object):
 
     def __init__(self, sensor):
         self.sensor = sensor
-        self.run()
 
     def run(self):
         self.timer = t.Thread(target=self.collect_and_report)
@@ -125,6 +124,10 @@ class Meter(object):
     def collect_and_report(self):
         while 1:
             self.process()
+            if (self.sensor.agent.is_timed_out()):
+                log.warn("Host agent offline for >1 min.  Going to sit in a corner...")
+                self.sensor.agent.reset()
+                break
             time.sleep(1)
 
     def process(self):


### PR DESCRIPTION
- Track the last time the host agent was seen
- Properly timeout if more than 60 seconds
- Fallback into retry announce mode

- On timeout, let metric thread exit
- On successful announce, restart metric thread