### PR TITLE
AWS Lambda: ARN Normalization

### DIFF
--- a/instana/agent/aws_lambda.py
+++ b/instana/agent/aws_lambda.py
@@ -53,7 +53,7 @@ class AWSLambdaAgent(BaseAgent):
         Retrieves the From data that is reported alongside monitoring data.
         @return: dict()
         """
-        return {'hl': True, 'cp': 'aws', 'e': self.collector.context.invoked_function_arn}
+        return {'hl': True, 'cp': 'aws', 'e': self.collector.get_fq_arn()}
 
     def report_data_payload(self, payload):
         """
@@ -65,7 +65,7 @@ class AWSLambdaAgent(BaseAgent):
                 # Prepare request headers
                 self.report_headers = dict()
                 self.report_headers["Content-Type"] = "application/json"
-                self.report_headers["X-Instana-Host"] = self.collector.context.invoked_function_arn
+                self.report_headers["X-Instana-Host"] = self.collector.get_fq_arn()
                 self.report_headers["X-Instana-Key"] = self.options.agent_key
                 self.report_headers["X-Instana-Time"] = str(round(time.time() * 1000))
 

--- a/instana/instrumentation/aws/triggers.py
+++ b/instana/instrumentation/aws/triggers.py
@@ -119,7 +119,7 @@ def enrich_lambda_span(agent, span, event, context):
     @return: None
     """
     try:
-        span.set_tag('lambda.arn', context.invoked_function_arn)
+        span.set_tag('lambda.arn', agent.collector.get_fq_arn())
         span.set_tag('lambda.name', context.function_name)
         span.set_tag('lambda.version', context.function_version)
 

--- a/instana/util.py
+++ b/instana/util.py
@@ -374,3 +374,30 @@ def determine_service_name():
     except Exception as e:
         logger.debug("get_application_name: ", exc_info=True)
         return app_name
+
+
+def normalize_aws_lambda_arn(context):
+    """
+    Parse the AWS Lambda context object for a fully qualified AWS Lambda function ARN.
+
+    This method will ensure that the returned value matches the following ARN pattern:
+      arn:aws:lambda:${region}:${account-id}:function:${name}:${version}
+
+    @param context:  AWS Lambda context object
+    @return:
+    """
+    try:
+        arn = context.invoked_function_arn
+        parts = arn.split(':')
+
+        count = len(parts)
+        if count == 7:
+            # need to append version
+            arn = arn + ':' + context.function_version
+        elif count != 8:
+            logger.debug("Unexpected ARN parse issue: %s", arn)
+
+        return arn
+    except:
+        logger.debug("normalize_arn: ", exc_info=True)
+


### PR DESCRIPTION
This PR fixes an issue with service mapping that can be caused by partial ARNs without the function version.