### PR TITLE
Add support for API Gateway v2 Lambda payload

### DIFF
--- a/instana/instrumentation/aws/triggers.py
+++ b/instana/instrumentation/aws/triggers.py
@@ -18,7 +18,7 @@ def get_context(tracer, event):
         is_application_load_balancer_trigger(event)
 
     if is_proxy_event:
-        return tracer.extract('http_headers', event['headers'])
+        return tracer.extract('http_headers', event.get('headers', {}))
 
     return tracer.extract('http_headers', event)
 

--- a/instana/instrumentation/aws/triggers.py
+++ b/instana/instrumentation/aws/triggers.py
@@ -13,7 +13,11 @@ STR_LAMBDA_TRIGGER = 'lambda.trigger'
 
 def get_context(tracer, event):
     # TODO: Search for more types of trigger context
-    if is_api_gateway_proxy_trigger(event) or is_application_load_balancer_trigger(event):
+    is_proxy_event = is_api_gateway_proxy_trigger(event) or \
+        is_api_gateway_v2_proxy_trigger(event) or \
+        is_application_load_balancer_trigger(event)
+
+    if is_proxy_event:
         return tracer.extract('http_headers', event['headers'])
 
     return tracer.extract('http_headers', event)

--- a/instana/instrumentation/aws/triggers.py
+++ b/instana/instrumentation/aws/triggers.py
@@ -26,6 +26,20 @@ def is_api_gateway_proxy_trigger(event):
     return True
 
 
+def is_api_gateway_v2_proxy_trigger(event):
+    for key in ["version", "requestContext"]:
+        if key not in event:
+            return False
+
+    if event["version"] != "2.0":
+        return False
+
+    for key in ["apiId", "stage", "http"]:
+        if key not in event["requestContext"]:
+            return False
+
+    return True
+
 def is_application_load_balancer_trigger(event):
     if 'requestContext' in event and 'elb' in event['requestContext']:
         return True

--- a/tests/data/lambda/api_gateway_v2_event.json
+++ b/tests/data/lambda/api_gateway_v2_event.json
@@ -1,0 +1,75 @@
+{
+  "version": "2.0",
+  "routeKey": "ANY /my/{resource}",
+  "rawPath": "/my/path",
+  "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+  "cookies": [
+    "cookie1",
+    "cookie2"
+  ],
+  "headers": {
+    "Header1": "value1",
+    "Header2": "value1,value2",
+    "X-Instana-T": "0000000000001234",
+    "X-Instana-S": "0000000000004567",
+    "X-Instana-L": "1",
+    "X-Instana-Synthetic": "1",
+    "X-Custom-Header-1": "value1",
+    "x-custom-header-2": "value2"
+  },
+  "queryStringParameters": {
+    "secret": "key",
+    "q": "term"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "api-id",
+    "authentication": {
+      "clientCert": {
+        "clientCertPem": "CERT_CONTENT",
+        "subjectDN": "www.example.com",
+        "issuerDN": "Example issuer",
+        "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+        "validity": {
+          "notBefore": "May 28 12:30:02 2019 GMT",
+          "notAfter": "Aug  5 09:36:04 2021 GMT"
+        }
+      }
+    },
+    "authorizer": {
+      "jwt": {
+        "claims": {
+          "claim1": "value1",
+          "claim2": "value2"
+        },
+        "scopes": [
+          "scope1",
+          "scope2"
+        ]
+      }
+    },
+    "domainName": "id.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "id",
+    "http": {
+      "method": "POST",
+      "path": "/my/path",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "IP",
+      "userAgent": "agent"
+    },
+    "requestId": "id",
+    "routeKey": "$default",
+    "stage": "$default",
+    "time": "12/Mar/2020:19:03:58 +0000",
+    "timeEpoch": 1583348638390
+  },
+  "body": "Hello from Lambda",
+  "pathParameters": {
+    "parameter1": "value1"
+  },
+  "isBase64Encoded": false,
+  "stageVariables": {
+    "stageVariable1": "value1",
+    "stageVariable2": "value2"
+  }
+}


### PR DESCRIPTION
AWS has [introduced](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html) a new trigger event type, which is now a default for newly created triggers. This PR adds support for such payload format, extracting the trace context and necessary tags for the entry span.