### PR TITLE
remove raising of the exception as it was not sending the data to the…

### DIFF
--- a/instana/instrumentation/aws/lambda_inst.py
+++ b/instana/instrumentation/aws/lambda_inst.py
@@ -37,6 +37,10 @@ def lambda_handler_with_instana(wrapped, instance, args, kwargs):
         except Exception as exc:
             if scope.span:
                 scope.span.log_exception(exc)
+            raise
+        finally:
+            scope.close()
+            agent.collector.shutdown()
 
     agent.collector.shutdown()
     return result

--- a/instana/instrumentation/aws/lambda_inst.py
+++ b/instana/instrumentation/aws/lambda_inst.py
@@ -37,7 +37,6 @@ def lambda_handler_with_instana(wrapped, instance, args, kwargs):
         except Exception as exc:
             if scope.span:
                 scope.span.log_exception(exc)
-            raise
 
     agent.collector.shutdown()
     return result

--- a/instana/version.py
+++ b/instana/version.py
@@ -3,4 +3,4 @@
 
 # Module version file.  Used by setup.py and snapshot reporting.
 
-VERSION = '1.35.0'
+VERSION = '1.35.1'


### PR DESCRIPTION

The raise was causing total call loss in case of unhandled aws lambda exception, the addition of finally block was needed to close the scope and send the data to the agent. Now the call is appearing and it is getting marked as erroneous. 