### PR TITLE
Improved Tornado Tests

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -51,3 +51,17 @@ if 'REDIS' in os.environ:
     testenv['redis_url']= os.environ['REDIS']
 else:
     testenv['redis_url'] = '127.0.0.1:6379'
+
+
+def get_first_span_by_name(spans, name):
+    for span in spans:
+        if span.n == name:
+            return span
+    return None
+
+
+def get_span_by_filter(spans, filter):
+    for span in spans:
+        if filter(span) is True:
+            return span
+    return None

--- a/tests/test_tornado_server.py
+++ b/tests/test_tornado_server.py
@@ -168,7 +168,7 @@ class TestTornadoServer(unittest.TestCase):
                 async with aiohttp.ClientSession() as session:
                     return await self.fetch(session, testenv["tornado_server"] + "/301")
 
-        response = self.loop.run_until_complete(test())
+        response = tornado.ioloop.IOLoop.current().run_sync(test)
 
         spans = self.recorder.queued_spans()
         self.assertEqual(4, len(spans))
@@ -241,7 +241,7 @@ class TestTornadoServer(unittest.TestCase):
                 async with aiohttp.ClientSession() as session:
                     return await self.fetch(session, testenv["tornado_server"] + "/405")
 
-        response = self.loop.run_until_complete(test())
+        response = tornado.ioloop.IOLoop.current().run_sync(test)
 
         spans = self.recorder.queued_spans()
         self.assertEqual(3, len(spans))
@@ -301,7 +301,7 @@ class TestTornadoServer(unittest.TestCase):
                 async with aiohttp.ClientSession() as session:
                     return await self.fetch(session, testenv["tornado_server"] + "/500")
 
-        response = self.loop.run_until_complete(test())
+        response = tornado.ioloop.IOLoop.current().run_sync(test)
 
         spans = self.recorder.queued_spans()
         self.assertEqual(3, len(spans))
@@ -362,7 +362,7 @@ class TestTornadoServer(unittest.TestCase):
                 async with aiohttp.ClientSession() as session:
                     return await self.fetch(session, testenv["tornado_server"] + "/504")
 
-        response = self.loop.run_until_complete(test())
+        response = tornado.ioloop.IOLoop.current().run_sync(test)
 
         spans = self.recorder.queued_spans()
         self.assertEqual(3, len(spans))
@@ -423,7 +423,7 @@ class TestTornadoServer(unittest.TestCase):
                 async with aiohttp.ClientSession() as session:
                     return await self.fetch(session, testenv["tornado_server"] + "/?secret=yeah")
 
-        response = self.loop.run_until_complete(test())
+        response = tornado.ioloop.IOLoop.current().run_sync(test)
 
         spans = self.recorder.queued_spans()
         self.assertEqual(3, len(spans))
@@ -491,7 +491,7 @@ class TestTornadoServer(unittest.TestCase):
 
                     return await self.fetch(session, testenv["tornado_server"] + "/?secret=iloveyou", headers=headers)
 
-        response = self.loop.run_until_complete(test())
+        response = tornado.ioloop.IOLoop.current().run_sync(test)
 
         spans = self.recorder.queued_spans()
         self.assertEqual(3, len(spans))

--- a/tests/test_tornado_server.py
+++ b/tests/test_tornado_server.py
@@ -57,9 +57,9 @@ class TestTornadoServer(unittest.TestCase):
         aiohttp_span = get_first_span_by_name(spans, "aiohttp-client")
         test_span = get_first_span_by_name(spans, "sdk")
 
-        assert(tornado_span)
-        assert(aiohttp_span)
-        assert(test_span)
+        self.assertIsNotNone(tornado_span)
+        self.assertIsNotNone(aiohttp_span)
+        self.assertIsNotNone(test_span)
 
         self.assertIsNone(async_tracer.active_span)
 
@@ -95,13 +95,13 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(aiohttp_span.stack) is list)
         self.assertTrue(len(aiohttp_span.stack) > 1)
 
-        assert("X-Instana-T" in response.headers)
+        self.assertTrue("X-Instana-T" in response.headers)
         self.assertEqual(response.headers["X-Instana-T"], traceId)
-        assert("X-Instana-S" in response.headers)
+        self.assertTrue("X-Instana-S" in response.headers)
         self.assertEqual(response.headers["X-Instana-S"], tornado_span.s)
