### PR TITLE
Standardize on INSTANA_AGENT_HOST; Deprecate *_IP

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -7,7 +7,7 @@ The sensor tries to communicate with the Instana agent via IP 127.0.0.1 and as a
 To use these, these environment variables should be set in the environment of the running Python process.
 
 ```shell
-export INSTANA_AGENT_IP = '127.0.0.1'
+export INSTANA_AGENT_HOST = '127.0.0.1'
 export INSTANA_AGENT_PORT = '42699'
 ```
 

--- a/instana/fsm.py
+++ b/instana/fsm.py
@@ -70,7 +70,14 @@ class Fsm(object):
         host = a.AGENT_DEFAULT_HOST
         port = a.AGENT_DEFAULT_PORT
 
-        if "INSTANA_AGENT_IP" in os.environ:
+        if "INSTANA_AGENT_HOST" in os.environ:
+            host = os.environ["INSTANA_AGENT_HOST"]
+            if "INSTANA_AGENT_PORT" in os.environ:
+                port = int(os.environ["INSTANA_AGENT_PORT"])
+
+        elif "INSTANA_AGENT_IP" in os.environ:
+            # Deprecated: INSTANA_AGENT_IP environment variable
+            # To be removed in a future version
             host = os.environ["INSTANA_AGENT_IP"]
             if "INSTANA_AGENT_PORT" in os.environ:
                 port = int(os.environ["INSTANA_AGENT_PORT"])

--- a/instana/options.py
+++ b/instana/options.py
@@ -16,7 +16,12 @@ class Options(object):
             self.log_level = logging.DEBUG
 
         if "INSTANA_AGENT_IP" in os.environ:
+            # Deprecated: INSTANA_AGENT_IP environment variable
+            # To be removed in a future version
             self.agent_host = os.environ["INSTANA_AGENT_IP"]
+
+        if "INSTANA_AGENT_HOST" in os.environ:
+            self.agent_host = os.environ["INSTANA_AGENT_HOST"]
 
         if "INSTANA_AGENT_PORT" in os.environ:
             self.agent_port = os.environ["INSTANA_AGENT_PORT"]


### PR DESCRIPTION
For the time being, we will still check for and use the INSTANA_HOST_IP environment variable but give INSTANA_AGENT_HOST priority going forward.

INSTANA_HOST_IP will be removed in a future version.