### PR TITLE
Send separate 'host' and 'port' tags for MySQL/PostgreSQL tags

### DIFF
--- a/instana/instrumentation/pep0249.py
+++ b/instana/instrumentation/pep0249.py
@@ -27,11 +27,9 @@ class CursorWrapper(wrapt.ObjectProxy):
                 span.set_tag(ext.DATABASE_INSTANCE, self._connect_params[1]['database'])
 
             span.set_tag(ext.DATABASE_STATEMENT, sql_sanitizer(sql))
-            # span.set_tag(ext.DATABASE_TYPE, 'mysql')
             span.set_tag(ext.DATABASE_USER, self._connect_params[1]['user'])
-            span.set_tag('host', "%s:%s" %
-                         (self._connect_params[1]['host'],
-                          self._connect_params[1]['port']))
+            span.set_tag('host', self._connect_params[1]['host'])
+            span.set_tag('port', self._connect_params[1]['port'])
         except Exception as e:
             logger.debug(e)
         finally:

--- a/instana/recorder.py
+++ b/instana/recorder.py
@@ -206,6 +206,7 @@ class InstanaRecorder(SpanRecorder):
 
         if span.operation_name == "mysql":
             data.mysql = MySQLData(host=span.tags.pop('host', None),
+                                   port=span.tags.pop('port', None),
                                    db=span.tags.pop(ext.DATABASE_INSTANCE, None),
                                    user=span.tags.pop(ext.DATABASE_USER, None),
                                    stmt=span.tags.pop(ext.DATABASE_STATEMENT, None))
