### PR TITLE
No pid in the logger instance

### DIFF
--- a/instana/fsm.py
+++ b/instana/fsm.py
@@ -36,6 +36,8 @@ class Fsm(object):
     fsm = None
     timer = None
 
+    warnedPeriodic = False
+
     def __init__(self, agent):
         log.info("Stan is on the scene.  Starting Instana instrumentation version", instana.__version__)
         log.debug("initializing fsm")
@@ -104,7 +106,10 @@ class Fsm(object):
                     self.fsm.announce()
                     return True
 
-        log.info("Instana Host Agent couldn't be found. Scheduling retry.")
+        if (self.warnedPeriodic is False):
+            log.warn("Instana Host Agent couldn't be found. Will retry periodically...")
+            self.warnedPeriodic = True
+
         self.schedule_retry(self.lookup_agent_host, e, "agent_lookup")
         return False
 

--- a/instana/log.py
+++ b/instana/log.py
@@ -1,12 +1,11 @@
 import logging as log
 import os
 
-logger = log.getLogger('instana(' + str(os.getpid()) + ')')
-
+logger = log.getLogger('instana')
 
 def init(level):
     ch = log.StreamHandler()
-    f = log.Formatter('%(asctime)s: %(levelname)s: %(name)s: %(message)s')
+    f = log.Formatter('%(asctime)s: %(process)d %(levelname)s %(name)s: %(message)s')
     ch.setFormatter(f)
     logger.addHandler(ch)
     if "INSTANA_DEV" in os.environ:


### PR DESCRIPTION
## Problem
When using custom logging is hard to override the handler and format of a logger that is named after a process id.

https://github.com/instana/python-sensor/blob/3810da69e05df351e54ca6685160acb9bd0a20f7/instana/log.py#L4

## Proposal
Use the LogRecord attributes to output a per process or per thread log in the format instead.
Optional, use the `dictConfig` to set up loggers.

## For Example

### In
https://github.com/instana/python-sensor/blob/3810da69e05df351e54ca6685160acb9bd0a20f7/instana/log.py#L9
### Do
`[%(process)d - %(thread)d] ...`
and name the logger `instana`

## Reference
* https://docs.python.org/3/library/logging.html#logrecord-attributes
* https://docs.python.org/3/library/logging.config.html#logging.config.dictConfig