### PR TITLE
Avoid pre-emptively loading Django middleware

### DIFF
--- a/instana/django.py
+++ b/instana/django.py
@@ -3,6 +3,7 @@ import opentracing as ot
 from instana import internal_tracer
 from instana.log import logger
 import opentracing.ext.tags as ext
+import wrapt
 import os
 
 
@@ -49,19 +50,30 @@ class InstanaMiddleware(MiddlewareMixin):
         return response
 
     def process_exception(self, request, exception):
-        logger.warn("process exception")
         if self.span:
             self.span.log_kv({'message': exception})
             self.span.set_tag("error", True)
             ec = self.span.tags.get('ec', 0)
             self.span.set_tag("ec", ec+1)
 
-    # def process_template_response(self, request, response):
-    #     logger.warn("process template response")
-    #
-    # def process_view(self, request, view_func, view_args, view_kwargs):
-    #     logger.warn("process_view %s %s %s %s", request, view_func, view_args, view_kwargs)
+def load_middleware_wrapper(wrapped, instance, args, kwargs):
+    try:
+        from django.conf import settings
 
+        if DJ_INSTANA_MIDDLEWARE in settings.MIDDLEWARE:
+            return
+
+        if type(settings.MIDDLEWARE) is tuple:
+            settings.MIDDLEWARE = (DJ_INSTANA_MIDDLEWARE,) + settings.MIDDLEWARE
+        elif type(settings.MIDDLEWARE) is list:
+            settings.MIDDLEWARE = [DJ_INSTANA_MIDDLEWARE] + settings.MIDDLEWARE
+        else:
+            logger.warn("Instana: Couldn't add InstanaMiddleware to Django")
+
+        return wrapped(*args, **kwargs)
+
+    except Exception as e:
+            logger.warn("Instana: Couldn't add InstanaMiddleware to Django: ", e)
 
 def hook(module):
     """ Hook method to install the Instana middleware into Django >= 1.10 """
@@ -69,33 +81,26 @@ def hook(module):
         print("==============================================================")
         print("Instana: Running django hook")
         print("==============================================================")
-
-    if DJ_INSTANA_MIDDLEWARE in module.settings.MIDDLEWARE:
-        return
-
-    if type(module.settings.MIDDLEWARE) is tuple:
-        module.settings.MIDDLEWARE = (
-                DJ_INSTANA_MIDDLEWARE,) + module.settings.MIDDLEWARE
-    elif type(module.settings.MIDDLEWARE) is list:
-        module.settings.MIDDLEWARE = [
-                DJ_INSTANA_MIDDLEWARE] + module.settings.MIDDLEWARE
-    else:
-        print("Instana: Couldn't add InstanaMiddleware to Django")
+    wrapt.wrap_function_wrapper(module, 'BaseHandler.load_middleware', load_middleware_wrapper)
 
 
 def hook19(module):
-    """ Hook method to install the Instana middleware into Django <= 1.9 """
-    if "INSTANA_DEV" in os.environ:
-        print("==============================================================")
-        print("Instana: Running django19 hook")
-        print("==============================================================")
+    try:
+        """ Hook method to install the Instana middleware into Django <= 1.9 """
+        if "INSTANA_DEV" in os.environ:
+            print("==============================================================")
+            print("Instana: Running django19 hook")
+            print("==============================================================")
 
-    if DJ_INSTANA_MIDDLEWARE in module.settings.MIDDLEWARE_CLASSES:
-        return
+        if DJ_INSTANA_MIDDLEWARE in module.settings.MIDDLEWARE_CLASSES:
+            return
 
-    if type(module.settings.MIDDLEWARE_CLASSES) is tuple:
-        module.settings.MIDDLEWARE_CLASSES = (DJ_INSTANA_MIDDLEWARE,) + module.settings.MIDDLEWARE_CLASSES
-    elif type(module.settings.MIDDLEWARE_CLASSES) is list:
-        module.settings.MIDDLEWARE_CLASSES = [DJ_INSTANA_MIDDLEWARE] + module.settings.MIDDLEWARE_CLASSES
-    else:
-        print("Instana: Couldn't add InstanaMiddleware to Django")
+        if type(module.settings.MIDDLEWARE_CLASSES) is tuple:
+            module.settings.MIDDLEWARE_CLASSES = (DJ_INSTANA_MIDDLEWARE,) + module.settings.MIDDLEWARE_CLASSES
+        elif type(module.settings.MIDDLEWARE_CLASSES) is list:
+            module.settings.MIDDLEWARE_CLASSES = [DJ_INSTANA_MIDDLEWARE] + module.settings.MIDDLEWARE_CLASSES
+        else:
+            logger.warn("Instana: Couldn't add InstanaMiddleware to Django")
+
+    except Exception as e:
+            logger.warn("Instana: Couldn't add InstanaMiddleware to Django: ", e)


### PR DESCRIPTION
For Django >= 1.10, load middleware when load_middleware() is called.