### PR TITLE
Fix for issue 172

### DIFF
--- a/instana/instrumentation/flask/vanilla.py
+++ b/instana/instrumentation/flask/vanilla.py
@@ -82,7 +82,8 @@ def handle_user_exception_with_instana(wrapped, instance, argv, kwargs):
         if not hasattr(exc, 'code'):
             span.log_exception(argv[0])
             span.set_tag(ext.HTTP_STATUS_CODE, 500)
-            scope.close()
+            # Issue 172 - leave scope open for downstream error handlers
+            #scope.close()
 
     return wrapped(*argv, **kwargs)
 

--- a/instana/instrumentation/flask/with_blinker.py
+++ b/instana/instrumentation/flask/with_blinker.py
@@ -94,8 +94,9 @@ def handle_user_exception_with_instana(wrapped, instance, argv, kwargs):
         if not hasattr(exc, 'code'):
             span.log_exception(exc)
             span.set_tag(ext.HTTP_STATUS_CODE, 500)
-            scope.close()
-            flask.g.scope = None
+            # Issue 172 - leave scope open for downstream error handlers
+            #scope.close()
+            #flask.g.scope = None
 
     return wrapped(*argv, **kwargs)
 


### PR DESCRIPTION
Leave the scope open for downstream error handles and logging instrumentation.