### PR TITLE
Asynqp: Fix redundant import

### DIFF
--- a/instana/instrumentation/asynqp.py
+++ b/instana/instrumentation/asynqp.py
@@ -8,7 +8,6 @@ from ..log import logger
 from ..singletons import tracer
 
 try:
-    import asyncio
     import asynqp
 
     @wrapt.patch_function_wrapper('asynqp.exchange','Exchange.publish')

--- a/instana/instrumentation/asynqp.py
+++ b/instana/instrumentation/asynqp.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import sys
+
 import opentracing
 import opentracing.ext.tags as ext
 import wrapt
@@ -7,90 +9,91 @@ import wrapt
 from ..log import logger
 from ..singletons import tracer
 
-try:
-    import asynqp
+if sys.version_info >= (3,4):
+    try:
+        import asynqp
 
-    @wrapt.patch_function_wrapper('asynqp.exchange','Exchange.publish')
-    def publish_with_instana(wrapped, instance, args, kwargs):
-        parent_span = tracer.active_span
+        @wrapt.patch_function_wrapper('asynqp.exchange','Exchange.publish')
+        def publish_with_instana(wrapped, instance, args, kwargs):
+            parent_span = tracer.active_span
 
-        # If we're not tracing, just return
-        if parent_span is None:
-            return wrapped(*args, **kwargs)
+            # If we're not tracing, just return
+            if parent_span is None:
+                return wrapped(*args, **kwargs)
 
-        with tracer.start_active_span("rabbitmq", child_of=parent_span) as scope:
-            host, port = instance.sender.protocol.transport._sock.getsockname()
+            with tracer.start_active_span("rabbitmq", child_of=parent_span) as scope:
+                host, port = instance.sender.protocol.transport._sock.getsockname()
 
-            msg = args[0]
-            if msg.headers is None:
-                msg.headers = {}
-            tracer.inject(scope.span.context, opentracing.Format.HTTP_HEADERS, msg.headers)
+                msg = args[0]
+                if msg.headers is None:
+                    msg.headers = {}
+                tracer.inject(scope.span.context, opentracing.Format.HTTP_HEADERS, msg.headers)
 
-            try:
-                scope.span.set_tag("exchange", instance.name)
-                scope.span.set_tag("sort", "publish")
-                scope.span.set_tag("address", host + ":" + str(port) )
-                scope.span.set_tag("key", args[1])
+                try:
+                    scope.span.set_tag("exchange", instance.name)
+                    scope.span.set_tag("sort", "publish")
+                    scope.span.set_tag("address", host + ":" + str(port) )
+                    scope.span.set_tag("key", args[1])
 
-                rv = wrapped(*args, **kwargs)
-            except Exception as e:
-                scope.span.log_kv({'message': e})
-                scope.span.set_tag("error", True)
-                ec = scope.span.tags.get('ec', 0)
-                scope.span.set_tag("ec", ec+1)
-                raise
-            else:
-                return rv
+                    rv = wrapped(*args, **kwargs)
+                except Exception as e:
+                    scope.span.log_kv({'message': e})
+                    scope.span.set_tag("error", True)
+                    ec = scope.span.tags.get('ec', 0)
+                    scope.span.set_tag("ec", ec+1)
+                    raise
+                else:
+                    return rv
 
-    @wrapt.patch_function_wrapper('asynqp.queue','Queue.get')
-    def get_with_instana(wrapped, instance, args, kwargs):
-        parent_span = tracer.active_span
+        @wrapt.patch_function_wrapper('asynqp.queue','Queue.get')
+        def get_with_instana(wrapped, instance, args, kwargs):
+            parent_span = tracer.active_span
 
-        with tracer.start_active_span("rabbitmq", child_of=parent_span) as scope:
-            host, port = instance.sender.protocol.transport._sock.getsockname()
+            with tracer.start_active_span("rabbitmq", child_of=parent_span) as scope:
+                host, port = instance.sender.protocol.transport._sock.getsockname()
 
-            try:
-                scope.span.set_tag("queue", instance.name)
-                scope.span.set_tag("sort", "consume")
-                scope.span.set_tag("address", host + ":" + str(port) )
+                try:
+                    scope.span.set_tag("queue", instance.name)
+                    scope.span.set_tag("sort", "consume")
+                    scope.span.set_tag("address", host + ":" + str(port) )
 
