### PR TITLE
fixed case

### DIFF
--- a/instana/json_span.py
+++ b/instana/json_span.py
@@ -124,7 +124,7 @@ class SDKData(object):
     name = None
     type = None
     arguments = None
-    Return = None
+    return = None
     custom = None
 
     def __init__(self, **kwds):

--- a/instana/json_span.py
+++ b/instana/json_span.py
@@ -122,7 +122,7 @@ class SoapData(object):
 
 class SDKData(object):
     name = None
-    Type = None
+    type = None
     arguments = None
     Return = None
     custom = None

--- a/instana/recorder.py
+++ b/instana/recorder.py
@@ -210,7 +210,7 @@ class InstanaRecorder(SpanRecorder):
         sdk_data = SDKData(name=span.operation_name,
                            custom=custom_data)
 
-        sdk_data.Type = self.get_span_kind(span)
+        sdk_data.type = self.get_span_kind(span)
         data = Data(service=instana.singletons.agent.sensor.options.service_name,
                     sdk=sdk_data)
         entity_from = {'e': instana.singletons.agent.from_.pid,


### PR DESCRIPTION
The type field for the SDK data object had the wrong case Type not type. The trace processing on the backend does a case sensitive lookup of this field. It does not find Type so tags the span as entry, the default. This makes it impossible to have an intermediate span, this fixes that.