-        assert("X-Instana-L" in response.headers)
+        self.assertTrue("X-Instana-L" in response.headers)
         self.assertEqual(response.headers["X-Instana-L"], '1')
-        assert("Server-Timing" in response.headers)
+        self.assertTrue("Server-Timing" in response.headers)
         self.assertEqual(response.headers["Server-Timing"], "intid;desc=%s" % traceId)
 
     def test_post(self):
@@ -119,9 +119,9 @@ class TestTornadoServer(unittest.TestCase):
         aiohttp_span = get_first_span_by_name(spans, "aiohttp-client")
         test_span = get_first_span_by_name(spans, "sdk")
 
-        assert(tornado_span)
-        assert(aiohttp_span)
-        assert(test_span)
+        self.assertIsNotNone(tornado_span)
+        self.assertIsNotNone(aiohttp_span)
+        self.assertIsNotNone(test_span)
 
         self.assertIsNone(async_tracer.active_span)
 
@@ -161,13 +161,13 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(aiohttp_span.stack) is list)
         self.assertTrue(len(aiohttp_span.stack) > 1)
 
-        assert("X-Instana-T" in response.headers)
+        self.assertTrue("X-Instana-T" in response.headers)
         self.assertEqual(response.headers["X-Instana-T"], traceId)
-        assert("X-Instana-S" in response.headers)
+        self.assertTrue("X-Instana-S" in response.headers)
         self.assertEqual(response.headers["X-Instana-S"], tornado_span.s)
-        assert("X-Instana-L" in response.headers)
+        self.assertTrue("X-Instana-L" in response.headers)
         self.assertEqual(response.headers["X-Instana-L"], '1')
-        assert("Server-Timing" in response.headers)
+        self.assertTrue("Server-Timing" in response.headers)
         self.assertEqual(response.headers["Server-Timing"], "intid;desc=%s" % traceId)
 
     def test_get_301(self):
@@ -188,8 +188,10 @@ class TestTornadoServer(unittest.TestCase):
         aiohttp_span = get_first_span_by_name(spans, "aiohttp-client")
         test_span = get_first_span_by_name(spans, "sdk")
 
-        assert(aiohttp_span)
-        assert(test_span)
+        self.assertIsNotNone(tornado_301_span)
+        self.assertIsNotNone(tornado_span)
+        self.assertIsNotNone(aiohttp_span)
+        self.assertIsNotNone(test_span)
 
         self.assertIsNone(async_tracer.active_span)
 
@@ -241,13 +243,13 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(aiohttp_span.stack) is list)
         self.assertTrue(len(aiohttp_span.stack) > 1)
 
-        assert("X-Instana-T" in response.headers)
+        self.assertTrue("X-Instana-T" in response.headers)
         self.assertEqual(response.headers["X-Instana-T"], traceId)
-        assert("X-Instana-S" in response.headers)
+        self.assertTrue("X-Instana-S" in response.headers)
         self.assertEqual(response.headers["X-Instana-S"], tornado_span.s)
-        assert("X-Instana-L" in response.headers)
+        self.assertTrue("X-Instana-L" in response.headers)
         self.assertEqual(response.headers["X-Instana-L"], '1')
-        assert("Server-Timing" in response.headers)
+        self.assertTrue("Server-Timing" in response.headers)
         self.assertEqual(response.headers["Server-Timing"], "intid;desc=%s" % traceId)
 
     def test_get_405(self):
@@ -265,9 +267,9 @@ class TestTornadoServer(unittest.TestCase):
         aiohttp_span = get_first_span_by_name(spans, "aiohttp-client")
         test_span = get_first_span_by_name(spans, "sdk")
 
-        assert(tornado_span)
-        assert(aiohttp_span)
-        assert(test_span)
+        self.assertIsNotNone(tornado_span)
+        self.assertIsNotNone(aiohttp_span)
+        self.assertIsNotNone(test_span)
 
         self.assertIsNone(async_tracer.active_span)
 
@@ -307,13 +309,13 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(aiohttp_span.stack) is list)
         self.assertTrue(len(aiohttp_span.stack) > 1)
 
-        assert("X-Instana-T" in response.headers)
+        self.assertTrue("X-Instana-T" in response.headers)
         self.assertEqual(response.headers["X-Instana-T"], traceId)