@@ -215,6 +216,7 @@ class InstanaRecorder(SpanRecorder):
 
         if span.operation_name == "postgres":
             data.pg = PostgresData(host=span.tags.pop('host', None),
+                                   port=span.tags.pop('port', None),
                                    db=span.tags.pop(ext.DATABASE_INSTANCE, None),
                                    user=span.tags.pop(ext.DATABASE_USER, None),
                                    stmt=span.tags.pop(ext.DATABASE_STATEMENT, None),

--- a/tests/test_mysql-python.py
+++ b/tests/test_mysql-python.py
@@ -100,7 +100,8 @@ class TestMySQLPython:
         assert_equals(db_span.data.mysql.db, testenv['mysql_db'])
         assert_equals(db_span.data.mysql.user, testenv['mysql_user'])
         assert_equals(db_span.data.mysql.stmt, 'SELECT * from users')
-        assert_equals(db_span.data.mysql.host, "%s:3306" % testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.host, testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.port, testenv['mysql_port'])
 
     def test_basic_insert(self):
         result = None
@@ -128,7 +129,8 @@ class TestMySQLPython:
         assert_equals(db_span.data.mysql.db, testenv['mysql_db'])
         assert_equals(db_span.data.mysql.user, testenv['mysql_user'])
         assert_equals(db_span.data.mysql.stmt, 'INSERT INTO users(name, email) VALUES(%s, %s)')
-        assert_equals(db_span.data.mysql.host, "%s:3306" % testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.host, testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.port, testenv['mysql_port'])
 
     def test_executemany(self):
         result = None
@@ -156,7 +158,8 @@ class TestMySQLPython:
         assert_equals(db_span.data.mysql.db, testenv['mysql_db'])
         assert_equals(db_span.data.mysql.user, testenv['mysql_user'])
         assert_equals(db_span.data.mysql.stmt, 'INSERT INTO users(name, email) VALUES(%s, %s)')
-        assert_equals(db_span.data.mysql.host, "%s:3306" % testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.host, testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.port, testenv['mysql_port'])
 
     def test_call_proc(self):
         result = None
@@ -182,7 +185,8 @@ class TestMySQLPython:
         assert_equals(db_span.data.mysql.db, testenv['mysql_db'])
         assert_equals(db_span.data.mysql.user, testenv['mysql_user'])
         assert_equals(db_span.data.mysql.stmt, 'test_proc')
-        assert_equals(db_span.data.mysql.host, "%s:3306" % testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.host, testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.port, testenv['mysql_port'])
 
     def test_error_capture(self):
         result = None
@@ -217,4 +221,5 @@ class TestMySQLPython:
         assert_equals(db_span.data.mysql.db, testenv['mysql_db'])
         assert_equals(db_span.data.mysql.user, testenv['mysql_user'])
         assert_equals(db_span.data.mysql.stmt, 'SELECT * from blah')
-        assert_equals(db_span.data.mysql.host, "%s:3306" % testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.host, testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.port, testenv['mysql_port'])

--- a/tests/test_mysqlclient.py
+++ b/tests/test_mysqlclient.py
@@ -100,7 +100,8 @@ class TestMySQLPython:
         assert_equals(db_span.data.mysql.db, testenv['mysql_db'])
         assert_equals(db_span.data.mysql.user, testenv['mysql_user'])
         assert_equals(db_span.data.mysql.stmt, 'SELECT * from users')
-        assert_equals(db_span.data.mysql.host, "%s:3306" % testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.host, testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.port, testenv['mysql_port'])
 
     def test_basic_insert(self):
         result = None
@@ -128,7 +129,8 @@ class TestMySQLPython:
         assert_equals(db_span.data.mysql.db, testenv['mysql_db'])
         assert_equals(db_span.data.mysql.user, testenv['mysql_user'])
         assert_equals(db_span.data.mysql.stmt, 'INSERT INTO users(name, email) VALUES(%s, %s)')
-        assert_equals(db_span.data.mysql.host, "%s:3306" % testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.host, testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.port, testenv['mysql_port'])
 
     def test_executemany(self):
         result = None
@@ -156,7 +158,8 @@ class TestMySQLPython:
         assert_equals(db_span.data.mysql.db, testenv['mysql_db'])
         assert_equals(db_span.data.mysql.user, testenv['mysql_user'])
         assert_equals(db_span.data.mysql.stmt, 'INSERT INTO users(name, email) VALUES(%s, %s)')
-        assert_equals(db_span.data.mysql.host, "%s:3306" % testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.host, testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.port, testenv['mysql_port'])
 
     def test_call_proc(self):
         result = None
@@ -182,7 +185,8 @@ class TestMySQLPython:
         assert_equals(db_span.data.mysql.db, testenv['mysql_db'])
         assert_equals(db_span.data.mysql.user, testenv['mysql_user'])
         assert_equals(db_span.data.mysql.stmt, 'test_proc')
-        assert_equals(db_span.data.mysql.host, "%s:3306" % testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.host, testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.port, testenv['mysql_port'])
 
     def test_error_capture(self):
         result = None
@@ -217,4 +221,5 @@ class TestMySQLPython:
         assert_equals(db_span.data.mysql.db, testenv['mysql_db'])
         assert_equals(db_span.data.mysql.user, testenv['mysql_user'])
         assert_equals(db_span.data.mysql.stmt, 'SELECT * from blah')
-        assert_equals(db_span.data.mysql.host, "%s:3306" % testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.host, testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.port, testenv['mysql_port'])

--- a/tests/test_psycopg2.py
+++ b/tests/test_psycopg2.py
@@ -99,7 +99,8 @@ class TestPsycoPG2:
         assert_equals(db_span.data.pg.db, testenv['postgresql_db'])
         assert_equals(db_span.data.pg.user, testenv['postgresql_user'])
         assert_equals(db_span.data.pg.stmt, 'SELECT * from users')
-        assert_equals(db_span.data.pg.host, "%s:5432" % testenv['postgresql_host'])
+        assert_equals(db_span.data.pg.host, testenv['postgresql_host'])
+        assert_equals(db_span.data.pg.port, testenv['postgresql_port'])
 
     def test_basic_insert(self):
         with tracer.start_active_span('test'):
@@ -122,7 +123,8 @@ class TestPsycoPG2:
         assert_equals(db_span.data.pg.db, testenv['postgresql_db'])
         assert_equals(db_span.data.pg.user, testenv['postgresql_user'])
         assert_equals(db_span.data.pg.stmt, 'INSERT INTO users(name, email) VALUES(%s, %s)')
-        assert_equals(db_span.data.pg.host, "%s:5432" % testenv['postgresql_host'])
+        assert_equals(db_span.data.pg.host, testenv['postgresql_host'])
+        assert_equals(db_span.data.pg.port, testenv['postgresql_port'])
 
     def test_executemany(self):
         result = None
@@ -148,7 +150,8 @@ class TestPsycoPG2:
         assert_equals(db_span.data.pg.db, testenv['postgresql_db'])
         assert_equals(db_span.data.pg.user, testenv['postgresql_user'])
         assert_equals(db_span.data.pg.stmt, 'INSERT INTO users(name, email) VALUES(%s, %s)')
-        assert_equals(db_span.data.pg.host, "%s:5432" % testenv['postgresql_host'])
+        assert_equals(db_span.data.pg.host, testenv['postgresql_host'])
+        assert_equals(db_span.data.pg.port, testenv['postgresql_port'])
 
     def test_call_proc(self):
         result = None
@@ -174,7 +177,8 @@ class TestPsycoPG2:
         assert_equals(db_span.data.pg.db, testenv['postgresql_db'])
         assert_equals(db_span.data.pg.user, testenv['postgresql_user'])
         assert_equals(db_span.data.pg.stmt, 'test_proc')
-        assert_equals(db_span.data.pg.host, "%s:5432" % testenv['postgresql_host'])
+        assert_equals(db_span.data.pg.host, testenv['postgresql_host'])
+        assert_equals(db_span.data.pg.port, testenv['postgresql_port'])
 
     def test_error_capture(self):
         result = None
@@ -209,7 +213,8 @@ class TestPsycoPG2:
         assert_equals(db_span.data.pg.db, testenv['postgresql_db'])
         assert_equals(db_span.data.pg.user, testenv['postgresql_user'])
         assert_equals(db_span.data.pg.stmt, 'SELECT * from blah')
-        assert_equals(db_span.data.pg.host, "%s:5432" % testenv['postgresql_host'])
+        assert_equals(db_span.data.pg.host, testenv['postgresql_host'])
+        assert_equals(db_span.data.pg.port, testenv['postgresql_port'])
 
     # Added to validate unicode support and register_type.
     def test_unicode(self):

--- a/tests/test_pymysql.py
+++ b/tests/test_pymysql.py
@@ -96,7 +96,8 @@ class TestPyMySQL:
         assert_equals(db_span.data.mysql.db, testenv['mysql_db'])
         assert_equals(db_span.data.mysql.user, testenv['mysql_user'])
         assert_equals(db_span.data.mysql.stmt, 'SELECT * from users')
-        assert_equals(db_span.data.mysql.host, "%s:3306" % testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.host, testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.port, testenv['mysql_port'])
 
     def test_query_with_params(self):
         result = None
@@ -123,7 +124,8 @@ class TestPyMySQL:
         assert_equals(db_span.data.mysql.db, testenv['mysql_db'])
         assert_equals(db_span.data.mysql.user, testenv['mysql_user'])
         assert_equals(db_span.data.mysql.stmt, 'SELECT * from users where id=?')
-        assert_equals(db_span.data.mysql.host, "%s:3306" % testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.host, testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.port, testenv['mysql_port'])
 
     def test_basic_insert(self):
         result = None
@@ -151,7 +153,8 @@ class TestPyMySQL:
         assert_equals(db_span.data.mysql.db, testenv['mysql_db'])
         assert_equals(db_span.data.mysql.user, testenv['mysql_user'])
         assert_equals(db_span.data.mysql.stmt, 'INSERT INTO users(name, email) VALUES(%s, %s)')
-        assert_equals(db_span.data.mysql.host, "%s:3306" % testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.host, testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.port, testenv['mysql_port'])
 
     def test_executemany(self):
         result = None
@@ -179,7 +182,8 @@ class TestPyMySQL:
         assert_equals(db_span.data.mysql.db, testenv['mysql_db'])
         assert_equals(db_span.data.mysql.user, testenv['mysql_user'])
         assert_equals(db_span.data.mysql.stmt, 'INSERT INTO users(name, email) VALUES(%s, %s)')
-        assert_equals(db_span.data.mysql.host, "%s:3306" % testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.host, testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.port, testenv['mysql_port'])
 
     def test_call_proc(self):
         result = None
@@ -205,7 +209,8 @@ class TestPyMySQL:
         assert_equals(db_span.data.mysql.db, testenv['mysql_db'])
         assert_equals(db_span.data.mysql.user, testenv['mysql_user'])
         assert_equals(db_span.data.mysql.stmt, 'test_proc')
-        assert_equals(db_span.data.mysql.host, "%s:3306" % testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.host, testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.port, testenv['mysql_port'])
 
     def test_error_capture(self):
         result = None
@@ -246,4 +251,5 @@ class TestPyMySQL:
         assert_equals(db_span.data.mysql.db, testenv['mysql_db'])
         assert_equals(db_span.data.mysql.user, testenv['mysql_user'])
         assert_equals(db_span.data.mysql.stmt, 'SELECT * from blah')
-        assert_equals(db_span.data.mysql.host, "%s:3306" % testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.host, testenv['mysql_host'])
+        assert_equals(db_span.data.mysql.port, testenv['mysql_port'])


### PR DESCRIPTION
Currently recorder sends db connection port within the `host` tag. This is tolerated for MySQL where port is being parsed from the host name and stored separately. However the PostgreSQL implementation behaves differently and stores the host as-is and keeps the `port` empty.

These changes unify the way postgres and mysql spans are being displayed in Instana by always sending db port separately from the host name.