### PR TITLE
fix(requirements-asynqp): Update flask to latest stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,6 +255,26 @@ jobs:
             pip uninstall -y uvloop
             pytest -v tests/clients/test_asynqp.py
 
+  py37asynqp-legacy:
+    docker:
+      - image: circleci/python:3.7.9
+      - image: rabbitmq:3.5.4
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - pip-install-deps:
+          requirements: "tests/requirements-asynqp-legacy-flask-markupsafe.txt"
+      - run:
+          name: run tests
+          environment:
+            INSTANA_TEST: "true"
+            ASYNQP_TEST: "true"
+          command: |
+            . venv/bin/activate
+            # We uninstall uvloop as it interferes with asyncio changing the event loop policy
+            pip uninstall -y uvloop
+            pytest -v tests/clients/test_asynqp.py
+
   gevent38:
     docker:
       - image: circleci/python:3.8.5
@@ -283,4 +303,5 @@ workflows:
       - py27cassandra
       - py36cassandra
       - py37asynqp
+      - py37asynqp-legacy
       - gevent38

--- a/tests/requirements-asynqp-legacy-flask-markupsafe.txt
+++ b/tests/requirements-asynqp-legacy-flask-markupsafe.txt
@@ -1,0 +1,16 @@
+# https://github.com/pallets/markupsafe/issues/284
+# Some of our customers still use legacy flask.
+# The latest `markupsafe` can't be used with
+# the required Jinja2 version of the required flask<2.0.0 version
+# so we have to pin down markupsafe to the last version
+# which still worked.
+
+aiohttp>=3.7.4
+asynqp>=0.6
+flask>=1.1.4,<2.0.0
+Jinja2<3.0.0
+markupsafe==2.0.1
+mock>=2.0.0
+nose>=1.0
+pytest>=4.6
+urllib3[secure]!=1.25.0,!=1.25.1,<1.27,>=1.21.1

--- a/tests/requirements-asynqp.txt
+++ b/tests/requirements-asynqp.txt
@@ -1,6 +1,6 @@
 aiohttp>=3.7.4
 asynqp>=0.6
-flask>=1.1.4,<2.0.0
+flask>=2.0.0,<3.0.0
 mock>=2.0.0
 nose>=1.0
 pytest>=4.6


### PR DESCRIPTION
* This issue is described in
  https://github.com/pallets/markupsafe/issues/284

* The recommended action is to upgrade Jinja2,
  https://github.com/pallets/markupsafe/issues/284#issuecomment-1044538043
  but that only works with newer flask, so hence the flask upgrade.

* The exact backtrace in our case, that we are trying to avoid here is this:
```
Traceback:
/usr/local/lib/python3.7/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/clients/test_asynqp.py:16: in <module>
    import tests.apps.flask_app
tests/apps/flask_app/__init__.py:5: in <module>
    from .app import flask_server as server
tests/apps/flask_app/app.py:10: in <module>
    from flask import jsonify, Response
venv/lib/python3.7/site-packages/flask/__init__.py:14: in <module>
    from jinja2 import escape
venv/lib/python3.7/site-packages/jinja2/__init__.py:12: in <module>
    from .environment import Environment
venv/lib/python3.7/site-packages/jinja2/environment.py:25: in <module>
    from .defaults import BLOCK_END_STRING
venv/lib/python3.7/site-packages/jinja2/defaults.py:3: in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
venv/lib/python3.7/site-packages/jinja2/filters.py:13: in <module>
    from markupsafe import soft_unicode
E   ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/home/circleci/repo/venv/lib/python3.7/site-packages/markupsafe/__init__.py)
```