### PR TITLE
AWS Lambda: Validate Query params before parsing

### DIFF
--- a/instana/instrumentation/aws/triggers.py
+++ b/instana/instrumentation/aws/triggers.py
@@ -61,15 +61,15 @@ def read_http_query_params(event):
     @param event: lambda event dict
     @return: String in the form of "a=b&c=d"
     """
-    # print("multiValueQueryStringParameters=%s" % event['multiValueQueryStringParameters'])
-    # print("queryStringParameters=%s" % event['queryStringParameters'])
+    if event is None or type(event) is not dict:
+        return ""
 
     params = []
-    if 'multiValueQueryStringParameters' in event:
+    if 'multiValueQueryStringParameters' in event and event['multiValueQueryStringParameters'] is not None:
         for key in event['multiValueQueryStringParameters']:
             params.append("%s=%s" % (key, event['multiValueQueryStringParameters'][key]))
         return "&".join(params)
-    elif 'queryStringParameters' in event:
+    elif 'queryStringParameters' in event and event['queryStringParameters'] is not None:
         for key in event['queryStringParameters']:
             params.append("%s=%s" % (key, event['queryStringParameters'][key]))
         return "&".join(params)

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -13,6 +13,7 @@ from instana.recorder import AWSLambdaRecorder
 from instana import lambda_handler
 from instana import get_lambda_handler_or_default
 from instana.instrumentation.aws.lambda_inst import lambda_handler_with_instana
+from instana.instrumentation.aws.triggers import read_http_query_params
 
 
 # Mock Context object
@@ -411,3 +412,19 @@ class TestLambda(unittest.TestCase):
         message = messages[0]
         self.assertEqual('arn:aws:sqs:us-west-1:123456789012:MyQueue', message['queue'])
 
+    def test_read_query_params(self):
+        event = { "queryStringParameters": {"foo": "bar" },
+                  "multiValueQueryStringParameters": { "foo": ["bar"] } }
+        params = read_http_query_params(event)
+        self.assertEqual("foo=['bar']", params)
+
+    def test_read_query_params_with_none_data(self):
+        event = { "queryStringParameters": None,
+                  "multiValueQueryStringParameters": None }
+        params = read_http_query_params(event)
+        self.assertEqual("", params)
+
+    def test_read_query_params_with_bad_event(self):
+        event = None
+        params = read_http_query_params(event)
+        self.assertEqual("", params)


### PR DESCRIPTION
This PR adds code to protect against unexpected values (e.g. None) in the event payload.

- Add tests to validate