### PR TITLE
Do not mark Django HTTP 404 response spans as errors

### DIFF
--- a/instana/instrumentation/django/middleware.py
+++ b/instana/instrumentation/django/middleware.py
@@ -59,7 +59,6 @@ class InstanaMiddleware(MiddlewareMixin):
                 request.iscope.span.set_tag(ext.HTTP_STATUS_CODE, response.status_code)
                 tracer.inject(request.iscope.span.context, ot.Format.HTTP_HEADERS, response)
                 response['Server-Timing'] = "intid;desc=%s" % request.iscope.span.context.trace_id
-
         except Exception:
             logger.debug("Instana middleware @ process_response", exc_info=True)
         finally:
@@ -69,6 +68,11 @@ class InstanaMiddleware(MiddlewareMixin):
             return response
 
     def process_exception(self, request, exception):
+        from django.http.response import Http404
+
+        if isinstance(exception, Http404):
+            return None
+
         if request.iscope is not None:
             request.iscope.span.log_exception(exception)
 

--- a/tests/apps/app_django.py
+++ b/tests/apps/app_django.py
@@ -7,7 +7,7 @@ import opentracing
 import opentracing.ext.tags as ext
 
 from django.conf.urls import url
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404
 
 filepath, extension = os.path.splitext(__file__)
 os.environ['DJANGO_SETTINGS_MODULE'] = os.path.basename(filepath)
@@ -91,6 +91,10 @@ def another(request):
     return HttpResponse('Stan wuz here!')
 
 
+def not_found(request):
+    raise Http404('Nothing here')
+
+
 def complex(request):
     with opentracing.tracer.start_active_span('asteroid') as pscope:
         pscope.span.set_tag(ext.COMPONENT, "Python simple example app")
@@ -118,5 +122,6 @@ urlpatterns = [
     url(r'^$', index, name='index'),
     url(r'^cause_error$', cause_error, name='cause_error'),
     url(r'^another$', another),
+    url(r'^not_found$', not_found, name='not_found'),
     url(r'^complex$', complex, name='complex')
 ]


### PR DESCRIPTION
This PR updates Django instrumentation to not to count `django.http.response.Http404` exceptions as errors. This is a perfectly normal case for an app to signal that the requested document is not found, hence it should not be reported as an error.