### PR TITLE
Psycopg2 instrumentation breaks json registration (in aiohttp)

### DIFF
--- a/instana/instrumentation/psycopg2.py
+++ b/instana/instrumentation/psycopg2.py
@@ -25,6 +25,14 @@ try:
 
         return wrapped(*args_clone, **kwargs)
 
+    @wrapt.patch_function_wrapper('psycopg2._json', 'register_json')
+    def register_json_with_instana(wrapped, instance, args, kwargs):
+        if 'conn_or_curs' in kwargs:
+            if hasattr(kwargs['conn_or_curs'], '__wrapped__'):
+                kwargs['conn_or_curs'] = kwargs['conn_or_curs'].__wrapped__
+
+        return wrapped(*args, **kwargs)
+
     logger.debug("Instrumenting psycopg2")
 except ImportError:
     pass


### PR DESCRIPTION
running this wrapper-

```
@wrapt.patch_function_wrapper('psycopg2.extensions', 'register_type')
    def register_type_with_instana(wrapped, instance, args, kwargs):
        args_clone = list(copy.copy(args))

        if (len(args_clone) >= 2) and hasattr(args_clone[1], '__wrapped__'):
            args_clone[1] = args_clone[1].__wrapped__

        return wrapped(*args_clone, **kwargs)
```

Is causing an error to be thrown here psycopg2/_json.py:

```
def register_json(conn_or_curs=None, globally=False, loads=None,
                  oid=None, array_oid=None, name='json'):
    if oid is None:
        oid, array_oid = _get_json_oids(conn_or_curs, name)

    JSON, JSONARRAY = _create_json_typecasters(
        oid, array_oid, loads=loads, name=name.upper())

    register_type(JSON, not globally and conn_or_curs or None) . <--------- argument 2 must be a connection, cursor or None

    if JSONARRAY is not None:
        register_type(JSONARRAY, not globally and conn_or_curs or None)

    return JSON, JSONARRAY
```