### PR TITLE
Handle Server-Timing headers manually

### DIFF
--- a/instana/http_propagator.py
+++ b/instana/http_propagator.py
@@ -25,20 +25,16 @@ class HTTPPropagator():
     HEADER_KEY_T = 'X-Instana-T'
     HEADER_KEY_S = 'X-Instana-S'
     HEADER_KEY_L = 'X-Instana-L'
-    HEADER_KEY_ST = 'Server-Timing'
     LC_HEADER_KEY_T = 'x-instana-t'
     LC_HEADER_KEY_S = 'x-instana-s'
     LC_HEADER_KEY_L = 'x-instana-l'
-    LC_HEADER_KEY_ST = 'server-timing'
 
     ALT_HEADER_KEY_T = 'HTTP_X_INSTANA_T'
     ALT_HEADER_KEY_S = 'HTTP_X_INSTANA_S'
     ALT_HEADER_KEY_L = 'HTTP_X_INSTANA_L'
-    ATL_HEADER_KEY_ST = 'HTTP_SERVER_TIMING'
     ALT_LC_HEADER_KEY_T = 'http_x_instana_t'
     ALT_LC_HEADER_KEY_S = 'http_x_instana_s'
     ALT_LC_HEADER_KEY_L = 'http_x_instana_l'
-    ATL_LC_HEADER_KEY_ST = 'http_server_timing'
 
     def inject(self, span_context, carrier):
         try:
@@ -49,17 +45,14 @@ class HTTPPropagator():
                 carrier[self.HEADER_KEY_T] = trace_id
                 carrier[self.HEADER_KEY_S] = span_id
                 carrier[self.HEADER_KEY_L] = "1"
-                carrier[self.HEADER_KEY_ST] = "intid;desc=%s" % trace_id
             elif type(carrier) is list:
                 carrier.append((self.HEADER_KEY_T, trace_id))
                 carrier.append((self.HEADER_KEY_S, span_id))
                 carrier.append((self.HEADER_KEY_L, "1"))
-                carrier.append((self.HEADER_KEY_ST, "intid;desc=%s" % trace_id))
             elif hasattr(carrier, '__setitem__'):
                 carrier.__setitem__(self.HEADER_KEY_T, trace_id)
                 carrier.__setitem__(self.HEADER_KEY_S, span_id)
                 carrier.__setitem__(self.HEADER_KEY_L, "1")
-                carrier.__setitem__(self.HEADER_KEY_ST, "intid;desc=%s" % trace_id)
             else:
                 raise Exception("Unsupported carrier type", type(carrier))
 

--- a/instana/instrumentation/aiohttp/server.py
+++ b/instana/instrumentation/aiohttp/server.py
@@ -49,6 +49,7 @@ try:
 
                 scope.span.set_tag("http.status_code", response.status)
                 async_tracer.inject(scope.span.context, opentracing.Format.HTTP_HEADERS, response.headers)
+                response.headers['Server-Timing'] = "intid;desc=%s" % scope.span.context.trace_id
 
             return response
         except:

--- a/instana/instrumentation/django/middleware.py
+++ b/instana/instrumentation/django/middleware.py
@@ -60,6 +60,8 @@ class InstanaMiddleware(MiddlewareMixin):
 
                 request.iscope.span.set_tag(ext.HTTP_STATUS_CODE, response.status_code)
                 tracer.inject(request.iscope.span.context, ot.Format.HTTP_HEADERS, response)
+                response['Server-Timing'] = "intid;desc=%s" % request.iscope.span.context.trace_id
+
         except Exception:
             logger.debug("Instana middleware @ process_response", exc_info=True)
         finally:

--- a/instana/wsgi.py
+++ b/instana/wsgi.py
@@ -20,6 +20,8 @@ class iWSGIMiddleware(object):
         def new_start_response(status, headers, exc_info=None):
             """Modified start response with additional headers."""
             tracer.inject(self.scope.span.context, ot.Format.HTTP_HEADERS, headers)
+            headers.append(('Server-Timing', "intid;desc=%s" % self.scope.span.context.trace_id))
+
             res = start_response(status, headers, exc_info)
 
             sc = status.split(' ')[0]

--- a/tests/test_ot_propagators.py
+++ b/tests/test_ot_propagators.py
@@ -35,9 +35,6 @@ def test_inject_with_dict():
     assert_equals(carrier['X-Instana-S'], span.context.span_id)
     assert 'X-Instana-L' in carrier
     assert_equals(carrier['X-Instana-L'], "1")
-    assert 'Server-Timing' in carrier
-    server_timing_value = "intid;desc=%s" % span.context.trace_id
-    assert_equals(carrier['Server-Timing'], server_timing_value)
 
 
 def test_inject_with_list():
@@ -51,8 +48,6 @@ def test_inject_with_list():
     assert ('X-Instana-T', span.context.trace_id) in carrier
     assert ('X-Instana-S', span.context.span_id) in carrier
     assert ('X-Instana-L', "1") in carrier
-    server_timing_value = "intid;desc=%s" % span.context.trace_id
-    assert ('Server-Timing', server_timing_value) in carrier
 
 
 def test_basic_extract():


### PR DESCRIPTION
OpenTracing propagators are ignorant of what type of carrier we are
inserting into (HTTP Server, HTTP Client, RabbitMQ message carrier)
and that gives us no way to conditionally insert optional headers
such as Server-Timing.

The possible alternative to to create a unique propagator for every case
but that is a lot of duplicated code and unecessary for this one current
exception.

This PR breaks Server-Timing handling out from the HTTP propagagor and 
inserts it manually when needed.