### PR TITLE
fix the object parameter of hasattr

### DIFF
--- a/instana/__init__.py
+++ b/instana/__init__.py
@@ -54,7 +54,7 @@ def load(_):
     environment variable.
     """
     # Work around https://bugs.python.org/issue32573
-    if not hasattr("sys", "argv"):
+    if not hasattr(sys, "argv"):
         sys.argv = ['']
     return None
 


### PR DESCRIPTION
`hasattr` takes an [object](https://docs.python.org/3/library/functions.html#hasattr) and string as a parameter

Fixes #323