### PR TITLE
Send Server-Timing in response headers

### DIFF
--- a/instana/http_propagator.py
+++ b/instana/http_propagator.py
@@ -25,15 +25,20 @@ class HTTPPropagator():
     HEADER_KEY_T = 'X-Instana-T'
     HEADER_KEY_S = 'X-Instana-S'
     HEADER_KEY_L = 'X-Instana-L'
+    HEADER_KEY_ST = 'Server-Timing'
     LC_HEADER_KEY_T = 'x-instana-t'
     LC_HEADER_KEY_S = 'x-instana-s'
     LC_HEADER_KEY_L = 'x-instana-l'
+    LC_HEADER_KEY_ST = 'server-timing'
+
     ALT_HEADER_KEY_T = 'HTTP_X_INSTANA_T'
     ALT_HEADER_KEY_S = 'HTTP_X_INSTANA_S'
     ALT_HEADER_KEY_L = 'HTTP_X_INSTANA_L'
+    ATL_HEADER_KEY_ST = 'HTTP_SERVER_TIMING'
     ALT_LC_HEADER_KEY_T = 'http_x_instana_t'
     ALT_LC_HEADER_KEY_S = 'http_x_instana_s'
     ALT_LC_HEADER_KEY_L = 'http_x_instana_l'
+    ATL_LC_HEADER_KEY_ST = 'http_server_timing'
 
     def inject(self, span_context, carrier):
         try:
@@ -44,10 +49,12 @@ class HTTPPropagator():
                 carrier[self.HEADER_KEY_T] = trace_id
                 carrier[self.HEADER_KEY_S] = span_id
                 carrier[self.HEADER_KEY_L] = "1"
+                carrier[self.HEADER_KEY_ST] = "intid;desc=%s" % trace_id
             elif type(carrier) is list:
                 carrier.append((self.HEADER_KEY_T, trace_id))
                 carrier.append((self.HEADER_KEY_S, span_id))
                 carrier.append((self.HEADER_KEY_L, "1"))
+                carrier.append((self.HEADER_KEY_ST, "intid;desc=%s" % trace_id))
             else:
                 raise Exception("Unsupported carrier type", type(carrier))
 

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -29,12 +29,6 @@ class TestDjango(StaticLiveServerTestCase):
 
         assert response
         assert_equals(200, response.status)
-        assert('X-Instana-T' in response.headers)
-        assert(int(response.headers['X-Instana-T'], 16))
-        assert('X-Instana-S' in response.headers)
-        assert(int(response.headers['X-Instana-S'], 16))
-        assert('X-Instana-L' in response.headers)
-        assert_equals('1', response.headers['X-Instana-L'])
 
         spans = self.recorder.queued_spans()
         assert_equals(3, len(spans))
@@ -42,6 +36,21 @@ class TestDjango(StaticLiveServerTestCase):
         test_span = spans[2]
         urllib3_span = spans[1]
         django_span = spans[0]
+
+        assert ('X-Instana-T' in response.headers)
+        assert (int(response.headers['X-Instana-T'], 16))
+        self.assertEqual(django_span.t, response.headers['X-Instana-T'])
+
+        assert ('X-Instana-S' in response.headers)
+        assert (int(response.headers['X-Instana-S'], 16))
+        self.assertEqual(django_span.s, response.headers['X-Instana-S'])
+
+        assert ('X-Instana-L' in response.headers)
+        assert_equals('1', response.headers['X-Instana-L'])
+
+        server_timing_value = "intid;desc=%s" % django_span.t
+        assert ('Server-Timing' in response.headers)
+        self.assertEqual(server_timing_value, response.headers['Server-Timing'])
 
         assert_equals("test", test_span.data.sdk.name)
         assert_equals("urllib3", urllib3_span.n)
@@ -68,12 +77,6 @@ class TestDjango(StaticLiveServerTestCase):
 
         assert response
         assert_equals(500, response.status)
-        assert('X-Instana-T' in response.headers)
-        assert(int(response.headers['X-Instana-T'], 16))
-        assert('X-Instana-S' in response.headers)
-        assert(int(response.headers['X-Instana-S'], 16))
-        assert('X-Instana-L' in response.headers)
-        assert_equals('1', response.headers['X-Instana-L'])
 
         spans = self.recorder.queued_spans()
         assert_equals(3, len(spans))
