### PR TITLE
Add synthetic calls support

### DIFF
--- a/instana/http_propagator.py
+++ b/instana/http_propagator.py
@@ -108,6 +108,9 @@ class HTTPPropagator():
                                   baggage={},
                                   sampled=True,
                                   synthetic=synthetic)
+            elif synthetic:
+                ctx = SpanContext(synthetic=synthetic)
+
             return ctx
 
         except Exception:

--- a/instana/http_propagator.py
+++ b/instana/http_propagator.py
@@ -28,6 +28,7 @@ class HTTPPropagator():
     LC_HEADER_KEY_T = 'x-instana-t'
     LC_HEADER_KEY_S = 'x-instana-s'
     LC_HEADER_KEY_L = 'x-instana-l'
+    LC_HEADER_KEY_SYNTHETIC = 'x-instana-synthetic'
 
     ALT_HEADER_KEY_T = 'HTTP_X_INSTANA_T'
     ALT_HEADER_KEY_S = 'HTTP_X_INSTANA_S'
@@ -35,6 +36,7 @@ class HTTPPropagator():
     ALT_LC_HEADER_KEY_T = 'http_x_instana_t'
     ALT_LC_HEADER_KEY_S = 'http_x_instana_s'
     ALT_LC_HEADER_KEY_L = 'http_x_instana_l'
+    ALT_LC_HEADER_KEY_SYNTHETIC = 'http_x_instana_synthetic'
 
     def inject(self, span_context, carrier):
         try:
@@ -63,6 +65,7 @@ class HTTPPropagator():
         trace_id = None
         span_id = None
         level = 1
+        synthetic = False
 
         try:
             if type(carrier) is dict or hasattr(carrier, "__getitem__"):
@@ -85,6 +88,8 @@ class HTTPPropagator():
                     span_id = header_to_id(dc[key])
                 elif self.LC_HEADER_KEY_L == lc_key:
                     level = dc[key]
+                elif self.LC_HEADER_KEY_SYNTHETIC == lc_key:
+                    synthetic = dc[key] == "1"
 
                 elif self.ALT_LC_HEADER_KEY_T == lc_key:
                     trace_id = header_to_id(dc[key])
@@ -92,14 +97,17 @@ class HTTPPropagator():
                     span_id = header_to_id(dc[key])
                 elif self.ALT_LC_HEADER_KEY_L == lc_key:
                     level = dc[key]
+                elif self.ALT_LC_HEADER_KEY_SYNTHETIC == lc_key:
+                    synthetic = dc[key] == "1"
 
             ctx = None
             if trace_id is not None and span_id is not None:
                 ctx = SpanContext(span_id=span_id,
-                                         trace_id=trace_id,
-                                         level=level,
-                                         baggage={},
-                                         sampled=True)
+                                  trace_id=trace_id,
+                                  level=level,
+                                  baggage={},
+                                  sampled=True,
+                                  synthetic=synthetic)
             return ctx
 
         except Exception:

--- a/instana/span.py
+++ b/instana/span.py
@@ -39,6 +39,7 @@ class SpanContext():
 
 class InstanaSpan(BasicSpan):
     stack = None
+    synthetic = False
 
     def finish(self, finish_time=None):
         super(InstanaSpan, self).finish(finish_time)
@@ -171,6 +172,9 @@ class BaseSpan(object):
         self.f = source
         self.ec = span.tags.pop('ec', None)
         self.data = DictionaryOfStan()
+
+        if span.synthetic:
+            self.sy = True
 
         if span.stack:
             self.stack = span.stack

--- a/instana/span.py
+++ b/instana/span.py
@@ -13,12 +13,14 @@ class SpanContext():
             span_id=None,
             baggage=None,
             sampled=True,
-            level=1):
+            level=1,
+            synthetic=False):
 
         self.level = level
         self.trace_id = trace_id
         self.span_id = span_id
         self.sampled = sampled
+        self.synthetic = synthetic
         self._baggage = baggage or {}
 
     @property

--- a/instana/span.py
+++ b/instana/span.py
@@ -157,6 +157,8 @@ class InstanaSpan(BasicSpan):
 
 
 class BaseSpan(object):
+    sy = None
+    
     def __str__(self):
         return "BaseSpan(%s)" % self.__dict__.__str__()
 

--- a/instana/tracer.py
+++ b/instana/tracer.py
@@ -99,7 +99,8 @@ class InstanaTracer(BasicTracer):
                            context=ctx,
                            parent_id=(None if parent_ctx is None else parent_ctx.span_id),
                            tags=tags,
-                           start_time=start_time)
+                           start_time=start_time,
+                           synthetic=(False if parent_ctx is None else parent_ctx.synthetic))
 
         if operation_name in RegisteredSpan.EXIT_SPANS:
             self.__add_stack(span)

