### PR TITLE
Urllib3: More safeties in KV collection & processing

### DIFF
--- a/instana/instrumentation/urllib3.py
+++ b/instana/instrumentation/urllib3.py
@@ -10,13 +10,14 @@ try:
     import urllib3 # noqa
 
     def collect(instance, args, kwargs):
+        """ Build and return a fully qualified URL for this request """
         try:
             kvs = {}
 
             kvs['host'] = instance.host
             kvs['port'] = instance.port
 
-            if len(args) is 2:
+            if args is not None and len(args) is 2:
                 kvs['method'] = args[0]
                 kvs['path'] = args[1]
             else:
@@ -45,8 +46,10 @@ try:
             span = instana.internal_tracer.start_span("urllib3", child_of=context)
 
             kvs = collect(instance, args, kwargs)
-            span.set_tag(ext.HTTP_URL, kvs['url'])
-            span.set_tag(ext.HTTP_METHOD, kvs['method'])
+            if 'url' in kvs:
+                span.set_tag(ext.HTTP_URL, kvs['url'])
+            if 'method' in kvs:
+                span.set_tag(ext.HTTP_METHOD, kvs['method'])
 
             instana.internal_tracer.inject(span.context, opentracing.Format.HTTP_HEADERS, kwargs["headers"])
             rv = wrapped(*args, **kwargs)


### PR DESCRIPTION
This fixes the case where if an exception is raised in `collect` that we don't incorrectly try to reference a key that might not be there.  This change also reduces the chance of an exception being raised in `collect`.