### PR TITLE
added skipping of tests which fail in OSX

### DIFF
--- a/tests/clients/test_google-cloud-storage.py
+++ b/tests/clients/test_google-cloud-storage.py
@@ -26,6 +26,7 @@ class TestGoogleCloudStorage(unittest.TestCase, _TraceContextMixin):
         self.recorder = tracer.recorder
         self.recorder.clear_spans()
 
+    @pytest.mark.skipif(sys.platform == "darwin", reason="Raises not Implemented exception in OSX")
     @patch('requests.Session.request')
     def test_buckets_list(self, mock_requests):
         mock_requests.return_value = self._mock_response(
@@ -514,6 +515,7 @@ class TestGoogleCloudStorage(unittest.TestCase, _TraceContextMixin):
         self.assertEqual('test bucket', gcs_span.data["gcs"]["bucket"])
         self.assertEqual('test object', gcs_span.data["gcs"]["object"])
 
+    @pytest.mark.skipif(sys.platform == "darwin", reason="Raises not Implemented exception in OSX")
     @patch('requests.Session.request')
     def test_objects_list(self, mock_requests):
         mock_requests.return_value = self._mock_response(
@@ -787,6 +789,7 @@ class TestGoogleCloudStorage(unittest.TestCase, _TraceContextMixin):
         self.assertEqual('test-project', gcs_span.data["gcs"]["projectId"])
         self.assertEqual('test key', gcs_span.data["gcs"]["accessId"])
 
+    @pytest.mark.skipif(sys.platform == "darwin", reason="Raises not Implemented exception in OSX")
     @patch('requests.Session.request')
     def test_object_hmac_keys_list(self, mock_requests):
         mock_requests.return_value = self._mock_response(

--- a/tests/opentracing/test_ot_span.py
+++ b/tests/opentracing/test_ot_span.py
@@ -6,6 +6,7 @@ import sys
 import json
 import time
 import unittest
+import pytest
 import opentracing
 from uuid import UUID
 from instana.util import to_json
@@ -72,6 +73,7 @@ class TestOTSpan(unittest.TestCase):
         self.assertEqual("string", span.tags['tagone'])
         self.assertEqual(150, span.tags['tagtwo'])
 
+    @pytest.mark.skipif(sys.platform == "darwin", reason="Raises not Implemented exception in OSX")
     def test_span_queueing(self):
         recorder = opentracing.tracer.recorder
 


### PR DESCRIPTION
I just marked some tests to be skipped when they are running in Mac because they are not supported and causing false failures