-        assert("X-Instana-S" in response.headers)
+        self.assertTrue("X-Instana-S" in response.headers)
         self.assertEqual(response.headers["X-Instana-S"], tornado_span.s)
-        assert("X-Instana-L" in response.headers)
+        self.assertTrue("X-Instana-L" in response.headers)
         self.assertEqual(response.headers["X-Instana-L"], '1')
-        assert("Server-Timing" in response.headers)
+        self.assertTrue("Server-Timing" in response.headers)
         self.assertEqual(response.headers["Server-Timing"], "intid;desc=%s" % traceId)
 
     def test_get_500(self):
@@ -331,9 +333,9 @@ class TestTornadoServer(unittest.TestCase):
         aiohttp_span = get_first_span_by_name(spans, "aiohttp-client")
         test_span = get_first_span_by_name(spans, "sdk")
 
-        assert(tornado_span)
-        assert(aiohttp_span)
-        assert(test_span)
+        self.assertIsNotNone(tornado_span)
+        self.assertIsNotNone(aiohttp_span)
+        self.assertIsNotNone(test_span)
 
         self.assertIsNone(async_tracer.active_span)
 
@@ -374,13 +376,13 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(aiohttp_span.stack) is list)
         self.assertTrue(len(aiohttp_span.stack) > 1)
 
-        assert("X-Instana-T" in response.headers)
+        self.assertTrue("X-Instana-T" in response.headers)
         self.assertEqual(response.headers["X-Instana-T"], traceId)
-        assert("X-Instana-S" in response.headers)
+        self.assertTrue("X-Instana-S" in response.headers)
         self.assertEqual(response.headers["X-Instana-S"], tornado_span.s)
-        assert("X-Instana-L" in response.headers)
+        self.assertTrue("X-Instana-L" in response.headers)
         self.assertEqual(response.headers["X-Instana-L"], '1')
-        assert("Server-Timing" in response.headers)
+        self.assertTrue("Server-Timing" in response.headers)
         self.assertEqual(response.headers["Server-Timing"], "intid;desc=%s" % traceId)
 
     def test_get_504(self):
@@ -398,9 +400,9 @@ class TestTornadoServer(unittest.TestCase):
         aiohttp_span = get_first_span_by_name(spans, "aiohttp-client")
         test_span = get_first_span_by_name(spans, "sdk")
 
-        assert(tornado_span)
-        assert(aiohttp_span)
-        assert(test_span)
+        self.assertIsNotNone(tornado_span)
+        self.assertIsNotNone(aiohttp_span)
+        self.assertIsNotNone(test_span)
 
         self.assertIsNone(async_tracer.active_span)
 
@@ -441,13 +443,13 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(aiohttp_span.stack) is list)
         self.assertTrue(len(aiohttp_span.stack) > 1)
 
-        assert("X-Instana-T" in response.headers)
+        self.assertTrue("X-Instana-T" in response.headers)
         self.assertEqual(response.headers["X-Instana-T"], traceId)
-        assert("X-Instana-S" in response.headers)
+        self.assertTrue("X-Instana-S" in response.headers)
         self.assertEqual(response.headers["X-Instana-S"], tornado_span.s)
-        assert("X-Instana-L" in response.headers)
+        self.assertTrue("X-Instana-L" in response.headers)
         self.assertEqual(response.headers["X-Instana-L"], '1')
-        assert("Server-Timing" in response.headers)
+        self.assertTrue("Server-Timing" in response.headers)
         self.assertEqual(response.headers["Server-Timing"], "intid;desc=%s" % traceId)
 
     def test_get_with_params_to_scrub(self):
@@ -467,9 +469,9 @@ class TestTornadoServer(unittest.TestCase):
         aiohttp_span = get_first_span_by_name(spans, "aiohttp-client")
         test_span = get_first_span_by_name(spans, "sdk")
 
-        assert(tornado_span)
-        assert(aiohttp_span)
-        assert(test_span)
+        self.assertIsNotNone(tornado_span)
+        self.assertIsNotNone(aiohttp_span)
+        self.assertIsNotNone(test_span)
 
         self.assertEqual("tornado-server", tornado_span.n)
         self.assertEqual("aiohttp-client", aiohttp_span.n)
@@ -508,13 +510,13 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(aiohttp_span.stack) is list)
         self.assertTrue(len(aiohttp_span.stack) > 1)
 