--- a/instana/tracer.py
+++ b/instana/tracer.py
@@ -99,8 +99,10 @@ class InstanaTracer(BasicTracer):
                            context=ctx,
                            parent_id=(None if parent_ctx is None else parent_ctx.span_id),
                            tags=tags,
-                           start_time=start_time,
-                           synthetic=(False if parent_ctx is None else parent_ctx.synthetic))
+                           start_time=start_time)
+
+        if parent_ctx is not None:
+            span.synthetic = parent_ctx.synthetic
 
         if operation_name in RegisteredSpan.EXIT_SPANS:
             self.__add_stack(span)

--- a/instana/tracer.py
+++ b/instana/tracer.py
@@ -84,7 +84,7 @@ class InstanaTracer(BasicTracer):
         # Assemble the child ctx
         gid = generate_id()
         ctx = SpanContext(span_id=gid)
-        if parent_ctx is not None:
+        if parent_ctx is not None and parent_ctx.trace_id is not None:
             if parent_ctx._baggage is not None:
                 ctx._baggage = parent_ctx._baggage.copy()
             ctx.trace_id = parent_ctx.trace_id

--- a/tests/clients/test_urllib3.py
+++ b/tests/clients/test_urllib3.py
@@ -509,6 +509,8 @@ class TestUrllib3(unittest.TestCase):
         self.assertEqual(1, urllib3_span.ec)
 
     def test_requestspkg_get(self):
+        self.recorder.clear_spans()
+        
         with tracer.start_active_span('test'):
             r = requests.get(testenv["wsgi_server"] + '/', timeout=2)
 

--- a/tests/data/lambda/api_gateway_event.json
+++ b/tests/data/lambda/api_gateway_event.json
@@ -39,7 +39,8 @@
     "X-Forwarded-Proto": "https",
     "X-Instana-T": "d5cb361b256413a9",
     "X-Instana-S": "0901d8ae4fbf1529",
