### PR TITLE
Remove debug message

### DIFF
--- a/instana/fsm.py
+++ b/instana/fsm.py
@@ -187,7 +187,6 @@ class Fsm(object):
         self.timer.daemon = True
         self.timer.name = name
         self.timer.start()
-        log.debug('Threadlist: ', str(t.enumerate()))
 
     def test_agent(self, e):
         log.debug("testing communication with the agent")


### PR DESCRIPTION
We have (had) a debug message that would log a debug message showing the currently running threads.

Doing this in certain versions of Python may cause an assertion error early in the boot process.