-        assert("X-Instana-T" in response.headers)
+        self.assertTrue("X-Instana-T" in response.headers)
         self.assertEqual(response.headers["X-Instana-T"], traceId)
-        assert("X-Instana-S" in response.headers)
+        self.assertTrue("X-Instana-S" in response.headers)
         self.assertEqual(response.headers["X-Instana-S"], tornado_span.s)
-        assert("X-Instana-L" in response.headers)
+        self.assertTrue("X-Instana-L" in response.headers)
         self.assertEqual(response.headers["X-Instana-L"], '1')
-        assert("Server-Timing" in response.headers)
+        self.assertTrue("Server-Timing" in response.headers)
         self.assertEqual(response.headers["Server-Timing"], "intid;desc=%s" % traceId)
 
     def test_custom_header_capture(self):
@@ -539,9 +541,9 @@ class TestTornadoServer(unittest.TestCase):
         aiohttp_span = get_first_span_by_name(spans, "aiohttp-client")
         test_span = get_first_span_by_name(spans, "sdk")
 
-        assert(tornado_span)
-        assert(aiohttp_span)
-        assert(test_span)
+        self.assertIsNotNone(tornado_span)
+        self.assertIsNotNone(aiohttp_span)
+        self.assertIsNotNone(test_span)
 
         self.assertIsNone(async_tracer.active_span)
 
@@ -582,16 +584,16 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(aiohttp_span.stack) is list)
         self.assertTrue(len(aiohttp_span.stack) > 1)
 
-        assert("X-Instana-T" in response.headers)
+        self.assertTrue("X-Instana-T" in response.headers)
         self.assertEqual(response.headers["X-Instana-T"], traceId)
-        assert("X-Instana-S" in response.headers)
+        self.assertTrue("X-Instana-S" in response.headers)
         self.assertEqual(response.headers["X-Instana-S"], tornado_span.s)
-        assert("X-Instana-L" in response.headers)
+        self.assertTrue("X-Instana-L" in response.headers)
         self.assertEqual(response.headers["X-Instana-L"], '1')
-        assert("Server-Timing" in response.headers)
+        self.assertTrue("Server-Timing" in response.headers)
         self.assertEqual(response.headers["Server-Timing"], "intid;desc=%s" % traceId)
 
-        assert("http.X-Capture-This" in tornado_span.data.custom.tags)
+        self.assertTrue("http.X-Capture-This" in tornado_span.data.custom.tags)
         self.assertEqual('this', tornado_span.data.custom.tags['http.X-Capture-This'])
-        assert("http.X-Capture-That" in tornado_span.data.custom.tags)
+        self.assertTrue("http.X-Capture-That" in tornado_span.data.custom.tags)
         self.assertEqual('that', tornado_span.data.custom.tags['http.X-Capture-That'])

--- a/tests/test_tornado_server.py
+++ b/tests/test_tornado_server.py
@@ -59,6 +59,10 @@ class TestTornadoServer(unittest.TestCase):
 
         self.assertIsNone(async_tracer.active_span)
 
+        self.assertEqual("tornado-server", tornado_span.n)
+        self.assertEqual("aiohttp-client", aiohttp_span.n)
+        self.assertEqual("sdk", test_span.n)
+
         # Same traceId
         traceId = test_span.t
         self.assertEqual(traceId, aiohttp_span.t)
@@ -76,7 +80,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertFalse(tornado_span.error)
         self.assertIsNone(tornado_span.ec)
 
-        self.assertEqual("tornado-server", tornado_span.n)
         self.assertEqual(200, tornado_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/", tornado_span.data.http.url)
         self.assertIsNone(tornado_span.data.http.params)
@@ -85,7 +88,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(tornado_span.stack) is list)
         self.assertTrue(len(tornado_span.stack) > 1)
 
