### PR TITLE
Flask: Path Templates Support

### DIFF
--- a/tests/apps/flaskalino.py
+++ b/tests/apps/flaskalino.py
@@ -44,6 +44,11 @@ def hello():
     return "<center><h1>🐍 Hello Stan! 🦄</h1></center>"
 
 
+@app.route("/users/<username>/sayhello")
+def username_hello(username):
+    return "<center><h1>🐍 Hello %s! 🦄</h1></center>" % username
+
+
 @app.route("/complex")
 def gen_opentracing():
     with tracer.start_active_span('asteroid') as pscope:

--- a/tests/apps/flaskalino.py
+++ b/tests/apps/flaskalino.py
@@ -46,7 +46,7 @@ def hello():
 
 @app.route("/users/<username>/sayhello")
 def username_hello(username):
-    return "<center><h1>🐍 Hello %s! 🦄</h1></center>" % username
+    return u"<center><h1>🐍 Hello %s! 🦄</h1></center>" % username
 
 
 @app.route("/complex")

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -94,6 +94,9 @@ class TestFlask(unittest.TestCase):
         self.assertTrue(type(urllib3_span.stack) is list)
         self.assertTrue(len(urllib3_span.stack) > 1)
 
+        # We should NOT have a path template for this route
+        self.assertIsNone(wsgi_span.data.http.path_tpl)
+
     def test_render_template(self):
         with tracer.start_active_span('test'):
             response = self.http.request('GET', testenv["wsgi_server"] + '/render')
@@ -173,6 +176,9 @@ class TestFlask(unittest.TestCase):
         self.assertIsNotNone(urllib3_span.stack)
         self.assertTrue(type(urllib3_span.stack) is list)
         self.assertTrue(len(urllib3_span.stack) > 1)
+
+        # We should NOT have a path template for this route
+        self.assertIsNone(wsgi_span.data.http.path_tpl)
 
     def test_render_template_string(self):
         with tracer.start_active_span('test'):
@@ -254,6 +260,9 @@ class TestFlask(unittest.TestCase):
         self.assertTrue(type(urllib3_span.stack) is list)
         self.assertTrue(len(urllib3_span.stack) > 1)
 
+        # We should NOT have a path template for this route
+        self.assertIsNone(wsgi_span.data.http.path_tpl)
+
     def test_301(self):
         with tracer.start_active_span('test'):
             response = self.http.request('GET', testenv["wsgi_server"] + '/301', redirect=False)
@@ -321,6 +330,9 @@ class TestFlask(unittest.TestCase):
         self.assertIsNotNone(urllib3_span.stack)
         self.assertTrue(type(urllib3_span.stack) is list)
         self.assertTrue(len(urllib3_span.stack) > 1)
+
+        # We should NOT have a path template for this route
+        self.assertIsNone(wsgi_span.data.http.path_tpl)
 
     def test_404(self):
         with tracer.start_active_span('test'):
@@ -390,6 +402,9 @@ class TestFlask(unittest.TestCase):
         self.assertTrue(type(urllib3_span.stack) is list)
         self.assertTrue(len(urllib3_span.stack) > 1)
 
+        # We should NOT have a path template for this route
+        self.assertIsNone(wsgi_span.data.http.path_tpl)
+
     def test_500(self):
         with tracer.start_active_span('test'):
             response = self.http.request('GET', testenv["wsgi_server"] + '/500')
@@ -457,6 +472,9 @@ class TestFlask(unittest.TestCase):
         self.assertIsNotNone(urllib3_span.stack)
         self.assertTrue(type(urllib3_span.stack) is list)
         self.assertTrue(len(urllib3_span.stack) > 1)
+
+        # We should NOT have a path template for this route
+        self.assertIsNone(wsgi_span.data.http.path_tpl)
 
     def test_render_error(self):
         if signals_available is True:
@@ -535,6 +553,9 @@ class TestFlask(unittest.TestCase):
         self.assertTrue(type(urllib3_span.stack) is list)
         self.assertTrue(len(urllib3_span.stack) > 1)
 
+        # We should NOT have a path template for this route
+        self.assertIsNone(wsgi_span.data.http.path_tpl)
+
     def test_exception(self):
         if signals_available is True:
             raise unittest.SkipTest("Exceptions without handlers vary with blinker")
@@ -603,6 +624,9 @@ class TestFlask(unittest.TestCase):
         self.assertIsNotNone(urllib3_span.stack)
         self.assertTrue(type(urllib3_span.stack) is list)
         self.assertTrue(len(urllib3_span.stack) > 1)
