### PR TITLE
Urllib3: Respect tracing state

### DIFF
--- a/instana/tracer.py
+++ b/instana/tracer.py
@@ -69,7 +69,10 @@ class InstanaTracer(BasicTracer):
         return self.current_span
 
     def current_context(self):
-        return self.current_span.context
+        context = None
+        if self.current_span:
+            context = self.current_span.context
+        return context
 
     def inject(self, span_context, format, carrier):
         if format in self._propagators:

--- a/tests/test_urllib3.py
+++ b/tests/test_urllib3.py
@@ -10,6 +10,7 @@ class TestUrllib3:
         self.http = urllib3.PoolManager()
         self.recorder = tracer.recorder
         self.recorder.clear_spans()
+        tracer.current_span = None
 
     def tearDown(self):
         """ Do nothing for now """
@@ -18,6 +19,9 @@ class TestUrllib3:
     def test_vanilla_requests(self):
         r = self.http.request('GET', 'http://127.0.0.1:5000/')
         assert_equals(r.status, 200)
+
+        spans = self.recorder.queued_spans()
+        assert_equals(0, len(spans))
 
     def test_get_request(self):
         span = tracer.start_span("test")


### PR DESCRIPTION
This PR fixes the Urllib3 instrumentation to assure that it doesn't trace if there is no active trace happening.