### PR TITLE
Allow customers to disable metrics collection

### DIFF
--- a/instana/collector/helpers/runtime.py
+++ b/instana/collector/helpers/runtime.py
@@ -55,6 +55,9 @@ class RuntimeHelper(BaseHelper):
         return [plugin_data]
 
     def _collect_runtime_metrics(self, plugin_data, with_snapshot):
+        if os.environ.get('INSTANA_DISABLE_METRICS_COLLECTION', False):
+            return False
+        
         """ Collect up and return the runtime metrics """
         try:
             rusage = resource.getrusage(resource.RUSAGE_SELF)

--- a/instana/collector/helpers/runtime.py
+++ b/instana/collector/helpers/runtime.py
@@ -56,7 +56,7 @@ class RuntimeHelper(BaseHelper):
 
     def _collect_runtime_metrics(self, plugin_data, with_snapshot):
         if os.environ.get('INSTANA_DISABLE_METRICS_COLLECTION', False):
-            return False
+            return
         
         """ Collect up and return the runtime metrics """
         try:

--- a/instana/version.py
+++ b/instana/version.py
@@ -3,4 +3,4 @@
 
 # Module version file.  Used by setup.py and snapshot reporting.
 
-VERSION = '1.35.2'
+VERSION = '1.35.3'

--- a/tests/platforms/test_host_collector.py
+++ b/tests/platforms/test_host_collector.py
@@ -132,7 +132,7 @@ class TestHostCollector(unittest.TestCase):
         assert type(python_plugin['data']['metrics']['gc']['threshold2']) in [float, int]
 
     def test_prepare_payload_basics_disable_runtime_metrics(self):
-        os.environ["INSTANA_DISABLE_METRICS_COLLECTION"] = "disable"
+        os.environ["INSTANA_DISABLE_METRICS_COLLECTION"] = "TRUE"
         self.create_agent_and_setup_tracer()
 
         payload = self.agent.collector.prepare_payload()

--- a/tests/platforms/test_host_collector.py
+++ b/tests/platforms/test_host_collector.py
@@ -40,6 +40,8 @@ class TestHostCollector(unittest.TestCase):
             os.environ.pop("INSTANA_ZONE")
         if "INSTANA_TAGS" in os.environ:
             os.environ.pop("INSTANA_TAGS")
+        if "INSTANA_DISABLE_METRICS_COLLECTION" in os.environ:
+            os.environ.pop("INSTANA_DISABLE_METRICS_COLLECTION")
 
         set_agent(self.original_agent)
         set_tracer(self.original_tracer)
@@ -55,17 +57,17 @@ class TestHostCollector(unittest.TestCase):
         self.create_agent_and_setup_tracer()
 
         payload = self.agent.collector.prepare_payload()
-        assert(payload)
+        assert (payload)
 
-        assert(len(payload.keys()) == 3)
-        assert('spans' in payload)
-        assert(isinstance(payload['spans'], list))
-        assert(len(payload['spans']) == 0)
-        assert('metrics' in payload)
-        assert(len(payload['metrics'].keys()) == 1)
-        assert('plugins' in payload['metrics'])
-        assert(isinstance(payload['metrics']['plugins'], list))
-        assert(len(payload['metrics']['plugins']) == 1)
+        assert (len(payload.keys()) == 3)
+        assert ('spans' in payload)
+        assert (isinstance(payload['spans'], list))
+        assert (len(payload['spans']) == 0)
+        assert ('metrics' in payload)
+        assert (len(payload['metrics'].keys()) == 1)
+        assert ('plugins' in payload['metrics'])
+        assert (isinstance(payload['metrics']['plugins'], list))
+        assert (len(payload['metrics']['plugins']) == 1)
 
         python_plugin = payload['metrics']['plugins'][0]
         assert python_plugin['name'] == 'com.instana.plugin.python'
@@ -113,7 +115,7 @@ class TestHostCollector(unittest.TestCase):
         assert type(python_plugin['data']['metrics']['dummy_threads']) in [float, int]
         assert 'daemon_threads' in python_plugin['data']['metrics']
         assert type(python_plugin['data']['metrics']['daemon_threads']) in [float, int]
-        
+
         assert 'gc' in python_plugin['data']['metrics']
         assert isinstance(python_plugin['data']['metrics']['gc'], dict)
         assert 'collect0' in python_plugin['data']['metrics']['gc']
@@ -128,3 +130,27 @@ class TestHostCollector(unittest.TestCase):
         assert type(python_plugin['data']['metrics']['gc']['threshold1']) in [float, int]
         assert 'threshold2' in python_plugin['data']['metrics']['gc']
         assert type(python_plugin['data']['metrics']['gc']['threshold2']) in [float, int]
+
+    def test_prepare_payload_basics_disable_runtime_metrics(self):
+        os.environ["INSTANA_DISABLE_METRICS_COLLECTION"] = "disable"
+        self.create_agent_and_setup_tracer()
+
+        payload = self.agent.collector.prepare_payload()
+        assert (payload)
+
+        assert (len(payload.keys()) == 3)
+        assert ('spans' in payload)
+        assert (isinstance(payload['spans'], list))
+        assert (len(payload['spans']) == 0)
+        assert ('metrics' in payload)
+        assert (len(payload['metrics'].keys()) == 1)
+        assert ('plugins' in payload['metrics'])
+        assert (isinstance(payload['metrics']['plugins'], list))
+        assert (len(payload['metrics']['plugins']) == 1)
+
+        python_plugin = payload['metrics']['plugins'][0]
+        assert python_plugin['name'] == 'com.instana.plugin.python'
+        assert python_plugin['entityId'] == str(os.getpid())
+        assert 'data' in python_plugin
+        assert 'snapshot' in python_plugin['data']
+        assert 'metrics' not in python_plugin['data']


### PR DESCRIPTION
For certain hardened runtimes, collecting metrics can trigger slow
paths in the security subsystems in place. By setting
`INSTANA_DISABLE_METRICS_COLLECTION` to `TRUE`, a customer can now
disable collecting these metrics and avoid the performance impact
that the setup causes.