### PR TITLE
Fix trace context extraction in AWS Lambda

### DIFF
--- a/instana/instrumentation/aws/lambda_inst.py
+++ b/instana/instrumentation/aws/lambda_inst.py
@@ -14,7 +14,6 @@ from ... import get_lambda_handler_or_default
 
 def lambda_handler_with_instana(wrapped, instance, args, kwargs):
     event = args[0]
-    context = args[1]
     agent = get_agent()
     tracer = get_tracer()
 

--- a/instana/instrumentation/aws/triggers.py
+++ b/instana/instrumentation/aws/triggers.py
@@ -11,6 +11,9 @@ from ...log import logger
 
 def get_context(tracer, event):
     # TODO: Search for more types of trigger context
+    if is_api_gateway_proxy_trigger(event) or is_application_load_balancer_trigger(event):
+        return tracer.extract('http_headers', event['headers'])
+
     return tracer.extract('http_headers', event)
 
 

--- a/tests/platforms/test_lambda.py
+++ b/tests/platforms/test_lambda.py
@@ -152,9 +152,9 @@ class TestLambda(unittest.TestCase):
 
         span = payload['spans'][0]
         self.assertEqual('aws.lambda.entry', span.n)
-        self.assertIsNotNone(span.t)
+        self.assertEqual('d5cb361b256413a9', span.t)
         self.assertIsNotNone(span.s)
-        self.assertIsNone(span.p)
+        self.assertEqual('0901d8ae4fbf1529', span.p)
         self.assertIsNotNone(span.ts)
         self.assertIsNotNone(span.d)
 
@@ -210,9 +210,9 @@ class TestLambda(unittest.TestCase):
 
         span = payload['spans'][0]
         self.assertEqual('aws.lambda.entry', span.n)
-        self.assertIsNotNone(span.t)
+        self.assertEqual('d5cb361b256413a9', span.t)
         self.assertIsNotNone(span.s)
-        self.assertIsNone(span.p)
+        self.assertEqual('0901d8ae4fbf1529', span.p)
         self.assertIsNotNone(span.ts)
         self.assertIsNotNone(span.d)
 
@@ -267,9 +267,9 @@ class TestLambda(unittest.TestCase):
 
         span = payload['spans'][0]
         self.assertEqual('aws.lambda.entry', span.n)
-        self.assertIsNotNone(span.t)
+        self.assertEqual('d5cb361b256413a9', span.t)
         self.assertIsNotNone(span.s)
-        self.assertIsNone(span.p)
+        self.assertEqual('0901d8ae4fbf1529', span.p)
         self.assertIsNotNone(span.ts)
         self.assertIsNotNone(span.d)
 


### PR DESCRIPTION
The HTTP headers are [passed in the `headers` section](https://docs.aws.amazon.com/lambda/latest/dg/services-alb.html) of event payload when a Lambda function is invoked via ELB and API Gateway, while Python sensor's Lambda instrumentation passes the whole event to the `tracer.extract()`. As a result the tract context is not being picked up, forcing each Lambda invocation to start a new trace.

In this PR `get_context()` attempts to detect the event type and pass the appropriate object to the propagator.