### PR TITLE
Asynqp: Protect against short tuples

### DIFF
--- a/instana/instrumentation/asynqp.py
+++ b/instana/instrumentation/asynqp.py
@@ -30,7 +30,9 @@ try:
                 scope.span.set_tag("exchange", instance.name)
                 scope.span.set_tag("sort", "publish")
                 scope.span.set_tag("address", host + ":" + str(port) )
-                scope.span.set_tag("key", argv[1])
+
+                if len(argv) > 1 and argv[1] is not None:
+                    scope.span.set_tag("key", argv[1])
 
                 rv = wrapped(*argv, **kwargs)
             except Exception as e:

--- a/tests/test_asynqp.py
+++ b/tests/test_asynqp.py
@@ -66,7 +66,7 @@ class TestAsynqp(unittest.TestCase):
         @asyncio.coroutine
         def test():
             with async_tracer.start_active_span('test'):
-                msg = asynqp.Message({'hello': 'world'})
+                msg = asynqp.Message({'hello': 'world'}, content_type='application/json')
                 self.exchange.publish(msg, 'routing.key')
 
         self.loop.run_until_complete(test())


### PR DESCRIPTION
A case was identified where the incoming tuple of argv in publish_message
may be shorter than expected.  This change protects against accessing beyond
the length of the tuple.