### PR TITLE
Limit Asynqp instrumentation to Py versions >=3.4...<3.7

### DIFF
--- a/instana/__init__.py
+++ b/instana/__init__.py
@@ -60,7 +60,7 @@ import instana.singletons #noqa
 def load_instrumentation():
     if "INSTANA_DISABLE_AUTO_INSTR" not in os.environ:
         # Import & initialize instrumentation
-        if sys.version_info >= (3, 4):
+        if sys.version_info >= (3, 4) and sys.version_info < (3, 7):
             from .instrumentation import asynqp  # noqa
         from .instrumentation import mysqlpython  # noqa
         from .instrumentation import redis  # noqa


### PR DESCRIPTION
Asynqp doesn't work on Py 3.7 - don't instrument it

https://github.com/benjamin-hodgson/asynqp/issues/108