+
+        # We should NOT have a path template for this route
+        self.assertIsNone(wsgi_span.data.http.path_tpl)
 
     def test_custom_exception_with_log(self):
         with tracer.start_active_span('test'):
@@ -679,3 +703,77 @@ class TestFlask(unittest.TestCase):
         self.assertIsNotNone(urllib3_span.stack)
         self.assertTrue(type(urllib3_span.stack) is list)
         self.assertTrue(len(urllib3_span.stack) > 1)
+
+        # We should NOT have a path template for this route
+        self.assertIsNone(wsgi_span.data.http.path_tpl)
+
+    def test_path_templates(self):
+        with tracer.start_active_span('test'):
+            response = self.http.request('GET', testenv["wsgi_server"] + '/users/Ricky/sayhello')
+
+        spans = self.recorder.queued_spans()
+        self.assertEqual(3, len(spans))
+
+        wsgi_span = spans[0]
+        urllib3_span = spans[1]
+        test_span = spans[2]
+
+        assert response
+        self.assertEqual(200, response.status)
+
+        assert('X-Instana-T' in response.headers)
+        assert(int(response.headers['X-Instana-T'], 16))
+        self.assertEqual(response.headers['X-Instana-T'], wsgi_span.t)
+
+        assert('X-Instana-S' in response.headers)
+        assert(int(response.headers['X-Instana-S'], 16))
+        self.assertEqual(response.headers['X-Instana-S'], wsgi_span.s)
+
+        assert('X-Instana-L' in response.headers)
+        self.assertEqual(response.headers['X-Instana-L'], '1')
+
+        assert('Server-Timing' in response.headers)
+        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        self.assertEqual(response.headers['Server-Timing'], server_timing_value)
+
+        self.assertIsNone(tracer.active_span)
+
+        # Same traceId
+        self.assertEqual(test_span.t, urllib3_span.t)
+        self.assertEqual(urllib3_span.t, wsgi_span.t)
+
+        # Parent relationships
+        self.assertEqual(urllib3_span.p, test_span.s)
+        self.assertEqual(wsgi_span.p, urllib3_span.s)
+
+        # Error logging
+        self.assertFalse(test_span.error)
+        self.assertIsNone(test_span.ec)
+        self.assertFalse(urllib3_span.error)
+        self.assertIsNone(urllib3_span.ec)
+        self.assertFalse(wsgi_span.error)
+        self.assertIsNone(wsgi_span.ec)
+
+        # wsgi
+        self.assertEqual("wsgi", wsgi_span.n)
+        self.assertEqual('127.0.0.1:' + str(testenv['wsgi_port']), wsgi_span.data.http.host)
+        self.assertEqual('/users/Ricky/sayhello', wsgi_span.data.http.url)
+        self.assertEqual('GET', wsgi_span.data.http.method)
+        self.assertEqual(200, wsgi_span.data.http.status)
+        self.assertIsNone(wsgi_span.data.http.error)
+        self.assertIsNotNone(wsgi_span.stack)
+        self.assertEqual(2, len(wsgi_span.stack))
+
+        # urllib3
+        self.assertEqual("test", test_span.data.sdk.name)
+        self.assertEqual("urllib3", urllib3_span.n)
+        self.assertEqual(200, urllib3_span.data.http.status)
+        self.assertEqual(testenv["wsgi_server"] + '/users/Ricky/sayhello', urllib3_span.data.http.url)
+        self.assertEqual("GET", urllib3_span.data.http.method)
+        self.assertIsNotNone(urllib3_span.stack)
+        self.assertTrue(type(urllib3_span.stack) is list)
+        self.assertTrue(len(urllib3_span.stack) > 1)
+
+        # We should have a reported path template for this route
+        self.assertEqual("/users/{username}/sayhello", wsgi_span.data.http.path_tpl)
+


### PR DESCRIPTION
This PR adds support for Path Templates under Flask.

Flask routes such as:
```python
@app.route("/users/<username>/sayhello")
def username_hello(username):
    return "<center><h1>🐍 Hello %s! 🦄</h1></center>" % username
```

will now show as grouped endpoints in Instana Analyze:

![Screen Shot 2020-01-13 at 1 39 21 PM](https://user-images.githubusercontent.com/395132/72256984-ca4f7800-360a-11ea-8998-c7e1b53f837e.png)

...and when drilling down:

![Screen Shot 2020-01-13 at 1 37 44 PM](https://user-images.githubusercontent.com/395132/72257008-d63b3a00-360a-11ea-98e5-6f0d1e888597.png)

Read more about endpoint grouping here:
https://docs.instana.io/products/application_service_management/#endpoint-grouping---path-templates
