### PR TITLE
Don't count successful responses as errors

### DIFF
--- a/instana/instrumentation/aiohttp/server.py
+++ b/instana/instrumentation/aiohttp/server.py
@@ -37,7 +37,13 @@ try:
                     if custom_header in request.headers:
                         scope.span.set_tag("http.%s" % custom_header, request.headers[custom_header])
 
-            response = await handler(request)
+            response = None
+            try:
+                response = await handler(request)
+            except aiohttp.web.HTTPException as e:
+                # AIOHTTP uses exceptions for specific responses
+                # see https://docs.aiohttp.org/en/latest/web_exceptions.html#web-server-exceptions
+                response = e
 
             if response is not None:
                 # Mark 500 responses as errored


### PR DESCRIPTION
AIOHTTP uses some exceptions to indicate successful responses. We frequently use this for 204 / No Content APIs.

These 204s are currently showing in Instana as "Erroneous Calls", but they aren't our APIs perspective.

See https://docs.aiohttp.org/en/latest/web_exceptions.html#successful-exceptions