### PR TITLE
Add config to disable automatic instrumentation

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -19,3 +19,7 @@ for development.
 ```Python
 export INSTANA_DEV="true"
 ```
+
+## Disabling Automatic instrumentation
+
+You can disable automatic instrumentation (tracing) by setting the environment variable `INSTANA_DISABLE_AUTO_INSTR`.  This will suppress the loading of instrumentation built-into the sensor.

--- a/instana/__init__.py
+++ b/instana/__init__.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
+import os
 import opentracing
 from .sensor import Sensor
 from .tracer import InstanaTracer
 from .options import Options
 
-# Import & initialize instrumentation
-from .instrumentation import urllib3
+if "INSTANA_DISABLE_AUTO_INSTR" not in os.environ:
+    # Import & initialize instrumentation
+    from .instrumentation import urllib3
 
 """
 The Instana package has two core components: the sensor and the tracer.


### PR DESCRIPTION
There are cases when users of the python sensor may not want the automatic instrumentation to be used.  We should add a config option and environment variable to disable initialization of the automatic instrumentation.