### PR TITLE
Add setuptools check on install with clear message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,23 @@
 # coding: utf-8
-from setuptools import setup, find_packages
+from distutils.version import LooseVersion
+
+from setuptools import find_packages, setup
+
+
+def check_setuptools():
+    import pkg_resources
+    st_version = pkg_resources.get_distribution('setuptools').version
+    if LooseVersion(st_version) < LooseVersion('20.2.2'):
+        exit('The Instana sensor requires a newer verion of `setuptools` (>=20.2.2).\n'
+             'Please run `pip install --upgrade setuptools` to upgrade. \n'
+             '  and then try the install again.\n'
+             'Also:\n'
+             '  `pip show setuptools` - shows the current version\n'
+             '  To see the setuptool releases: \n'
+             '    https://setuptools.readthedocs.io/en/latest/history.html')
+
+
+check_setuptools()
 
 setup(name='instana',
       version='0.11.0',


### PR DESCRIPTION
Adds a check on install if setuptools==20.2.2 or greater is installed.  If that check fails, put out a clear message explaining how to resolve:

<img width="845" alt="schermata 2018-07-16 alle 14 51 28" src="https://user-images.githubusercontent.com/395132/42759668-1363ebea-8908-11e8-8090-f83ee60861d5.png">
