### PR TITLE
Use /proc/net/route to determine default gateway

### DIFF
--- a/instana/fsm.py
+++ b/instana/fsm.py
@@ -12,6 +12,7 @@ import pkg_resources
 
 from .agent_const import AGENT_DEFAULT_HOST, AGENT_DEFAULT_PORT
 from .log import logger
+from .util import get_default_gateway
 
 
 class Discovery(object):
@@ -86,7 +87,7 @@ class Fsm(object):
             self.fsm.announce()
             return True
         elif os.path.exists("/proc/"):
-            host = self.get_default_gateway()
+            host = get_default_gateway()
             if host:
                 if self.agent.is_agent_listening(host, port):
                     self.agent.host = host
@@ -100,21 +101,6 @@ class Fsm(object):
 
         self.schedule_retry(self.lookup_agent_host, e, "agent_lookup")
         return False
-
-    def get_default_gateway(self):
-        logger.debug("checking default gateway")
-
-        try:
-            proc = subprocess.Popen(
-                "/sbin/ip route | awk '/default/' | cut -d ' ' -f 3 | tr -d '\n'",
-                shell=True, stdout=subprocess.PIPE)
-
-            addr = proc.stdout.read()
-            return addr.decode("UTF-8")
-        except Exception as e:
-            logger.error(e)
-
-            return None
 
     def announce_sensor(self, e):
         logger.debug("announcing sensor to the agent")

--- a/instana/util.py
+++ b/instana/util.py
@@ -172,6 +172,11 @@ def strip_secrets(qp, matcher, kwlist):
 
 
 def get_default_gateway():
+    """
+    Attempts to read /proc/self/net/route to determine the default gateway in use.
+
+    :return: String - the ip address of the default gateway or None if not found/possible/non-existant
+    """
     try:
         # The first line is the header line
         # We look for the line where the Destination is 00000000 - that is the default route
@@ -182,7 +187,7 @@ def get_default_gateway():
                 if '00000000' == parts[1]:
                     hip = parts[2]
 
-        if hip is not None:
+        if hip is not None and len(hip) is 8:
             # Reverse order, convert hex to int
             return "%i.%i.%i.%i" % (int(hip[6:8], 16), int(hip[4:6], 16), int(hip[2:4], 16), int(hip[0:2], 16))
 

--- a/instana/util.py
+++ b/instana/util.py
@@ -170,6 +170,26 @@ def strip_secrets(qp, matcher, kwlist):
     except:
         logger.debug("strip_secrets", exc_info=True)
 
+
+def get_default_gateway():
+    try:
+        # The first line is the header line
+        # We look for the line where the Destination is 00000000 - that is the default route
+        # The Gateway IP is encoded backwards in hex.
+        with open("/proc/self/net/route") as routes:
+            for line in routes:
+                parts = line.split('\t')
+                if '00000000' == parts[1]:
+                    hip = parts[2]
+
+        if hip is not None:
+            # Reverse order, convert hex to int
+            return "%i.%i.%i.%i" % (int(hip[6:8], 16), int(hip[4:6], 16), int(hip[2:4], 16), int(hip[0:2], 16))
+
+    except:
+        logger.warn("get_default_gateway: ", exc_info=True)
+
+
 def get_py_source(file):
     """
     Retrieves and returns the source code for any Python

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ traces to your Instana dashboard.",
             'redis<3.0.0',
             'requests>=2.17.1',
             'sqlalchemy>=1.1.15',
-            'spyne>=2.9',
+            'spyne>=2.9,<=2.12.14',
             'suds-jurko>=0.6',
             'urllib3[secure]>=1.15'
         ],


### PR DESCRIPTION
This also removes the external dependency of using /sbin/ip to determine host routes.