### PR TITLE
Respect INSTANA_SERVICE_NAME consistently.

### DIFF
--- a/instana/meter.py
+++ b/instana/meter.py
@@ -201,7 +201,9 @@ class Meter(object):
     def collect_snapshot(self):
         """  Collects snapshot related information to this process and environment """
         try:
-            if "FLASK_APP" in os.environ:
+            if "INSTANA_SERVICE_NAME" in os.environ:
+                appname = os.environ["INSTANA_SERVICE_NAME"]
+            elif "FLASK_APP" in os.environ:
                 appname = os.environ["FLASK_APP"]
             elif "DJANGO_SETTINGS_MODULE" in os.environ:
                 appname = os.environ["DJANGO_SETTINGS_MODULE"].split('.')[0]

--- a/instana/options.py
+++ b/instana/options.py
@@ -3,7 +3,7 @@ import os
 
 
 class Options(object):
-    service = ''
+    service = None
     service_name = None
     agent_host = ''
     agent_port = 0

--- a/instana/recorder.py
+++ b/instana/recorder.py
@@ -93,8 +93,7 @@ class InstanaRecorder(SpanRecorder):
 
     def build_registered_span(self, span):
         """ Takes a BasicSpan and converts it into a registered JsonSpan """
-        data = Data(baggage=span.context.baggage,
-                    service=instana.singletons.agent.sensor.options.service_name)
+        data = Data(baggage=span.context.baggage)
 
         logs = self.collect_logs(span)
         if len(logs) > 0:

--- a/instana/recorder.py
+++ b/instana/recorder.py
@@ -93,7 +93,8 @@ class InstanaRecorder(SpanRecorder):
 
     def build_registered_span(self, span):
         """ Takes a BasicSpan and converts it into a registered JsonSpan """
-        data = Data(baggage=span.context.baggage)
+        data = Data(baggage=span.context.baggage,
+                    service=instana.singletons.agent.sensor.options.service_name)
 
         logs = self.collect_logs(span)
         if len(logs) > 0:
@@ -191,7 +192,8 @@ class InstanaRecorder(SpanRecorder):
                            custom=custom_data)
 
         sdk_data.Type = self.get_span_kind(span)
-        data = Data(service=self.get_service_name(span), sdk=sdk_data)
+        data = Data(service=instana.singletons.agent.sensor.options.service_name,
+                    sdk=sdk_data)
         entity_from = {'e': instana.singletons.agent.from_.pid,
                       'h': instana.singletons.agent.from_.agentUuid}
 
@@ -224,9 +226,6 @@ class InstanaRecorder(SpanRecorder):
             return h
 
         return "localhost"
-
-    def get_service_name(self, span):
-        return instana.singletons.agent.sensor.options.service_name
 
     def get_span_kind(self, span):
         kind = ""


### PR DESCRIPTION
If the `INSTANA_SERVICE_NAME` environment variable is set, we should apply it's value consistently across tracing and snapshot reporting.