### PR TITLE
Console support

### DIFF
--- a/instana/__main__.py
+++ b/instana/__main__.py
@@ -1,3 +1,10 @@
+"""
+This module provides "python -m instana" functionality.  This is used for basic module
+information display and a IPython console to diagnose environments.
+
+The console is disabled by default unless the ipython package is installed.
+"""
+import os
 import sys
 
 print("""\
@@ -20,7 +27,23 @@ if "console" in sys.argv:
         print("This console is not enabled by default.")
         print("IPython not installed.  To use this debug console do: 'pip install ipython'\n")
     else:
-        print("Welcome to the Instana debug console.\n")
+        print("Welcome to the Instana console.\n")
+        print("This is a simple IPython console with the Instana Python Sensor pre-loaded.\n")
+
+        if "INSTANA_DEBUG" not in os.environ:
+            print("If you want debug output of this sensors' activity run instead:\n")
+            print("   INSTANA_DEBUG=true python -m instana console")
+
+        print("""
+Helpful Links
+============================================================================
+
+Monitoring Python Documentation:
+https://docs.instana.io/ecosystem/python
+
+Help & Support:
+https://support.instana.com/
+""")
 
         IPython.start_ipython(argv=[])
 else:
@@ -28,10 +51,13 @@ else:
 This is an informational screen for Instana.
 
 Supported commands:
- - console: "python -m instana console"
+ - console: 
+   * Requires ipython package: pip install ipython
+   * Example: 
+     - python -m instana console
 
 See the Instana Python documentation for details on using this package with
-your Python applications, workers, queues and more.
+your Python applications, workers, queues, neural networks and more.
 
 
 Related Blog Posts:
@@ -51,10 +77,8 @@ Monitoring Python Documentation:
 https://docs.instana.io/ecosystem/python
 
 Help & Support:
-https://support.instana.com/hc/en-us
+https://support.instana.com/
 
 Python Instrumentation on Github:
 https://github.com/instana/python-sensor/
 """)
-
-

--- a/instana/__main__.py
+++ b/instana/__main__.py
@@ -1,3 +1,5 @@
+import sys
+
 print("""\
 ============================================================================
 8888888 888b    888  .d8888b. 88888888888     d8888 888b    888        d8888
@@ -9,8 +11,24 @@ print("""\
   888   888   Y8888 Y88b  d88P    888   d8888888888 888   Y8888  d8888888888
 8888888 888    Y888  "Y8888P"     888  d88P     888 888    Y888 d88P     888
 ============================================================================
+""")
 
+if "console" in sys.argv:
+    try:
+        import IPython
+    except ImportError:
+        print("This console is not enabled by default.")
+        print("IPython not installed.  To use this debug console do: 'pip install ipython'\n")
+    else:
+        print("Welcome to the Instana debug console.\n")
+
+        IPython.start_ipython(argv=[])
+else:
+    print("""\
 This is an informational screen for Instana.
+
+Supported commands:
+ - console: "python -m instana console"
 
 See the Instana Python documentation for details on using this package with
 your Python applications, workers, queues and more.
@@ -38,3 +56,5 @@ https://support.instana.com/hc/en-us
 Python Instrumentation on Github:
 https://github.com/instana/python-sensor/
 """)
+
+


### PR DESCRIPTION
This PR adds the ability to invoke an instana console with:

    python -m instana console

The console depends on ipython and is not installed by default with Instana.

To enable the console, you must install ipython.  Package output describes as much.
