### PR TITLE
Improved Tag Validation & Reporting

### DIFF
--- a/instana/span.py
+++ b/instana/span.py
@@ -55,15 +55,16 @@ class InstanaSpan(BasicSpan):
 
         final_value = value
         value_type = type(value)
-        if value_type not in [bool, float, int, list, str]:
+        if value_type not in [bool, float, int, str]:
             try:
-                final_value = str(value)
+                final_value = repr(value)
             except:
-                final_value = "(non-fatal) span.set_tag: values must be one of these types: bool, float, int, list or str. tag discarded"
+                final_value = "(non-fatal) span.set_tag: values must be one of these types: bool, float, int, list, " \
+                              "set, str or alternatively support 'repr'. tag discarded"
                 logger.debug(final_value, exc_info=True)
+                return self
 
         return super(InstanaSpan, self).set_tag(key, final_value)
-
 
     def mark_as_errored(self, tags = None):
         """

--- a/instana/span.py
+++ b/instana/span.py
@@ -1,16 +1,9 @@
+import six
 import sys
 from .log import logger
 from .util import DictionaryOfStan
 from basictracer.span import BasicSpan
 import opentracing.ext.tags as ot_tags
-
-
-PY3 = sys.version_info[0] == 3
-
-if PY3:
-    string_type = str
-else:
-    string_type = basestring
 
 
 class SpanContext():
@@ -49,13 +42,22 @@ class InstanaSpan(BasicSpan):
         super(InstanaSpan, self).finish(finish_time)
 
     def set_tag(self, key, value):
-        if not isinstance(key, string_type):
+        # Key validation
+        if not isinstance(key, six.text_type) and not isinstance(key, six.string_types) :
             logger.debug("(non-fatal) span.set_tag: tag names must be strings. tag discarded for %s", type(key))
             return self
 
         final_value = value
         value_type = type(value)
-        if value_type not in [bool, float, int, str]:
+
+        # Value validation
+        if value_type in [bool, float, int, list, str]:
+            return super(InstanaSpan, self).set_tag(key, final_value)
+
+        elif isinstance(value, six.text_type):
+            final_value = str(value)
+
+        else:
             try:
                 final_value = repr(value)
             except:

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(name='instana',
                         'fysom>=2.1.2',
                         'opentracing>=2.0.0',
                         'requests>=2.8.0',
+                        'six>=1.12.0',
                         'urllib3>=1.18.1'],
       entry_points={
                     'instana':  ['string = instana:load'],

--- a/tests/opentracing/test_ot_span.py
+++ b/tests/opentracing/test_ot_span.py
@@ -194,7 +194,7 @@ class TestOTSpan(unittest.TestCase):
             set_regexp = re.compile(r"set\(\[.*,.*\]\)")
             assert(set_regexp.search(test_span.data['sdk']['custom']['tags']['myset']))
         else:
-            set_regexp = re.compile(r"\{.*,.*\}")
+            set_regexp = re.compile(r"{.*,.*}")
             assert(set_regexp.search(test_span.data['sdk']['custom']['tags']['myset']))
 
     def test_tag_names(self):

--- a/tests/opentracing/test_ot_span.py
+++ b/tests/opentracing/test_ot_span.py
@@ -170,7 +170,7 @@ class TestOTSpan(unittest.TestCase):
         assert(test_span.data['sdk']['custom']['tags']['uuid'] == "UUID('12345678-1234-5678-1234-567812345678')")
         assert(test_span.data['sdk']['custom']['tags']['tracer'])
         assert(test_span.data['sdk']['custom']['tags']['none'] == 'None')
-        assert(test_span.data['sdk']['custom']['tags']['mylist'] == '[1, 2, 3]')
+        assert(test_span.data['sdk']['custom']['tags']['mylist'] == [1, 2, 3])
         if PY2:
             assert(test_span.data['sdk']['custom']['tags']['myset'] == "set(['three', 'two', 'one'])")
         else:
@@ -186,7 +186,7 @@ class TestOTSpan(unittest.TestCase):
         assert(span_dict['data']['sdk']['custom']['tags']['uuid'] == "UUID('12345678-1234-5678-1234-567812345678')")
         assert(span_dict['data']['sdk']['custom']['tags']['tracer'])
         assert(span_dict['data']['sdk']['custom']['tags']['none'] == 'None')
-        assert(span_dict['data']['sdk']['custom']['tags']['mylist'] == '[1, 2, 3]')
+        assert(span_dict['data']['sdk']['custom']['tags']['mylist'] == [1, 2, 3])
         if PY2:
             assert(span_dict['data']['sdk']['custom']['tags']['myset'] == "set(['three', 'two', 'one'])")
         else:
@@ -196,13 +196,16 @@ class TestOTSpan(unittest.TestCase):
         with tracer.start_active_span('test') as scope:
             # Tag names (keys) must be strings
             scope.span.set_tag(1234567890, 'This should not get set')
+            # Unicode key name
+            scope.span.set_tag(u'asdf', 'This should be ok')
 
         spans = tracer.recorder.queued_spans()
         assert len(spans) == 1
 
         test_span = spans[0]
         assert(test_span)
-        assert(len(test_span.data['sdk']['custom']['tags']) == 0)
+        assert(len(test_span.data['sdk']['custom']['tags']) == 1)
+        assert(test_span.data['sdk']['custom']['tags']['asdf'] == 'This should be ok')
 
         json_data = to_json(test_span)
         assert(json_data)

--- a/tests/opentracing/test_ot_span.py
+++ b/tests/opentracing/test_ot_span.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import json
 import time
@@ -159,7 +160,7 @@ class TestOTSpan(unittest.TestCase):
             scope.span.set_tag('tracer', tracer)
             scope.span.set_tag('none', None)
             scope.span.set_tag('mylist', [1, 2, 3])
-            scope.span.set_tag('myset', {"one", "two", "three"})
+            scope.span.set_tag('myset', {"one", 2})
 
         spans = tracer.recorder.queued_spans()
         assert len(spans) == 1
@@ -172,9 +173,11 @@ class TestOTSpan(unittest.TestCase):
         assert(test_span.data['sdk']['custom']['tags']['none'] == 'None')
         assert(test_span.data['sdk']['custom']['tags']['mylist'] == [1, 2, 3])
         if PY2:
-            assert(test_span.data['sdk']['custom']['tags']['myset'] == "set(['three', 'two', 'one'])")
+            set_regexp = re.compile(r"set\(\[.*,.*\]\)")
+            assert(set_regexp.search(test_span.data['sdk']['custom']['tags']['myset']))
         else:
-            assert(test_span.data['sdk']['custom']['tags']['myset'] == "{'two', 'one', 'three'}")
+            set_regexp = re.compile(r"\{.*,.*\}")
+            assert(set_regexp.search(test_span.data['sdk']['custom']['tags']['myset']))
 
         # Convert to JSON
         json_data = to_json(test_span)
@@ -188,9 +191,11 @@ class TestOTSpan(unittest.TestCase):
         assert(span_dict['data']['sdk']['custom']['tags']['none'] == 'None')
         assert(span_dict['data']['sdk']['custom']['tags']['mylist'] == [1, 2, 3])
         if PY2:
-            assert(span_dict['data']['sdk']['custom']['tags']['myset'] == "set(['three', 'two', 'one'])")
+            set_regexp = re.compile(r"set\(\[.*,.*\]\)")
+            assert(set_regexp.search(test_span.data['sdk']['custom']['tags']['myset']))
         else:
-            assert(span_dict['data']['sdk']['custom']['tags']['myset'] == "{'three', 'two', 'one'}")
+            set_regexp = re.compile(r"\{.*,.*\}")
+            assert(set_regexp.search(test_span.data['sdk']['custom']['tags']['myset']))
 
     def test_tag_names(self):
         with tracer.start_active_span('test') as scope:


### PR DESCRIPTION
With this PR, we switch to `repr` for representing objects and add more tests to validate various scenarios.

Invalid tag keys now log a DEBUG message and are discarded:
> 11:03:52 DEBUG (non-fatal) span.set_tag: tag names must be strings. tag discarded for <type 'int'>