-                rv = wrapped(*args, **kwargs)
-            except Exception as e:
-                scope.span.log_kv({'message': e})
-                scope.span.set_tag("error", True)
-                ec = scope.span.tags.get('ec', 0)
-                scope.span.set_tag("ec", ec+1)
-                raise
-            else:
-                return rv
+                    rv = wrapped(*args, **kwargs)
+                except Exception as e:
+                    scope.span.log_kv({'message': e})
+                    scope.span.set_tag("error", True)
+                    ec = scope.span.tags.get('ec', 0)
+                    scope.span.set_tag("ec", ec+1)
+                    raise
+                else:
+                    return rv
 
-    @wrapt.patch_function_wrapper('asynqp.queue','Consumers.deliver')
-    def deliver_with_instana(wrapped, instance, args, kwargs):
+        @wrapt.patch_function_wrapper('asynqp.queue','Consumers.deliver')
+        def deliver_with_instana(wrapped, instance, args, kwargs):
 
-        ctx = None
-        msg = args[1]
-        if 'X-Instana-T' in msg.headers and 'X-Instana-S' in msg.headers:
-            ctx = tracer.extract(opentracing.Format.HTTP_HEADERS, dict(msg.headers))
+            ctx = None
+            msg = args[1]
+            if 'X-Instana-T' in msg.headers and 'X-Instana-S' in msg.headers:
+                ctx = tracer.extract(opentracing.Format.HTTP_HEADERS, dict(msg.headers))
 
-        with tracer.start_active_span("rabbitmq", child_of=ctx) as scope:
-            host, port = args[1].sender.protocol.transport._sock.getsockname()
+            with tracer.start_active_span("rabbitmq", child_of=ctx) as scope:
+                host, port = args[1].sender.protocol.transport._sock.getsockname()
 
-            try:
-                scope.span.set_tag("exchange", msg.exchange_name)
-                scope.span.set_tag("sort", "consume")
-                scope.span.set_tag("address", host + ":" + str(port) )
-                scope.span.set_tag("key", msg.routing_key)
+                try:
+                    scope.span.set_tag("exchange", msg.exchange_name)
+                    scope.span.set_tag("sort", "consume")
+                    scope.span.set_tag("address", host + ":" + str(port) )
+                    scope.span.set_tag("key", msg.routing_key)
 
-                rv = wrapped(*args, **kwargs)
-            except Exception as e:
-                scope.span.log_kv({'message': e})
-                scope.span.set_tag("error", True)
-                ec = scope.span.tags.get('ec', 0)
-                scope.span.set_tag("ec", ec+1)
-                raise
-            else:
-                return rv
+                    rv = wrapped(*args, **kwargs)
+                except Exception as e:
+                    scope.span.log_kv({'message': e})
+                    scope.span.set_tag("error", True)
+                    ec = scope.span.tags.get('ec', 0)
+                    scope.span.set_tag("ec", ec+1)
+                    raise
+                else:
+                    return rv
 
-    logger.debug("Instrumenting asynqp")
-except ImportError:
-    pass
+        logger.debug("Instrumenting asynqp")
+    except ImportError:
+        pass


### PR DESCRIPTION
This fix avoids the following stack trace which can occur under some versions of Python.

```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/threading.py", line 1182, in run
    self.function(*self.args, **self.kwargs)
  File "/tmp/instana/python/instana/__init__.py", line 62, in load_instrumentation
    from .instrumentation import asynqp  # noqa
  File "/tmp/instana/python/instana/instrumentation/asynqp.py", line 11, in <module>
    import asyncio
  File "/usr/lib/python3.6/asyncio/__init__.py", line 21, in <module>
    from .base_events import *
  File "/usr/lib/python3.6/asyncio/base_events.py", line 17, in <module>
    import concurrent.futures
  File "/tmp/instana/python/concurrent/futures/__init__.py", line 8, in <module>
    from concurrent.futures._base import (FIRST_COMPLETED,
  File "/tmp/instana/python/concurrent/futures/_base.py", line 414
    raise exception_type, self._exception, self._traceback
                        ^
SyntaxError: invalid syntax
```