@@ -81,6 +84,21 @@ class TestDjango(StaticLiveServerTestCase):
         test_span = spans[2]
         urllib3_span = spans[1]
         django_span = spans[0]
+
+        assert ('X-Instana-T' in response.headers)
+        assert (int(response.headers['X-Instana-T'], 16))
+        self.assertEqual(django_span.t, response.headers['X-Instana-T'])
+
+        assert ('X-Instana-S' in response.headers)
+        assert (int(response.headers['X-Instana-S'], 16))
+        self.assertEqual(django_span.s, response.headers['X-Instana-S'])
+
+        assert ('X-Instana-L' in response.headers)
+        assert_equals('1', response.headers['X-Instana-L'])
+
+        server_timing_value = "intid;desc=%s" % django_span.t
+        assert ('Server-Timing' in response.headers)
+        self.assertEqual(server_timing_value, response.headers['Server-Timing'])
 
         assert_equals("test", test_span.data.sdk.name)
         assert_equals("urllib3", urllib3_span.n)
@@ -108,13 +126,6 @@ class TestDjango(StaticLiveServerTestCase):
 
         assert response
         assert_equals(200, response.status)
-        assert('X-Instana-T' in response.headers)
-        assert(int(response.headers['X-Instana-T'], 16))
-        assert('X-Instana-S' in response.headers)
-        assert(int(response.headers['X-Instana-S'], 16))
-        assert('X-Instana-L' in response.headers)
-        assert_equals('1', response.headers['X-Instana-L'])
-
         spans = self.recorder.queued_spans()
         assert_equals(5, len(spans))
 
@@ -123,6 +134,21 @@ class TestDjango(StaticLiveServerTestCase):
         django_span = spans[2]
         ot_span1 = spans[1]
         ot_span2 = spans[0]
+
+        assert ('X-Instana-T' in response.headers)
+        assert (int(response.headers['X-Instana-T'], 16))
+        self.assertEqual(django_span.t, response.headers['X-Instana-T'])
+
+        assert ('X-Instana-S' in response.headers)
+        assert (int(response.headers['X-Instana-S'], 16))
+        self.assertEqual(django_span.s, response.headers['X-Instana-S'])
+
+        assert ('X-Instana-L' in response.headers)
+        assert_equals('1', response.headers['X-Instana-L'])
+
+        server_timing_value = "intid;desc=%s" % django_span.t
+        assert ('Server-Timing' in response.headers)
+        self.assertEqual(server_timing_value, response.headers['Server-Timing'])
 
         assert_equals("test", test_span.data.sdk.name)
         assert_equals("urllib3", urllib3_span.n)
@@ -163,12 +189,6 @@ class TestDjango(StaticLiveServerTestCase):
 
         assert response
         assert_equals(200, response.status)
-        assert('X-Instana-T' in response.headers)
-        assert(int(response.headers['X-Instana-T'], 16))
-        assert('X-Instana-S' in response.headers)
-        assert(int(response.headers['X-Instana-S'], 16))
-        assert('X-Instana-L' in response.headers)
-        assert_equals('1', response.headers['X-Instana-L'])
 
         spans = self.recorder.queued_spans()
         assert_equals(3, len(spans))
@@ -210,13 +230,6 @@ class TestDjango(StaticLiveServerTestCase):
 
         assert response
         assert_equals(200, response.status)
-        assert('X-Instana-T' in response.headers)
-        assert(int(response.headers['X-Instana-T'], 16))
-        self.assertEqual('0000000000000001', response.headers['X-Instana-T'])
-        assert('X-Instana-S' in response.headers)
-        assert(int(response.headers['X-Instana-S'], 16))
-        assert('X-Instana-L' in response.headers)
-        assert_equals('1', response.headers['X-Instana-L'])
 
         spans = self.recorder.queued_spans()
         assert_equals(1, len(spans))