-        self.assertEqual("aiohttp-client", aiohttp_span.n)
         self.assertEqual(200, aiohttp_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/", aiohttp_span.data.http.url)
         self.assertEqual("GET", aiohttp_span.data.http.method)
@@ -119,6 +121,10 @@ class TestTornadoServer(unittest.TestCase):
 
         self.assertIsNone(async_tracer.active_span)
 
+        self.assertEqual("tornado-server", tornado_span.n)
+        self.assertEqual("aiohttp-client", aiohttp_span.n)
+        self.assertEqual("sdk", test_span.n)
+
         # Same traceId
         traceId = test_span.t
         self.assertEqual(traceId, aiohttp_span.t)
@@ -136,7 +142,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertFalse(tornado_span.error)
         self.assertIsNone(tornado_span.ec)
 
-        self.assertEqual("tornado-server", tornado_span.n)
         self.assertEqual(200, tornado_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/", tornado_span.data.http.url)
         self.assertIsNone(tornado_span.data.http.params)
@@ -145,7 +150,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(tornado_span.stack) is list)
         self.assertTrue(len(tornado_span.stack) > 1)
 
-        self.assertEqual("aiohttp-client", aiohttp_span.n)
         self.assertEqual(200, aiohttp_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/", aiohttp_span.data.http.url)
         self.assertEqual("POST", aiohttp_span.data.http.method)
@@ -180,6 +184,11 @@ class TestTornadoServer(unittest.TestCase):
 
         self.assertIsNone(async_tracer.active_span)
 
+        self.assertEqual("tornado-server", tornado_301_span.n)
+        self.assertEqual("tornado-server", tornado_span.n)
+        self.assertEqual("aiohttp-client", aiohttp_span.n)
+        self.assertEqual("sdk", test_span.n)
+
         # Same traceId
         traceId = test_span.t
         self.assertEqual(traceId, aiohttp_span.t)
@@ -201,7 +210,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertFalse(tornado_span.error)
         self.assertIsNone(tornado_span.ec)
 
-        self.assertEqual("tornado-server", tornado_301_span.n)
         self.assertEqual(301, tornado_301_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/301", tornado_301_span.data.http.url)
         self.assertIsNone(tornado_span.data.http.params)
@@ -210,7 +218,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(tornado_301_span.stack) is list)
         self.assertTrue(len(tornado_301_span.stack) > 1)
 
-        self.assertEqual("tornado-server", tornado_span.n)
         self.assertEqual(200, tornado_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/", tornado_span.data.http.url)
         self.assertEqual("GET", tornado_span.data.http.method)
@@ -218,7 +225,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(tornado_span.stack) is list)
         self.assertTrue(len(tornado_span.stack) > 1)
 
-        self.assertEqual("aiohttp-client", aiohttp_span.n)
         self.assertEqual(200, aiohttp_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/301", aiohttp_span.data.http.url)
         self.assertEqual("GET", aiohttp_span.data.http.method)
@@ -252,6 +258,10 @@ class TestTornadoServer(unittest.TestCase):
 
         self.assertIsNone(async_tracer.active_span)
 
+        self.assertEqual("tornado-server", tornado_span.n)
+        self.assertEqual("aiohttp-client", aiohttp_span.n)
+        self.assertEqual("sdk", test_span.n)
+
         # Same traceId
         traceId = test_span.t
         self.assertEqual(traceId, aiohttp_span.t)
@@ -269,7 +279,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertFalse(tornado_span.error)
         self.assertIsNone(tornado_span.ec)
 
-        self.assertEqual("tornado-server", tornado_span.n)
         self.assertEqual(405, tornado_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/405", tornado_span.data.http.url)
         self.assertIsNone(tornado_span.data.http.params)
@@ -278,7 +287,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(tornado_span.stack) is list)
         self.assertTrue(len(tornado_span.stack) > 1)
 
-        self.assertEqual("aiohttp-client", aiohttp_span.n)
         self.assertEqual(405, aiohttp_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/405", aiohttp_span.data.http.url)
         self.assertEqual("GET", aiohttp_span.data.http.method)
@@ -312,6 +320,10 @@ class TestTornadoServer(unittest.TestCase):
 
         self.assertIsNone(async_tracer.active_span)
 
+        self.assertEqual("tornado-server", tornado_span.n)
+        self.assertEqual("aiohttp-client", aiohttp_span.n)
+        self.assertEqual("sdk", test_span.n)
+
         # Same traceId
         traceId = test_span.t
         self.assertEqual(traceId, aiohttp_span.t)
@@ -329,7 +341,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(tornado_span.error)
         self.assertEqual(tornado_span.ec, 1)
 
-        self.assertEqual("tornado-server", tornado_span.n)
         self.assertEqual(500, tornado_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/500", tornado_span.data.http.url)
         self.assertIsNone(tornado_span.data.http.params)
@@ -338,7 +349,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(tornado_span.stack) is list)
         self.assertTrue(len(tornado_span.stack) > 1)
 
-        self.assertEqual("aiohttp-client", aiohttp_span.n)
         self.assertEqual(500, aiohttp_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/500", aiohttp_span.data.http.url)
         self.assertEqual("GET", aiohttp_span.data.http.method)
@@ -373,6 +383,10 @@ class TestTornadoServer(unittest.TestCase):
 
         self.assertIsNone(async_tracer.active_span)
 
+        self.assertEqual("tornado-server", tornado_span.n)
+        self.assertEqual("aiohttp-client", aiohttp_span.n)
+        self.assertEqual("sdk", test_span.n)
+
         # Same traceId
         traceId = test_span.t
         self.assertEqual(traceId, aiohttp_span.t)
@@ -390,7 +404,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(tornado_span.error)
         self.assertEqual(tornado_span.ec, 1)
 
-        self.assertEqual("tornado-server", tornado_span.n)
         self.assertEqual(504, tornado_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/504", tornado_span.data.http.url)
         self.assertIsNone(tornado_span.data.http.params)
@@ -399,7 +412,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(tornado_span.stack) is list)
         self.assertTrue(len(tornado_span.stack) > 1)
 
-        self.assertEqual("aiohttp-client", aiohttp_span.n)
         self.assertEqual(504, aiohttp_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/504", aiohttp_span.data.http.url)
         self.assertEqual("GET", aiohttp_span.data.http.method)
@@ -428,11 +440,15 @@ class TestTornadoServer(unittest.TestCase):
         spans = self.recorder.queued_spans()
         self.assertEqual(3, len(spans))
 
+        self.assertIsNone(async_tracer.active_span)
+
         tornado_span = spans[0]
         aiohttp_span = spans[1]
         test_span = spans[2]
 
-        self.assertIsNone(async_tracer.active_span)
+        self.assertEqual("tornado-server", tornado_span.n)
+        self.assertEqual("aiohttp-client", aiohttp_span.n)
+        self.assertEqual("sdk", test_span.n)
 
         # Same traceId
         traceId = test_span.t
@@ -451,7 +467,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertFalse(tornado_span.error)
         self.assertIsNone(tornado_span.ec)
 
-        self.assertEqual("tornado-server", tornado_span.n)
         self.assertEqual(200, tornado_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/", tornado_span.data.http.url)
         self.assertEqual("secret=<redacted>", tornado_span.data.http.params)
@@ -460,7 +475,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(tornado_span.stack) is list)
         self.assertTrue(len(tornado_span.stack) > 1)
 
-        self.assertEqual("aiohttp-client", aiohttp_span.n)
         self.assertEqual(200, aiohttp_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/", aiohttp_span.data.http.url)
         self.assertEqual("GET", aiohttp_span.data.http.method)
@@ -502,6 +516,10 @@ class TestTornadoServer(unittest.TestCase):
 
         self.assertIsNone(async_tracer.active_span)
 
+        self.assertEqual("tornado-server", tornado_span.n)
+        self.assertEqual("aiohttp-client", aioclient_span.n)
+        self.assertEqual("sdk", test_span.n)
+
         # Same traceId
         traceId = test_span.t
         self.assertEqual(traceId, aioclient_span.t)
@@ -519,7 +537,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertFalse(tornado_span.error)
         self.assertIsNone(tornado_span.ec)
 
-        self.assertEqual("tornado-server", tornado_span.n)
         self.assertEqual(200, tornado_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/", tornado_span.data.http.url)
         self.assertEqual("secret=<redacted>", tornado_span.data.http.params)
@@ -528,7 +545,6 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(tornado_span.stack) is list)
         self.assertTrue(len(tornado_span.stack) > 1)
 
-        self.assertEqual("aiohttp-client", aioclient_span.n)
         self.assertEqual(200, aioclient_span.data.http.status)
         self.assertEqual(testenv["tornado_server"] + "/", aioclient_span.data.http.url)
         self.assertEqual("GET", aioclient_span.data.http.method)

--- a/tests/test_tornado_server.py
+++ b/tests/test_tornado_server.py
@@ -9,7 +9,7 @@ from tornado.httpclient import AsyncHTTPClient
 
 from instana.singletons import async_tracer, agent
 
-from .helpers import testenv
+from .helpers import testenv, get_first_span_by_name, get_span_by_filter
 
 
 class TestTornadoServer(unittest.TestCase):
@@ -53,15 +53,15 @@ class TestTornadoServer(unittest.TestCase):
         spans = self.recorder.queued_spans()
         self.assertEqual(3, len(spans))
 
-        tornado_span = spans[0]
-        aiohttp_span = spans[1]
-        test_span = spans[2]
+        tornado_span = get_first_span_by_name(spans, "tornado-server")
+        aiohttp_span = get_first_span_by_name(spans, "aiohttp-client")
+        test_span = get_first_span_by_name(spans, "sdk")
+
+        assert(tornado_span)
+        assert(aiohttp_span)
+        assert(test_span)
 
         self.assertIsNone(async_tracer.active_span)
-
-        self.assertEqual("tornado-server", tornado_span.n)
-        self.assertEqual("aiohttp-client", aiohttp_span.n)
-        self.assertEqual("sdk", test_span.n)
 
         # Same traceId
         traceId = test_span.t
@@ -115,9 +115,13 @@ class TestTornadoServer(unittest.TestCase):
         spans = self.recorder.queued_spans()
         self.assertEqual(3, len(spans))
 
-        tornado_span = spans[0]
-        aiohttp_span = spans[1]
-        test_span = spans[2]
+        tornado_span = get_first_span_by_name(spans, "tornado-server")
+        aiohttp_span = get_first_span_by_name(spans, "aiohttp-client")
+        test_span = get_first_span_by_name(spans, "sdk")
+
+        assert(tornado_span)
+        assert(aiohttp_span)
+        assert(test_span)
 
         self.assertIsNone(async_tracer.active_span)
 
@@ -177,10 +181,15 @@ class TestTornadoServer(unittest.TestCase):
         spans = self.recorder.queued_spans()
         self.assertEqual(4, len(spans))
 
-        tornado_301_span = spans[0]
-        tornado_span = spans[1]
-        aiohttp_span = spans[2]
-        test_span = spans[3]
+        filter = lambda span: span.n == "tornado-server" and span.data.http.status == 301
+        tornado_301_span = get_span_by_filter(spans, filter)
+        filter = lambda span: span.n == "tornado-server" and span.data.http.status == 200
+        tornado_span = get_span_by_filter(spans, filter)
+        aiohttp_span = get_first_span_by_name(spans, "aiohttp-client")
+        test_span = get_first_span_by_name(spans, "sdk")
+
+        assert(aiohttp_span)
+        assert(test_span)
 
         self.assertIsNone(async_tracer.active_span)
 
@@ -252,9 +261,13 @@ class TestTornadoServer(unittest.TestCase):
         spans = self.recorder.queued_spans()
         self.assertEqual(3, len(spans))
 
-        tornado_span = spans[0]
-        aiohttp_span = spans[1]
-        test_span = spans[2]
+        tornado_span = get_first_span_by_name(spans, "tornado-server")
+        aiohttp_span = get_first_span_by_name(spans, "aiohttp-client")
+        test_span = get_first_span_by_name(spans, "sdk")
+
+        assert(tornado_span)
+        assert(aiohttp_span)
+        assert(test_span)
 
         self.assertIsNone(async_tracer.active_span)
 
@@ -314,9 +327,13 @@ class TestTornadoServer(unittest.TestCase):
         spans = self.recorder.queued_spans()
         self.assertEqual(3, len(spans))
 
-        tornado_span = spans[0]
-        aiohttp_span = spans[1]
-        test_span = spans[2]
+        tornado_span = get_first_span_by_name(spans, "tornado-server")
+        aiohttp_span = get_first_span_by_name(spans, "aiohttp-client")
+        test_span = get_first_span_by_name(spans, "sdk")
+
+        assert(tornado_span)
+        assert(aiohttp_span)
+        assert(test_span)
 
         self.assertIsNone(async_tracer.active_span)
 
@@ -377,9 +394,13 @@ class TestTornadoServer(unittest.TestCase):
         spans = self.recorder.queued_spans()
         self.assertEqual(3, len(spans))
 
-        tornado_span = spans[0]
-        aiohttp_span = spans[1]
-        test_span = spans[2]
+        tornado_span = get_first_span_by_name(spans, "tornado-server")
+        aiohttp_span = get_first_span_by_name(spans, "aiohttp-client")
+        test_span = get_first_span_by_name(spans, "sdk")
+
+        assert(tornado_span)
+        assert(aiohttp_span)
+        assert(test_span)
 
         self.assertIsNone(async_tracer.active_span)
 
@@ -442,9 +463,13 @@ class TestTornadoServer(unittest.TestCase):
 
         self.assertIsNone(async_tracer.active_span)
 
-        tornado_span = spans[0]
-        aiohttp_span = spans[1]
-        test_span = spans[2]
+        tornado_span = get_first_span_by_name(spans, "tornado-server")
+        aiohttp_span = get_first_span_by_name(spans, "aiohttp-client")
+        test_span = get_first_span_by_name(spans, "sdk")
+
+        assert(tornado_span)
+        assert(aiohttp_span)
+        assert(test_span)
 
         self.assertEqual("tornado-server", tornado_span.n)
         self.assertEqual("aiohttp-client", aiohttp_span.n)
@@ -510,30 +535,34 @@ class TestTornadoServer(unittest.TestCase):
         spans = self.recorder.queued_spans()
         self.assertEqual(3, len(spans))
 
-        tornado_span = spans[0]
-        aioclient_span = spans[1]
-        test_span = spans[2]
+        tornado_span = get_first_span_by_name(spans, "tornado-server")
+        aiohttp_span = get_first_span_by_name(spans, "aiohttp-client")
+        test_span = get_first_span_by_name(spans, "sdk")
+
+        assert(tornado_span)
+        assert(aiohttp_span)
+        assert(test_span)
 
         self.assertIsNone(async_tracer.active_span)
 
         self.assertEqual("tornado-server", tornado_span.n)
-        self.assertEqual("aiohttp-client", aioclient_span.n)
+        self.assertEqual("aiohttp-client", aiohttp_span.n)
         self.assertEqual("sdk", test_span.n)
 
         # Same traceId
         traceId = test_span.t
-        self.assertEqual(traceId, aioclient_span.t)
+        self.assertEqual(traceId, aiohttp_span.t)
         self.assertEqual(traceId, tornado_span.t)
 
         # Parent relationships
-        self.assertEqual(aioclient_span.p, test_span.s)
-        self.assertEqual(tornado_span.p, aioclient_span.s)
+        self.assertEqual(aiohttp_span.p, test_span.s)
+        self.assertEqual(tornado_span.p, aiohttp_span.s)
 
         # Error logging
         self.assertFalse(test_span.error)
         self.assertIsNone(test_span.ec)
-        self.assertFalse(aioclient_span.error)
-        self.assertIsNone(aioclient_span.ec)
+        self.assertFalse(aiohttp_span.error)
+        self.assertIsNone(aiohttp_span.ec)
         self.assertFalse(tornado_span.error)
         self.assertIsNone(tornado_span.ec)
 
@@ -545,13 +574,13 @@ class TestTornadoServer(unittest.TestCase):
         self.assertTrue(type(tornado_span.stack) is list)
         self.assertTrue(len(tornado_span.stack) > 1)
 
-        self.assertEqual(200, aioclient_span.data.http.status)
-        self.assertEqual(testenv["tornado_server"] + "/", aioclient_span.data.http.url)
-        self.assertEqual("GET", aioclient_span.data.http.method)
-        self.assertEqual("secret=<redacted>", aioclient_span.data.http.params)
-        self.assertIsNotNone(aioclient_span.stack)
-        self.assertTrue(type(aioclient_span.stack) is list)
-        self.assertTrue(len(aioclient_span.stack) > 1)
+        self.assertEqual(200, aiohttp_span.data.http.status)
+        self.assertEqual(testenv["tornado_server"] + "/", aiohttp_span.data.http.url)
+        self.assertEqual("GET", aiohttp_span.data.http.method)
+        self.assertEqual("secret=<redacted>", aiohttp_span.data.http.params)
+        self.assertIsNotNone(aiohttp_span.stack)
+        self.assertTrue(type(aiohttp_span.stack) is list)
+        self.assertTrue(len(aiohttp_span.stack) > 1)
 
         assert("X-Instana-T" in response.headers)
         self.assertEqual(response.headers["X-Instana-T"], traceId)


### PR DESCRIPTION
There was some non-determinisim in the tornado test suite
due to mixed event loop usage.

Use tornado loop directly and consistently