### PR TITLE
WIP: Start cleaning up globals

### DIFF
--- a/instana/__init__.py
+++ b/instana/__init__.py
@@ -55,9 +55,6 @@ global_sensor = Sensor(Options())
 #
 internal_tracer = InstanaTracer()
 
-# Set ourselves as the tracer.
-opentracing.tracer = internal_tracer
-
 # Optional application wide service name.
 # Can be configured via environment variable or via code:
 #

--- a/instana/meter.py
+++ b/instana/meter.py
@@ -149,18 +149,7 @@ class Meter(object):
 
     def collect_snapshot(self):
         try:
-            if instana.service_name:
-                appname = instana.service_name
-            elif "FLASK_APP" in os.environ:
-                appname = os.environ["FLASK_APP"]
-            elif "DJANGO_SETTINGS_MODULE" in os.environ:
-                appname = os.environ["DJANGO_SETTINGS_MODULE"].split('.')[0]
-            elif hasattr(sys, '__interactivehook__') or hasattr(sys, 'ps1'):
-                appname = "Interactive Console"
-            else:
-                appname = os.path.basename(sys.argv[0])
-
-            s = Snapshot(name=appname, version=platform.version(),
+            s = Snapshot(name=self.sensor.options.service_name, version=platform.version(),
                          f=platform.python_implementation(),
                          a=platform.architecture()[0],
                          djmw=self.djmw)

--- a/instana/options.py
+++ b/instana/options.py
@@ -1,11 +1,13 @@
 import logging
 import os
+import sys
 
 
 class Options(object):
     service = ''
     agent_host = ''
     agent_port = 0
+    service_name = 'myservice'
     log_level = logging.WARN
 
     def __init__(self, **kwds):
@@ -25,5 +27,17 @@ class Options(object):
 
         if "INSTANA_AGENT_PORT" in os.environ:
             self.agent_port = os.environ["INSTANA_AGENT_PORT"]
+
+        if "INSTANA_SERVICE_NAME" in os.environ:
+            self.service_name = os.environ["INSTANA_SERVICE_NAME"]
+        elif "FLASK_APP" in os.environ:
+            self.service_name = os.environ["FLASK_APP"]
+        elif "DJANGO_SETTINGS_MODULE" in os.environ:
+            self.service_name = os.environ["DJANGO_SETTINGS_MODULE"].split('.')[0]
+        elif hasattr(sys, '__interactivehook__') or hasattr(sys, 'ps1'):
+            self.service_name = "Interactive Console"
+        else:
+            self.service_name = os.path.basename(sys.argv[0])
+
 
         self.__dict__.update(kwds)

--- a/instana/recorder.py
+++ b/instana/recorder.py
@@ -156,7 +156,7 @@ class InstanaRecorder(SpanRecorder):
         return "localhost"
 
     def get_service_name(self, span):
-        return instana.service_name
+        return self.sensor.options.service_name
 
     def get_span_kind(self, span):
         kind = ""

--- a/instana/tracer.py
+++ b/instana/tracer.py
@@ -16,8 +16,10 @@ class InstanaTracer(BasicTracer):
     sensor = None
     cur_ctx = None
 
-    def __init__(self, options=o.Options()):
-        self.sensor = instana.global_sensor
+    def __init__(self, sensor=None):
+        self.sensor = sensor
+        if not self.sensor:
+            self.sensor = instana.global_sensor
         super(InstanaTracer, self).__init__(
             r.InstanaRecorder(self.sensor), r.InstanaSampler())
 


### PR DESCRIPTION
Start to move some functionality out of global / package level variables, enabling more flexibility in using the library. With this change, you can make multiple tracers with different service names, rather than service name being based on instana.appname (module variable).

I haven't gone through to verify / test it yet but kind of shows where I'd like to take it if / when I have more time to finish. 