### PR TITLE
Fix: Gunicorn process detection

### DIFF
--- a/instana/__init__.py
+++ b/instana/__init__.py
@@ -85,6 +85,7 @@ def boot_agent():
     # Hooks
     from .hooks import hook_uwsgi
 
+
 if "INSTANA_MAGIC" in os.environ:
     pkg_resources.working_set.add_entry("/tmp/instana/python")
 

--- a/instana/log.py
+++ b/instana/log.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import logging
 import os
 import sys

--- a/instana/log.py
+++ b/instana/log.py
@@ -4,6 +4,8 @@ import sys
 
 logger = None
 
+from .util import get_proc_cmdline
+
 
 def get_standard_logger():
     """
@@ -35,14 +37,17 @@ def running_in_gunicorn():
     process_check = False
     package_check = False
 
+    # Is this a gunicorn process?
     if hasattr(sys, 'argv'):
         for arg in sys.argv:
             if arg.find('gunicorn') >= 0:
                 process_check = True
     else:
-        # We have no command line so rely on the gunicorn package presence entirely
-        process_check = True
+        cmdline = get_proc_cmdline(as_string=True)
+        if cmdline.find('gunicorn') >= 0:
+            process_check = True
 
+    # Is the glogging package available?
     try:
         from gunicorn import glogging
     except ImportError:
@@ -50,6 +55,7 @@ def running_in_gunicorn():
     else:
         package_check = True
 
+    # Both have to be true for gunicorn logging
     return process_check and package_check
 
 

--- a/instana/log.py
+++ b/instana/log.py
@@ -3,7 +3,6 @@ import os
 import sys
 
 logger = None
-level_debug = "INSTANA_DEBUG" in os.environ
 
 
 def get_standard_logger():
@@ -18,7 +17,7 @@ def get_standard_logger():
     f = logging.Formatter('%(asctime)s: %(process)d %(levelname)s %(name)s: %(message)s')
     ch.setFormatter(f)
     standard_logger.addHandler(ch)
-    if level_debug is True:
+    if "INSTANA_DEBUG" in os.environ:
         standard_logger.setLevel(logging.DEBUG)
     else:
         standard_logger.setLevel(logging.WARN)
@@ -69,10 +68,6 @@ def running_in_gunicorn():
 
 
 if running_in_gunicorn():
-    if level_debug is True:
-        print("Instana: Using gunicorn logger")
     logger = logging.getLogger("gunicorn.error")
 else:
-    if level_debug is True:
-        print("Instana: Using standard logger")
     logger = get_standard_logger()

--- a/instana/util.py
+++ b/instana/util.py
@@ -93,6 +93,34 @@ def to_json(obj):
         logger.debug("to_json non-fatal encoding issue: ", exc_info=True)
 
 
+def get_proc_cmdline(as_string=False):
+    """
+    Parse the proc file system for the command line of this process.  If not available, then return a default.
+    Return is dependent on the value of `as_string`.  If True, return the full command line as a string,
+    otherwise a list.
+    """
+    name = "python"
+    if os.path.isfile("/proc/self/cmdline"):
+        with open("/proc/self/cmdline") as cmd:
+            name = cmd.read()
+    else:
+        # Most likely not on a *nix based OS.  Return a default
+        if as_string is True:
+            return name
+        else:
+            return [name]
+
+    # /proc/self/command line will have strings with null bytes such as "/usr/bin/python\0-s\0-d\0".  This
+    # bit will prep the return value and drop the trailing null byte
+    parts = name.split('\0')
+    parts.pop()
+
+    if as_string is True:
+        parts = " ".join(parts)
+
+    return parts
+
+
 def package_version():
     """
     Determine the version of this package.

--- a/instana/util.py
+++ b/instana/util.py
@@ -262,13 +262,12 @@ def get_py_source(file):
 
     @param file [String] The fully qualified path to a file
     """
+    response = None
     try:
-        response = None
-        pysource = ""
-
         if regexp_py.search(file) is None:
             response = {"error": "Only Python source files are allowed. (*.py)"}
         else:
+            pysource = ""
             with open(file, 'r') as pyfile:
                 pysource = pyfile.read()
 
@@ -278,6 +277,7 @@ def get_py_source(file):
         response = {"error": str(e)}
     finally:
         return response
+
 
 # Used by get_py_source
 regexp_py = re.compile('\.py$')

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import unittest
 
-from instana.singletons import agent
 from instana.util import strip_secrets
 
 


### PR DESCRIPTION
This PR fixes a case where by for any Python process, if the gunicorn package was installed, it would default to the gunicorn logger - even if it wasn't a gunicorn process.

* Move get_proc_cmdline to util package for global use
* Use proc cmdline (when sys.argv isn't available) to see if this is a gunicorn process