### PR TITLE
Gunicorn: Fallback if process is not renamed

### DIFF
--- a/instana/meter.py
+++ b/instana/meter.py
@@ -259,12 +259,13 @@ class Meter(object):
 
             basename = os.path.basename(sys.argv[0])
             if basename == "gunicorn":
-                # gunicorn renames their processes to pretty things - we use those by default
-                # gunicorn: master [djface.wsgi]
-                # gunicorn: worker [djface.wsgi]
-                app_name = get_proc_cmdline(as_string=True)
-
-                if app_name is None:
+                if 'setproctitle' in sys.modules:
+                    # With the setproctitle package, gunicorn renames their processes
+                    # to pretty things - we use those by default
+                    # gunicorn: master [djface.wsgi]
+                    # gunicorn: worker [djface.wsgi]
+                    app_name = get_proc_cmdline(as_string=True)
+                else:
                     app_name = basename
             elif "FLASK_APP" in os.environ:
                 app_name = os.environ["FLASK_APP"]


### PR DESCRIPTION
Gunicorn uses the optional setproctitle package to rename processes (if it's installed).

This PR will properly name the Gunicorn process if setproctitle is not installed.