### PR TITLE
Adding GRPC support for HTTP headers

### DIFF
--- a/instana/http_propagator.py
+++ b/instana/http_propagator.py
@@ -26,6 +26,19 @@ class HTTPPropagator():
     ALT_HEADER_KEY_T = 'HTTP_X_INSTANA_T'
     ALT_HEADER_KEY_S = 'HTTP_X_INSTANA_S'
     ALT_HEADER_KEY_L = 'HTTP_X_INSTANA_L'
+    GRPC_SAFE_HEADER_KEY_T = 'x-instana-t'
+    GRPC_SAFE_HEADER_KEY_S = 'x-instana-s'
+    GRPC_SAFE_HEADER_KEY_L = 'x-instana-l'
+    
+    def __init__(self, use_grpc_safe_headers):
+        if(use_grpc_safe_headers):
+            self.header_key_t = self.GRPC_SAFE_HEADER_KEY_T
+            self.header_key_s = self.GRPC_SAFE_HEADER_KEY_S
+            self.header_key_l = self.GRPC_SAFE_HEADER_KEY_L
+        else:
+            self.header_key_t = self.HEADER_KEY_T
+            self.header_key_s = self.HEADER_KEY_S
+            self.header_key_l = self.HEADER_KEY_L
 
     def inject(self, span_context, carrier):
         try:
@@ -33,13 +46,13 @@ class HTTPPropagator():
             span_id = util.id_to_header(span_context.span_id)
 
             if type(carrier) is dict or hasattr(carrier, "__dict__"):
-                carrier[self.HEADER_KEY_T] = trace_id
-                carrier[self.HEADER_KEY_S] = span_id
-                carrier[self.HEADER_KEY_L] = "1"
+                carrier[self.header_key_t] = trace_id
+                carrier[self.header_key_s] = span_id
+                carrier[self.header_key_l] = "1"
             elif type(carrier) is list:
-                carrier.append((self.HEADER_KEY_T, trace_id))
-                carrier.append((self.HEADER_KEY_S, span_id))
-                carrier.append((self.HEADER_KEY_L, "1"))
+                carrier.append((self.header_key_t, trace_id))
+                carrier.append((self.header_key_s, span_id))
+                carrier.append((self.header_key_l, "1"))
             else:
                 raise Exception("Unsupported carrier type", type(carrier))
 
@@ -60,10 +73,15 @@ class HTTPPropagator():
                 trace_id = util.header_to_id(dc[self.HEADER_KEY_T])
                 span_id = util.header_to_id(dc[self.HEADER_KEY_S])
 
-            # Alternatively check for alternate HTTP_X_INSTANA_T/S style
+            # Check for alternate HTTP_X_INSTANA_T/S style
             elif self.ALT_HEADER_KEY_T in dc and self.ALT_HEADER_KEY_S in dc:
                 trace_id = util.header_to_id(dc[self.ALT_HEADER_KEY_T])
                 span_id = util.header_to_id(dc[self.ALT_HEADER_KEY_S])
+
+            # Check for GRPC safe x-instana-t/s style
+            elif self.GRPC_SAFE_HEADER_KEY_T in dc and self.GRPC_SAFE_HEADER_KEY_S in dc:
+                trace_id = util.header_to_id(dc[self.GRPC_SAFE_HEADER_KEY_T])
+                span_id = util.header_to_id(dc[self.GRPC_SAFE_HEADER_KEY_S])
 
             return SpanContext(span_id=span_id,
                                trace_id=trace_id,

--- a/instana/options.py
+++ b/instana/options.py
@@ -7,6 +7,7 @@ class Options(object):
     agent_host = ''
     agent_port = 0
     log_level = logging.WARN
+    use_grpc_safe_http_headers = False
 
     def __init__(self, **kwds):
         """ Initialize Options
@@ -25,5 +26,8 @@ class Options(object):
 
         if "INSTANA_AGENT_PORT" in os.environ:
             self.agent_port = os.environ["INSTANA_AGENT_PORT"]
+
+        if "USE_GRPC_SAFE_HTTP_HEADERS" in os.environ:
+            self.use_grpc_safe_http_headers = os.environ["USE_GRPC_SAFE_HTTP_HEADERS"] == "true"
 
         self.__dict__.update(kwds)

--- a/instana/tracer.py
+++ b/instana/tracer.py
@@ -21,7 +21,7 @@ class InstanaTracer(BasicTracer):
         super(InstanaTracer, self).__init__(
             r.InstanaRecorder(self.sensor), r.InstanaSampler())
 
-        self._propagators[ot.Format.HTTP_HEADERS] = HTTPPropagator()
+        self._propagators[ot.Format.HTTP_HEADERS] = HTTPPropagator(options.use_grpc_safe_http_headers)
         self._propagators[ot.Format.TEXT_MAP] = TextPropagator()
 
     def start_span(


### PR DESCRIPTION
I'm trying to use the [opentracing grpc library](https://github.com/opentracing-contrib/python-grpc) with the instana tracer.
However, the HTTP headers created by instana tracer are considered to be invalid metadata by the grpc lib since it contains upper case characters.

https://github.com/grpc/grpc/blob/master/src/core/lib/surface/validate_metadata.cc
validate_metadata: {"created":"@ ... ","description":"Illegal header key","file":"src/core/lib/surface/validate_metadata.cc","file_line":43,"offset":0,"raw_bytes":" ... 'X-Instana-T'"}

The fix here is to add an optional type of lower case http headers.