### PR TITLE
Instana 1.15.4 with Odoo 12 - AttributeError: module 'sys' has no attribute 'argv'

### DIFF
--- a/instana/log.py
+++ b/instana/log.py
@@ -35,9 +35,13 @@ def running_in_gunicorn():
     process_check = False
     package_check = False
 
-    for arg in sys.argv:
-        if arg.find('gunicorn') >= 0:
-            process_check = True
+    if hasattr(sys, 'argv'):
+        for arg in sys.argv:
+            if arg.find('gunicorn') >= 0:
+                process_check = True
+    else:
+        # We have no command line so rely on the gunicorn package presence entirely
+        process_check = True
 
     try:
         from gunicorn import glogging


### PR DESCRIPTION
Hello,

I am using instana Python library v1.15.4 with Odoo v12 (http://odoo.com) in a virtual environment.

When I start Odoo with:
```
export AUTOWRAPT_BOOTSTRAP=instana
```

I get the following error message:
```
/home/mchambreuil/odoo/12/env/bin/python /home/mchambreuil/odoo/12/env/bin/odoo -c odoo.conf 
Failed to import the site module
Traceback (most recent call last):
  File "/usr/lib/python3.6/site.py", line 570, in <module>
    main()
  File "/usr/lib/python3.6/site.py", line 563, in main
    execsitecustomize()
  File "/home/mchambreuil/odoo/12/env/lib/python3.6/site-packages/autowrapt/bootstrap.py", line 32, in _execsitecustomize
    return wrapped(*args, **kwargs)
  File "/home/mchambreuil/odoo/12/env/lib/python3.6/site-packages/autowrapt/bootstrap.py", line 38, in _execsitecustomize
    _register_bootstrap_functions()
  File "/home/mchambreuil/odoo/12/env/lib/python3.6/site-packages/autowrapt/bootstrap.py", line 27, in _register_bootstrap_functions
    discover_post_import_hooks(name)
  File "/home/mchambreuil/odoo/12/env/lib/python3.6/site-packages/wrapt/importer.py", line 120, in discover_post_import_hooks
    register_post_import_hook(callback, entrypoint.name)
  File "/home/mchambreuil/odoo/12/env/lib/python3.6/site-packages/wrapt/decorators.py", line 440, in _synchronized
    return wrapped(*args, **kwargs)
  File "/home/mchambreuil/odoo/12/env/lib/python3.6/site-packages/wrapt/importer.py", line 82, in register_post_import_hook
    hook(module)
  File "/home/mchambreuil/odoo/12/env/lib/python3.6/site-packages/wrapt/importer.py", line 105, in import_hook
    __import__(entrypoint.module_name)
  File "/home/mchambreuil/odoo/12/env/lib/python3.6/site-packages/instana/__init__.py", line 120, in <module>
    boot_agent()
  File "/home/mchambreuil/odoo/12/env/lib/python3.6/site-packages/instana/__init__.py", line 54, in boot_agent
    import instana.singletons
  File "/home/mchambreuil/odoo/12/env/lib/python3.6/site-packages/instana/singletons.py", line 4, in <module>
    from .agent import Agent
  File "/home/mchambreuil/odoo/12/env/lib/python3.6/site-packages/instana/agent.py", line 14, in <module>
    from .fsm import TheMachine
  File "/home/mchambreuil/odoo/12/env/lib/python3.6/site-packages/instana/fsm.py", line 14, in <module>
    from .log import logger
  File "/home/mchambreuil/odoo/12/env/lib/python3.6/site-packages/instana/log.py", line 52, in <module>
    if running_in_gunicorn():
  File "/home/mchambreuil/odoo/12/env/lib/python3.6/site-packages/instana/log.py", line 38, in running_in_gunicorn
    for arg in sys.argv:
AttributeError: module 'sys' has no attribute 'argv'
```