@@ -225,6 +238,21 @@ class TestDjango(StaticLiveServerTestCase):
 
         assert_equals(django_span.t, '0000000000000001')
         assert_equals(django_span.p, '0000000000000001')
+
+        assert ('X-Instana-T' in response.headers)
+        assert (int(response.headers['X-Instana-T'], 16))
+        self.assertEqual(django_span.t, response.headers['X-Instana-T'])
+
+        assert ('X-Instana-S' in response.headers)
+        assert (int(response.headers['X-Instana-S'], 16))
+        self.assertEqual(django_span.s, response.headers['X-Instana-S'])
+
+        assert ('X-Instana-L' in response.headers)
+        assert_equals('1', response.headers['X-Instana-L'])
+
+        server_timing_value = "intid;desc=%s" % django_span.t
+        assert ('Server-Timing' in response.headers)
+        self.assertEqual(server_timing_value, response.headers['Server-Timing'])
 
     def test_with_incoming_mixed_case_context(self):
         request_headers = dict()
@@ -235,13 +263,6 @@ class TestDjango(StaticLiveServerTestCase):
 
         assert response
         assert_equals(200, response.status)
-        assert('X-Instana-T' in response.headers)
-        assert(int(response.headers['X-Instana-T'], 16))
-        self.assertEqual('0000000000000001', response.headers['X-Instana-T'])
-        assert('X-Instana-S' in response.headers)
-        assert(int(response.headers['X-Instana-S'], 16))
-        assert('X-Instana-L' in response.headers)
-        assert_equals('1', response.headers['X-Instana-L'])
 
         spans = self.recorder.queued_spans()
         assert_equals(1, len(spans))
@@ -250,3 +271,18 @@ class TestDjango(StaticLiveServerTestCase):
 
         assert_equals(django_span.t, '0000000000000001')
         assert_equals(django_span.p, '0000000000000001')
+
+        assert ('X-Instana-T' in response.headers)
+        assert (int(response.headers['X-Instana-T'], 16))
+        self.assertEqual(django_span.t, response.headers['X-Instana-T'])
+
+        assert ('X-Instana-S' in response.headers)
+        assert (int(response.headers['X-Instana-S'], 16))
+        self.assertEqual(django_span.s, response.headers['X-Instana-S'])
+
+        assert ('X-Instana-L' in response.headers)
+        assert_equals('1', response.headers['X-Instana-L'])
+
+        server_timing_value = "intid;desc=%s" % django_span.t
+        assert ('Server-Timing' in response.headers)
+        self.assertEqual(server_timing_value, response.headers['Server-Timing'])

--- a/tests/test_ot_propagators.py
+++ b/tests/test_ot_propagators.py
@@ -21,7 +21,7 @@ def test_basics():
     assert callable(extract_func)
 
 
-def test_inject():
+def test_inject_with_dict():
     opts = options.Options()
     ot.tracer = InstanaTracer(opts)
 
@@ -35,6 +35,24 @@ def test_inject():
     assert_equals(carrier['X-Instana-S'], span.context.span_id)
     assert 'X-Instana-L' in carrier
     assert_equals(carrier['X-Instana-L'], "1")
+    assert 'Server-Timing' in carrier
+    server_timing_value = "intid;desc=%s" % span.context.trace_id
+    assert_equals(carrier['Server-Timing'], server_timing_value)
+
+
+def test_inject_with_list():
+    opts = options.Options()
+    ot.tracer = InstanaTracer(opts)
+
+    carrier = []
+    span = ot.tracer.start_span("nosetests")
+    ot.tracer.inject(span.context, ot.Format.HTTP_HEADERS, carrier)
+
+    assert ('X-Instana-T', span.context.trace_id) in carrier
+    assert ('X-Instana-S', span.context.span_id) in carrier
+    assert ('X-Instana-L', "1") in carrier
+    server_timing_value = "intid;desc=%s" % span.context.trace_id
+    assert ('Server-Timing', server_timing_value) in carrier
 
 
 def test_basic_extract():

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -42,12 +42,21 @@ class TestWSGI(unittest.TestCase):
 
         assert response
         self.assertEqual(200, response.status)
+
         assert('X-Instana-T' in response.headers)
         assert(int(response.headers['X-Instana-T'], 16))
