### PR TITLE
Fix: Make CI happy, sqlalchemy dbapi_error update

### DIFF
--- a/instana/instrumentation/sqlalchemy.py
+++ b/instana/instrumentation/sqlalchemy.py
@@ -58,15 +58,15 @@ try:
 
     @event.listens_for(Engine, error_event, named=True)
     def receive_handle_db_error(**kw):
-        context = kw['context']
+        context = kw['exception_context'].execution_context
 
         if context is not None and hasattr(context, '_stan_scope'):
             scope = context._stan_scope
             if scope is not None:
                 scope.span.mark_as_errored()
 
-                if 'exception' in kw:
-                    e = kw['exception']
+                if context.exception:
+                    e = context.exception
                     scope.span.set_tag('sqlalchemy.err', str(e))
                 else:
                     scope.span.set_tag('sqlalchemy.err', "No %s specified." % error_event)

--- a/instana/instrumentation/sqlalchemy.py
+++ b/instana/instrumentation/sqlalchemy.py
@@ -14,6 +14,7 @@ try:
     from sqlalchemy.engine import Engine
 
     url_regexp = re.compile(r"\/\/(\S+@)")
+    logger.debug("Instrumenting sqlalchemy")
 
 
     @event.listens_for(Engine, 'before_cursor_execute', named=True)
@@ -56,23 +57,36 @@ try:
         error_event = "dbapi_error"
 
 
+    def _set_error_tags(scope, exception):
+        scope.span.mark_as_errored()
+        if exception:
+            scope.span.set_tag('sqlalchemy.err', str(exception))
+        else:
+            scope.span.set_tag('sqlalchemy.err', "No %s specified." % error_event)
+        scope.close()
+
+
     @event.listens_for(Engine, error_event, named=True)
     def receive_handle_db_error(**kw):
-        context = kw['exception_context'].execution_context
 
-        if context is not None and hasattr(context, '_stan_scope'):
-            scope = context._stan_scope
-            if scope is not None:
-                scope.span.mark_as_errored()
+        # support older db error event
+        if error_event == "dbapi_error":
+            context = kw.get('context')
+            if hasattr(context, '_stan_scope') and \
+                    hasattr(context, 'exception'):
+                scope = context._stan_scope
+                context_exception = context.exception
+                if scope:
+                    _set_error_tags(scope, context_exception)
 
-                if context.exception:
-                    e = context.exception
-                    scope.span.set_tag('sqlalchemy.err', str(e))
-                else:
-                    scope.span.set_tag('sqlalchemy.err', "No %s specified." % error_event)
-                scope.close()
+        else:
+            context = kw.get('exception_context')
+            if hasattr(context.execution_context, '_stan_scope') and \
+                    hasattr(context, 'sqlalchemy_exception'):
+                scope = context.execution_context._stan_scope
+                context_exception = context.sqlalchemy_exception
+                if scope:
+                    _set_error_tags(scope, context_exception)
 
-
-    logger.debug("Instrumenting sqlalchemy")
 except ImportError:
     pass

--- a/instana/span.py
+++ b/instana/span.py
@@ -82,6 +82,8 @@ class InstanaSpan(BasicSpan):
                 self.set_tag('http.error', message)
             elif self.operation_name in ["celery-client", "celery-worker"]:
                 self.set_tag('error', message)
+            elif self.operation_name == "sqlalchemy":
+                self.set_tag('sqlalchemy.err', message)
             else:
                 self.log_kv({'message': message})
         except Exception:

--- a/tests/clients/test_sqlalchemy.py
+++ b/tests/clients/test_sqlalchemy.py
@@ -177,8 +177,7 @@ class TestSQLAlchemy(unittest.TestCase):
         self.assertEqual('postgresql', sql_span.data["sqlalchemy"]["eng"])
         self.assertEqual(sqlalchemy_url, sql_span.data["sqlalchemy"]["url"])
         self.assertEqual('htVwGrCwVThisIsInvalidSQLaw4ijXd88', sql_span.data["sqlalchemy"]["sql"])
-        self.assertEqual('syntax error at or near "htVwGrCwVThisIsInvalidSQLaw4ijXd88"\nLINE 1: htVwGrCwVThisIsInvalidSQLaw4ijXd88\n        ^\n', sql_span.data["sqlalchemy"]["err"])
-
+        self.assertIn('syntax error at or near "htVwGrCwVThisIsInvalidSQLaw4ijXd88', sql_span.data["sqlalchemy"]["err"])
         self.assertIsNotNone(sql_span.stack)
         self.assertTrue(type(sql_span.stack) is list)
         self.assertGreater(len(sql_span.stack), 0)

--- a/tests/requirements-27.txt
+++ b/tests/requirements-27.txt
@@ -25,7 +25,7 @@ pytest-celery
 redis>3.0.0
 requests>=2.17.1
 rsa<=4.5
-sqlalchemy>=1.1.15
+sqlalchemy>=1.1.15,<=1.4
 spyne>=2.9,<=2.12.14
 suds-jurko>=0.6
 tornado>=4.5.3,<6.0


### PR DESCRIPTION
Due to Sqlalchemy updates in v.1.4 the event `dbapi_error` does not exists anymore.
```
ImportError while loading conftest '/home/circleci/repo/tests/conftest.py'.
tests/conftest.py:45: in <module>
    import instana
instana/__init__.py:198: in <module>
    boot_agent()
instana/__init__.py:166: in boot_agent
    from .instrumentation import sqlalchemy
instana/instrumentation/sqlalchemy.py:50: in <module>
    @event.listens_for(Engine, 'dbapi_error', named=True)
venv/lib/python2.7/site-packages/sqlalchemy/event/api.py:142: in decorate
    listen(target, identifier, fn, *args, **kw)
venv/lib/python2.7/site-packages/sqlalchemy/event/api.py:99: in listen
    _event_key(target, identifier, fn).listen(*args, **kw)
venv/lib/python2.7/site-packages/sqlalchemy/event/api.py:30: in _event_key
    "No such event '%s' for target '%s'" % (identifier, target)
E   InvalidRequestError: No such event 'dbapi_error' for target '<class 'sqlalchemy.engine.base.Engine'>'
```

until v.1.3 there were both two events recognised: `dbapi_error` and the `handle_error` event
the signatures were
- `handle_error(self, exception_context):`
- `dbapi_error(self, conn, cursor, statement, parameters, context, exception)`

starting v.1.4, `dbapi_error` is gone now and hence throws:
```error
InvalidRequestError: No such event 'dbapi_error' for target '<class 'sqlalchemy.engine.base.Engine'>'
```

This PR adds a way to handle both the events.

To keep in mind for future: https://github.com/instana/python-sensor/issues/303 
This PR also locks the version to 1.4 in case of Python 2.x