### PR TITLE
Faster Announce: Lower agent lookup time from boot

### DIFF
--- a/instana/fsm.py
+++ b/instana/fsm.py
@@ -70,7 +70,7 @@ class TheMachine(object):
                 "onpending":      self.agent.start,
                 "onready":        self.on_ready}})
 
-        self.timer = t.Timer(5, self.fsm.lookup)
+        self.timer = t.Timer(1, self.fsm.lookup)
         self.timer.daemon = True
         self.timer.name = self.THREAD_NAME
         self.timer.start()


### PR DESCRIPTION
This PR lowers the time for the schedule timer for first agent lookup.  This results in a faster initial announce.