### PR TITLE
limit sanic version in requirements file

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -22,7 +22,7 @@ pyramid>=2.0
 pytest>=6.2.4
 pytest-celery
 redis>=3.5.3
-sanic>=19.0.0
+sanic>=19.0.0,<21.9.0
 sqlalchemy>=1.4.15
 spyne>=2.13.16
 suds-jurko>=0.6


### PR DESCRIPTION
Sanic version 21.9.0 and above is breaking the testing suite, it needs to be investigated what changes we may need to continue supporting newer versions