### PR TITLE
Flask: Add context injection safeties

### DIFF
--- a/instana/instrumentation/flask/vanilla.py
+++ b/instana/instrumentation/flask/vanilla.py
@@ -112,7 +112,10 @@ def handle_user_exception_with_instana(wrapped, instance, argv, kwargs):
 
                 if hasattr(response, 'headers'):
                     tracer.inject(scope.span.context, opentracing.Format.HTTP_HEADERS, response.headers)
-                    response.headers.add('Server-Timing', "intid;desc=%s" % scope.span.context.trace_id)
+                    if hasattr(response.headers, 'add'):
+                        response.headers.add('Server-Timing', "intid;desc=%s" % scope.span.context.trace_id)
+                    elif type(response.headers) is dict or hasattr(response.headers, "__dict__"):
+                        response.headers['Server-Timing'] = "intid;desc=%s" % scope.span.context.trace_id
 
             scope.close()
             flask.g.scope = None


### PR DESCRIPTION
This fixes the case of:

```
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/instana/instrumentation/flask/with_blinker.py", line 105, in handle_user_exception_with_instana
    response.headers.add('Server-Timing', "intid;desc=%s" % scope.span.context.trace_id)
AttributeError: 'dict' object has no attribute 'add'
```