### PR TITLE
Lambda error log fix

### DIFF
--- a/instana/instrumentation/aws/lambda_inst.py
+++ b/instana/instrumentation/aws/lambda_inst.py
@@ -12,6 +12,7 @@ from ...singletons import env_is_aws_lambda
 from ... import get_lambda_handler_or_default
 from ...singletons import get_agent, get_tracer
 from .triggers import enrich_lambda_span, get_context
+import traceback
 
 
 def lambda_handler_with_instana(wrapped, instance, args, kwargs):
@@ -36,6 +37,7 @@ def lambda_handler_with_instana(wrapped, instance, args, kwargs):
                     result['multiValueHeaders']['Server-Timing'] = [server_timing_value]
         except Exception as exc:
             if scope.span:
+                exc = traceback.format_exc()
                 scope.span.log_exception(exc)
             raise
         finally:

--- a/instana/instrumentation/sqlalchemy.py
+++ b/instana/instrumentation/sqlalchemy.py
@@ -28,7 +28,8 @@ try:
 
             scope = active_tracer.start_active_span("sqlalchemy", child_of=active_tracer.active_span)
             context = kw['context']
-            context._stan_scope = scope
+            if context:
+                context._stan_scope = scope
 
             conn = kw['conn']
             url = str(conn.engine.url)

--- a/instana/span.py
+++ b/instana/span.py
@@ -64,7 +64,6 @@ class InstanaSpan(BasicSpan):
         try:
             message = ""
             self.mark_as_errored()
-
             if hasattr(exc, '__str__') and len(str(exc)) > 0:
                 message = str(exc)
             elif hasattr(exc, 'message') and exc.message is not None:
@@ -84,6 +83,8 @@ class InstanaSpan(BasicSpan):
                 self.set_tag('error', message)
             elif self.operation_name == "sqlalchemy":
                 self.set_tag('sqlalchemy.err', message)
+            elif self.operation_name == "aws.lambda.entry":
+                self.set_tag('lambda.error', message)
             else:
                 self.log_kv({'message': message})
         except Exception:
@@ -295,7 +296,7 @@ class RegisteredSpan(BaseSpan):
             self.data["lambda"]["functionName"] = span.tags.pop('lambda.name', "Unknown")
             self.data["lambda"]["functionVersion"] = span.tags.pop('lambda.version', "Unknown")
             self.data["lambda"]["trigger"] = span.tags.pop('lambda.trigger', None)
-            self.data["lambda"]["error"] = None
+            self.data["lambda"]["error"] = span.tags.pop('lambda.error', None)
 
             trigger_type = self.data["lambda"]["trigger"]
 

--- a/instana/version.py
+++ b/instana/version.py
@@ -3,4 +3,4 @@
 
 # Module version file.  Used by setup.py and snapshot reporting.
 
-VERSION = '1.35.1'
+VERSION = '1.35.2'


### PR DESCRIPTION
Marking the lambda call as erroneous was fixed on the 1.35.1 release but there was no error log attached. The customer would  also like to see the error log and the traceback.
Plus, added a check in the sqlalchemy instrumentation as the context can potentially be None and a customer has reported an issue because of it.  