### PR TITLE
Add pkg_resources safety

### DIFF
--- a/instana/__init__.py
+++ b/instana/__init__.py
@@ -141,6 +141,8 @@ def boot_agent():
 
 if "INSTANA_MAGIC" in os.environ:
     pkg_resources.working_set.add_entry("/tmp/.instana/python")
+    # The following path is deprecated: To be removed at a future date
+    pkg_resources.working_set.add_entry("/tmp/instana/python")
 
     if "INSTANA_DEBUG" in os.environ:
         print("Instana: activated via AutoTrace")


### PR DESCRIPTION
We've updated our temp path for AutoTrace.  For the transition, this PR adds both paths for package resolution as a safety.  The deprecated path will be removed in a future version.