### PR TITLE
Install couchbase header files while running python3.6 build on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,6 +236,10 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt install lsb-release -y
+            curl -O https://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0-6-amd64.deb
+            sudo dpkg -i ./couchbase-release-1.0-6-amd64.deb
+            sudo apt-get update
+            sudo apt install libcouchbase-dev -y
             python -m venv venv
             . venv/bin/activate
             pip install -U pip


### PR DESCRIPTION
This PR fixes CI build for python-3.6-cassandra. These builds [currently fail](https://app.circleci.com/github/instana/python-sensor/pipelines/deaf82da-216e-49d7-b902-a4d3bc2fe73d/workflows/5ef71411-a879-4535-bb4b-49e1b0ace3ab) because of being unable to install couchbase drive due to missing header files.