### PR TITLE
Sanic exception bug fix

### DIFF
--- a/instana/version.py
+++ b/instana/version.py
@@ -3,4 +3,4 @@
 
 # Module version file.  Used by setup.py and snapshot reporting.
 
-VERSION = '1.35.3'
+VERSION = '1.35.4'

--- a/tests/apps/sanic_app/server.py
+++ b/tests/apps/sanic_app/server.py
@@ -20,6 +20,9 @@ async def uuid_handler(request, foo_id: int):
 async def test_request_args(request):
     raise SanicException("Something went wrong.", status_code=500)
 
+@app.route("/instana_exception")
+async def test_request_args(request):
+    raise SanicException(description="Something went wrong.", status_code=500)
 
 @app.route("/wrong")
 async def test_request_args(request):

--- a/tests/apps/sanic_app/server.py
+++ b/tests/apps/sanic_app/server.py
@@ -1,12 +1,13 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2021
 
+import instana
+
 from sanic import Sanic
 from sanic.exceptions import SanicException
 from tests.apps.sanic_app.simpleview import SimpleView
 from tests.apps.sanic_app.name import NameView
 from sanic.response import text
-import instana
 
 app = Sanic('test')
 
@@ -19,6 +20,10 @@ async def uuid_handler(request, foo_id: int):
 async def test_request_args(request):
     raise SanicException("Something went wrong.", status_code=500)
 
+
+@app.route("/wrong")
+async def test_request_args(request):
+    raise SanicException(message="Something went wrong.", status_code=400)
 
 @app.get("/tag/<tag>")
 async def tag_handler(request, tag):

--- a/tests/frameworks/test_sanic.py
+++ b/tests/frameworks/test_sanic.py
@@ -135,7 +135,7 @@ class TestSanic(unittest.TestCase, _TraceContextMixin):
         self.assertEqual(result.status_code, 400)
 
         spans = tracer.recorder.queued_spans()
-        self.assertEqual(len(spans), 4)
+        self.assertEqual(len(spans), 3)
 
         span_filter = lambda span: span.n == "sdk" and span.data['sdk']['name'] == 'test'
         test_span = get_first_span_by_filter(spans, span_filter)


### PR DESCRIPTION
Fixing bug on evaluating args[0] even when message was present as a keyword argument and was causing an IndexError
Additional added a try/catch block to log any possible exception could be triggered by a bug in the instana code, so that this will not influence the execution flow of the customer's code.