+        self.assertEqual(response.headers['X-Instana-T'], wsgi_span.t)
+
         assert('X-Instana-S' in response.headers)
         assert(int(response.headers['X-Instana-S'], 16))
+        self.assertEqual(response.headers['X-Instana-S'], wsgi_span.s)
+
         assert('X-Instana-L' in response.headers)
-        self.assertEqual('1', response.headers['X-Instana-L'])
+        self.assertEqual(response.headers['X-Instana-L'], '1')
+
+        assert('Server-Timing' in response.headers)
+        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        self.assertEqual(response.headers['Server-Timing'], server_timing_value)
 
         # Same traceId
         self.assertEqual(test_span.t, urllib3_span.t)
@@ -91,12 +100,21 @@ class TestWSGI(unittest.TestCase):
 
         assert response
         self.assertEqual(200, response.status)
+
         assert('X-Instana-T' in response.headers)
         assert(int(response.headers['X-Instana-T'], 16))
+        self.assertEqual(response.headers['X-Instana-T'], wsgi_span.t)
+
         assert('X-Instana-S' in response.headers)
         assert(int(response.headers['X-Instana-S'], 16))
+        self.assertEqual(response.headers['X-Instana-S'], wsgi_span.s)
+
         assert('X-Instana-L' in response.headers)
-        self.assertEqual('1', response.headers['X-Instana-L'])
+        self.assertEqual(response.headers['X-Instana-L'], '1')
+
+        assert('Server-Timing' in response.headers)
+        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        self.assertEqual(response.headers['Server-Timing'], server_timing_value)
 
         # Same traceId
         trace_id = test_span.t
@@ -155,12 +173,21 @@ class TestWSGI(unittest.TestCase):
 
         assert response
         self.assertEqual(200, response.status)
+
         assert('X-Instana-T' in response.headers)
         assert(int(response.headers['X-Instana-T'], 16))
+        self.assertEqual(response.headers['X-Instana-T'], wsgi_span.t)
+
         assert('X-Instana-S' in response.headers)
         assert(int(response.headers['X-Instana-S'], 16))
+        self.assertEqual(response.headers['X-Instana-S'], wsgi_span.s)
+
         assert('X-Instana-L' in response.headers)
-        self.assertEqual('1', response.headers['X-Instana-L'])
+        self.assertEqual(response.headers['X-Instana-L'], '1')
+
+        assert('Server-Timing' in response.headers)
+        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        self.assertEqual(response.headers['Server-Timing'], server_timing_value)
 
         # Same traceId
         self.assertEqual(test_span.t, urllib3_span.t)
@@ -208,12 +235,21 @@ class TestWSGI(unittest.TestCase):
 
         assert response
         self.assertEqual(200, response.status)
+
         assert('X-Instana-T' in response.headers)
         assert(int(response.headers['X-Instana-T'], 16))
+        self.assertEqual(response.headers['X-Instana-T'], wsgi_span.t)
+
         assert('X-Instana-S' in response.headers)
         assert(int(response.headers['X-Instana-S'], 16))
+        self.assertEqual(response.headers['X-Instana-S'], wsgi_span.s)
+
         assert('X-Instana-L' in response.headers)
-        self.assertEqual('1', response.headers['X-Instana-L'])
+        self.assertEqual(response.headers['X-Instana-L'], '1')
+
+        assert('Server-Timing' in response.headers)
+        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        self.assertEqual(response.headers['Server-Timing'], server_timing_value)
 
         # Same traceId
         self.assertEqual(test_span.t, urllib3_span.t)
@@ -251,21 +287,29 @@ class TestWSGI(unittest.TestCase):
 
         assert response
         self.assertEqual(200, response.status)
-        assert('X-Instana-T' in response.headers)
-        assert(int(response.headers['X-Instana-T'], 16))
-        self.assertEqual('0000000000000001', response.headers['X-Instana-T'])
-        assert('X-Instana-S' in response.headers)
-        assert(int(response.headers['X-Instana-S'], 16))
-        assert('X-Instana-L' in response.headers)
-        self.assertEqual('1', response.headers['X-Instana-L'])
 
         spans = self.recorder.queued_spans()
         self.assertEqual(1, len(spans))
 
