### PR TITLE
Only update working_set when loaded into live process

### DIFF
--- a/instana/__init__.py
+++ b/instana/__init__.py
@@ -25,7 +25,8 @@ Tracer
   Recorder
 """
 
-pkg_resources.working_set.add_entry("/tmp/instana/python")
+if "INSTANA_MAGIC" in os.environ:
+    pkg_resources.working_set.add_entry("/tmp/instana/python")
 
 __author__ = 'Instana Inc.'
 __copyright__ = 'Copyright 2018 Instana Inc.'


### PR DESCRIPTION
This fixes load path priority for manually instrumented Python processes.