### PR TITLE
Hook lower in urllib3 for greater coverage

### DIFF
--- a/instana/instrumentation/urllib3.py
+++ b/instana/instrumentation/urllib3.py
@@ -1,14 +1,39 @@
 from __future__ import absolute_import
-import opentracing.ext.tags as ext
 import instana
+from instana.log import logger
 import opentracing
+import opentracing.ext.tags as ext
 import wrapt
 
 
 try:
-    import urllib3
+    import urllib3 # noqa
 
-    @wrapt.patch_function_wrapper('urllib3', 'PoolManager.urlopen')
+    def collect(instance, args, kwargs):
+        try:
+            kvs = {}
+
+            kvs['host'] = instance.host
+            kvs['port'] = instance.port
+
+            if len(args) is 2:
+                kvs['method'] = args[0]
+                kvs['path'] = args[1]
+            else:
+                kvs['method'] = kwargs['method']
+                kvs['path'] = kwargs['url']
+
+            if type(instance) is urllib3.connectionpool.HTTPSConnectionPool:
+                kvs['url'] = 'https://%s:%d%s' % (kvs['host'], kvs['port'], kvs['path'])
+            else:
+                kvs['url'] = 'http://%s:%d%s' % (kvs['host'], kvs['port'], kvs['path'])
+        except Exception as e:
+            logger.debug(e)
+            return kvs
+        else:
+            return kvs
+
+    @wrapt.patch_function_wrapper('urllib3', 'HTTPConnectionPool.urlopen')
     def urlopen_with_instana(wrapped, instance, args, kwargs):
         context = instana.internal_tracer.current_context()
 
@@ -18,8 +43,10 @@ try:
 
         try:
             span = instana.internal_tracer.start_span("urllib3", child_of=context)
-            span.set_tag(ext.HTTP_URL, args[1])
-            span.set_tag(ext.HTTP_METHOD, args[0])
+
+            kvs = collect(instance, args, kwargs)
+            span.set_tag(ext.HTTP_URL, kvs['url'])
+            span.set_tag(ext.HTTP_METHOD, kvs['method'])
 
             instana.internal_tracer.inject(span.context, opentracing.Format.HTTP_HEADERS, kwargs["headers"])
             rv = wrapped(*args, **kwargs)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,3 +5,4 @@ basictracer>=2.2.0
 autowrapt>=1.0
 flask>=0.12.2
 urllib3>=1.9
+requests>=2.11.1


### PR DESCRIPTION
* Fixes situation where requests package calls won't be traced
* Add tests that include calls via requests package