-        django_span = spans[0]
+        wsgi_span = spans[0]
 
-        self.assertEqual(django_span.t, '0000000000000001')
-        self.assertEqual(django_span.p, '0000000000000001')
+        self.assertEqual(wsgi_span.t, '0000000000000001')
+        self.assertEqual(wsgi_span.p, '0000000000000001')
+
+        assert('X-Instana-T' in response.headers)
+        assert(int(response.headers['X-Instana-T'], 16))
+        self.assertEqual(response.headers['X-Instana-T'], wsgi_span.t)
+
+        assert('X-Instana-S' in response.headers)
+        assert(int(response.headers['X-Instana-S'], 16))
+        self.assertEqual(response.headers['X-Instana-S'], wsgi_span.s)
+
+        assert('X-Instana-L' in response.headers)
+        self.assertEqual(response.headers['X-Instana-L'], '1')
+
+        assert('Server-Timing' in response.headers)
+        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        self.assertEqual(response.headers['Server-Timing'], server_timing_value)
 
     def test_with_incoming_mixed_case_context(self):
         request_headers = dict()
@@ -276,18 +320,58 @@ class TestWSGI(unittest.TestCase):
 
         assert response
         self.assertEqual(200, response.status)
-        assert('X-Instana-T' in response.headers)
-        assert(int(response.headers['X-Instana-T'], 16))
-        self.assertEqual('0000000000000001', response.headers['X-Instana-T'])
-        assert('X-Instana-S' in response.headers)
-        assert(int(response.headers['X-Instana-S'], 16))
-        assert('X-Instana-L' in response.headers)
-        self.assertEqual('1', response.headers['X-Instana-L'])
 
         spans = self.recorder.queued_spans()
         self.assertEqual(1, len(spans))
 
-        django_span = spans[0]
+        wsgi_span = spans[0]
 
-        self.assertEqual(django_span.t, '0000000000000001')
-        self.assertEqual(django_span.p, '0000000000000001')
+        self.assertEqual(wsgi_span.t, '0000000000000001')
+        self.assertEqual(wsgi_span.p, '0000000000000001')
+
+        assert('X-Instana-T' in response.headers)
+        assert(int(response.headers['X-Instana-T'], 16))
+        self.assertEqual(response.headers['X-Instana-T'], wsgi_span.t)
+
+        assert('X-Instana-S' in response.headers)
+        assert(int(response.headers['X-Instana-S'], 16))
+        self.assertEqual(response.headers['X-Instana-S'], wsgi_span.s)
+
+        assert('X-Instana-L' in response.headers)
+        self.assertEqual(response.headers['X-Instana-L'], '1')
+
+        assert('Server-Timing' in response.headers)
+        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        self.assertEqual(response.headers['Server-Timing'], server_timing_value)
+
+    def test_response_headers(self):
+        with tracer.start_active_span('test'):
+            response = self.http.request('GET', 'http://127.0.0.1:5000/')
+
+        spans = self.recorder.queued_spans()
+
+        self.assertEqual(3, len(spans))
+        self.assertIsNone(tracer.active_span)
+
+        wsgi_span = spans[0]
+        urllib3_span = spans[1]
+        test_span = spans[2]
+
+        assert response
+        self.assertEqual(200, response.status)
+
+        assert('X-Instana-T' in response.headers)
+        assert(int(response.headers['X-Instana-T'], 16))
+        self.assertEqual(response.headers['X-Instana-T'], wsgi_span.t)
+
+        assert('X-Instana-S' in response.headers)
+        assert(int(response.headers['X-Instana-S'], 16))
+        self.assertEqual(response.headers['X-Instana-S'], wsgi_span.s)
+
+        assert('X-Instana-L' in response.headers)
+        self.assertEqual(response.headers['X-Instana-L'], '1')
+
+        assert('Server-Timing' in response.headers)
+        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        self.assertEqual(response.headers['Server-Timing'], server_timing_value)
+


### PR DESCRIPTION
This PR adds support for the `Server-Timing` header in HTTP responses for full EUM support.