### PR TITLE
Avoid dict changed warning by copying

### DIFF
--- a/instana/meter.py
+++ b/instana/meter.py
@@ -342,7 +342,7 @@ class Meter(object):
         """ Collect up the list of modules in use """
         try:
             res = {}
-            m = sys.modules
+            m = sys.modules.copy()
             for k in m:
                 # Don't report submodules (e.g. django.x, django.y, django.z)
                 # Skip modules that begin with underscore


### PR DESCRIPTION
At boot, if the sys.modules dict changed while we were iterating it for snapshot data, it would put out a warning.

```
RuntimeError: dictionary changed size during iteration
```

This PR avoids getting that warning by making a copy of the dict and iterating the copy instead.