-    "X-Instana-L": "1"
+    "X-Instana-L": "1",
+    "X-Instana-Synthetic": "1"
   },
   "multiValueHeaders": {
     "Accept": [

--- a/tests/frameworks/test_wsgi.py
+++ b/tests/frameworks/test_wsgi.py
@@ -68,6 +68,10 @@ class TestWSGI(unittest.TestCase):
         self.assertEqual(urllib3_span.p, test_span.s)
         self.assertEqual(wsgi_span.p, urllib3_span.s)
 
+        self.assertIsNone(wsgi_span.sy)
+        self.assertIsNone(urllib3_span.sy)
+        self.assertIsNone(test_span.sy)
+
         # Error logging
         self.assertIsNone(test_span.ec)
         self.assertIsNone(urllib3_span.ec)
@@ -82,6 +86,26 @@ class TestWSGI(unittest.TestCase):
         self.assertIsNone(wsgi_span.data["http"]["error"])
         self.assertIsNotNone(wsgi_span.stack)
         self.assertEqual(2, len(wsgi_span.stack))
+
+    def test_synthetic_request(self):
+        headers = {
+            'X-Instana-Synthetic': '1'
+        }
+        with tracer.start_active_span('test'):
+            response = self.http.request('GET', testenv["wsgi_server"] + '/', headers=headers)
+
+        spans = self.recorder.queued_spans()
+
+        self.assertEqual(3, len(spans))
+        self.assertIsNone(tracer.active_span)
+
+        wsgi_span = spans[0]
+        urllib3_span = spans[1]
+        test_span = spans[2]
+
+        self.assertTrue(wsgi_span.sy)
+        self.assertIsNone(urllib3_span.sy)
+        self.assertIsNone(test_span.sy)
 
     def test_complex_request(self):
         with tracer.start_active_span('test'):

--- a/tests/opentracing/test_ot_propagators.py
+++ b/tests/opentracing/test_ot_propagators.py
@@ -50,12 +50,13 @@ def test_http_inject_with_list():
 def test_http_basic_extract():
     ot.tracer = InstanaTracer()
 
-    carrier = {'X-Instana-T': '1', 'X-Instana-S': '1', 'X-Instana-L': '1'}
+    carrier = {'X-Instana-T': '1', 'X-Instana-S': '1', 'X-Instana-L': '1', 'X-Instana-Synthetic': '1'}
     ctx = ot.tracer.extract(ot.Format.HTTP_HEADERS, carrier)
 
     assert isinstance(ctx, span.SpanContext)
     assert('0000000000000001' == ctx.trace_id)
     assert('0000000000000001' == ctx.span_id)
+    assert ctx.synthetic
 
 
 def test_http_mixed_case_extract():
@@ -67,6 +68,7 @@ def test_http_mixed_case_extract():
     assert isinstance(ctx, span.SpanContext)
     assert('0000000000000001' == ctx.trace_id)
     assert('0000000000000001' == ctx.span_id)
+    assert not ctx.synthetic
 
 
 def test_http_no_context_extract():

--- a/tests/opentracing/test_ot_propagators.py
+++ b/tests/opentracing/test_ot_propagators.py
@@ -71,6 +71,18 @@ def test_http_mixed_case_extract():
     assert not ctx.synthetic
 
 
+def test_http_extract_synthetic_only():
+    ot.tracer = InstanaTracer()
+
+    carrier = {'X-Instana-Synthetic': '1'}
+    ctx = ot.tracer.extract(ot.Format.HTTP_HEADERS, carrier)
+
+    assert isinstance(ctx, span.SpanContext)
+    assert ctx.trace_id is None
+    assert ctx.span_id is None
+    assert ctx.synthetic
+
+
 def test_http_no_context_extract():
     ot.tracer = InstanaTracer()
 

--- a/tests/platforms/test_lambda.py
+++ b/tests/platforms/test_lambda.py
@@ -161,6 +161,8 @@ class TestLambda(unittest.TestCase):
         self.assertEqual({'hl': True, 'cp': 'aws', 'e': 'arn:aws:lambda:us-east-2:12345:function:TestPython:1'},
                          span.f)
 
+        self.assertTrue(span.sy)
+
         self.assertIsNone(span.ec)
         self.assertIsNone(span.data['lambda']['error'])
 
@@ -219,6 +221,8 @@ class TestLambda(unittest.TestCase):
         self.assertEqual({'hl': True, 'cp': 'aws', 'e': 'arn:aws:lambda:us-east-2:12345:function:TestPython:1'},
                          span.f)
 
+        self.assertTrue(span.sy)
+
         self.assertIsNone(span.ec)
         self.assertIsNone(span.data['lambda']['error'])
 
@@ -276,6 +280,8 @@ class TestLambda(unittest.TestCase):
         self.assertEqual({'hl': True, 'cp': 'aws', 'e': 'arn:aws:lambda:us-east-2:12345:function:TestPython:1'},
                          span.f)
 
+        self.assertTrue(span.sy)
+
         self.assertIsNone(span.ec)
         self.assertIsNone(span.data['lambda']['error'])
 
@@ -332,6 +338,8 @@ class TestLambda(unittest.TestCase):
         self.assertEqual({'hl': True, 'cp': 'aws', 'e': 'arn:aws:lambda:us-east-2:12345:function:TestPython:1'},
                          span.f)
 
+        self.assertIsNone(span.sy)
+
         self.assertIsNone(span.ec)
         self.assertIsNone(span.data['lambda']['error'])
 
@@ -387,6 +395,8 @@ class TestLambda(unittest.TestCase):
 
         self.assertEqual({'hl': True, 'cp': 'aws', 'e': 'arn:aws:lambda:us-east-2:12345:function:TestPython:1'},
                          span.f)
+
+        self.assertIsNone(span.sy)
 
         self.assertIsNone(span.ec)
         self.assertIsNone(span.data['lambda']['error'])
@@ -446,6 +456,8 @@ class TestLambda(unittest.TestCase):
         self.assertEqual({'hl': True, 'cp': 'aws', 'e': 'arn:aws:lambda:us-east-2:12345:function:TestPython:1'},
                          span.f)
 
+        self.assertIsNone(span.sy)
+
         self.assertIsNone(span.ec)
         self.assertIsNone(span.data['lambda']['error'])
 
@@ -502,6 +514,8 @@ class TestLambda(unittest.TestCase):
 
         self.assertEqual({'hl': True, 'cp': 'aws', 'e': 'arn:aws:lambda:us-east-2:12345:function:TestPython:1'},
                          span.f)
+
+        self.assertIsNone(span.sy)
 
         self.assertIsNone(span.ec)
         self.assertIsNone(span.data['lambda']['error'])


### PR DESCRIPTION
Mark HTTP calls made with `X-Instana-Synthetic` header set to `1` as synthetic by sending `span.sy: true` to the host agent for the instrumentation span.

This branch is on top of https://github.com/instana/python-sensor/pull/248 that addresses trace context extraction issue for Lambda.

@pglombardo, please note that `extract` now may return a span context without a trace ID if the synthetic call did not contain `X-Instana-{T,S}` headers. I believe the `tracer.start_span` change should address it, but I'd appreciate if you could give it a thorough view.

Closes https://github.com/instana/python-sensor/pull/231