### PR TITLE
feat(ci): Add a CI test job for Python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,31 @@ jobs:
             . venv/bin/activate
             pytest -v
 
+  python310:
+    docker:
+      - image: circleci/python:3.10.0-buster
+      - image: circleci/postgres:9.6.5-alpine-ram
+      - image: circleci/mariadb:10-ram
+      - image: circleci/redis:5.0.4
+      - image: rabbitmq:3.5.4
+      - image: circleci/mongo:4.2.3-ram
+      - image: singularities/pubsub-emulator
+        environment:
+          PUBSUB_PROJECT_ID: "project-test"
+          PUBSUB_LISTEN_ADDRESS: "0.0.0.0:8432"
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - pip-install-deps:
+          requirements: "tests/requirements-310.txt"
+      - run:
+          name: run tests
+          environment:
+            INSTANA_TEST: "true"
+          command: |
+            . venv/bin/activate
+            pytest -v
+
   py38couchbase:
     docker:
       - image: circleci/python:3.7.8-stretch
@@ -300,6 +325,7 @@ workflows:
       - python37
       - python38
       - python39
+      - python310
       - py27cassandra
       - py36cassandra
       - py37asynqp

--- a/instana/collector/base.py
+++ b/instana/collector/base.py
@@ -102,8 +102,8 @@ class BaseCollector(object):
             logger.debug("BaseCollector.start: launching collection thread")
             self.thread_shutdown.clear()
             self.reporting_thread = threading.Thread(target=self.thread_loop, args=())
-            self.reporting_thread.setDaemon(True)
-            self.reporting_thread.setName(self.THREAD_NAME)
+            self.reporting_thread.daemon = True
+            self.reporting_thread.name = self.THREAD_NAME
             self.reporting_thread.start()
             self.started = True
         else:

--- a/instana/instrumentation/logging.py
+++ b/instana/instrumentation/logging.py
@@ -8,6 +8,11 @@ import wrapt
 import logging
 import collections
 
+# TODO: Remove this alias once we don't have to support <=Python 3.3
+collections_abc = getattr(collections, 'abc', collections)
+Mapping = collections_abc.Mapping
+# End of alias
+
 from ..log import logger
 from ..util.traceutils import get_active_tracer
 
@@ -25,7 +30,7 @@ def log_with_instana(wrapped, instance, argv, kwargs):
 
             msg = str(argv[1])
             args = argv[2]
-            if args and len(args) == 1 and isinstance(args[0], collections.Mapping) and args[0]:
+            if args and len(args) == 1 and isinstance(args[0], Mapping) and args[0]:
                 args = args[0]
 
             # get the formatted log message

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,11 @@ if LooseVersion(sys.version) < LooseVersion('3.6.0'):
 if LooseVersion(sys.version) >= LooseVersion('3.7.0'):
     collect_ignore_glob.append("*test_sudsjurko*")
 
+if LooseVersion(sys.version) >= LooseVersion('3.10.0'):
+    collect_ignore_glob.append("*test_tornado*")
+    collect_ignore_glob.append("*test_boto3_secretsmanager*")
+
+
 # Set our testing flags
 os.environ["INSTANA_TEST"] = "true"
 # os.environ["INSTANA_DEBUG"] = "true"

--- a/tests/requirements-310.txt
+++ b/tests/requirements-310.txt
@@ -1,0 +1,44 @@
+# pre 6.0 tornado would try to import 'MutableMapping' from 'collections'
+# directly, and in Python 3.10 that doesn't work anymore, so that would fail with:
+# venv/lib/python3.10/site-packages/tornado/httputil.py:107: in <module>
+# AttributeError: module 'collections' has no attribute 'MutableMapping'
+# An alternative would be to disable this in testconf:
+# collect_ignore_glob.append("*test_tornado*")
+tornado>=6.1
+
+
+aiofiles>=0.5.0
+aiohttp>=3.7.4
+boto3>=1.17.74
+celery>=5.0.5
+coverage>=5.5
+Django>=3.2.3
+fastapi>=0.65.1
+flask>=2.0.0
+markupsafe>=2.1.0
+grpcio>=1.37.1
+google-cloud-pubsub<=2.1.0
+google-cloud-storage>=1.24.0
+lxml>=4.6.3
+mock>=4.0.3
+
+# We have to increase the minimum moto version so we can keep markupsafe on the required minimum
+moto>=2.0
+mysqlclient>=2.0.3
+nose>=1.3.7
+PyMySQL[rsa]>=1.0.2
+psycopg2-binary>=2.8.6
+pika>=1.2.0
+pymongo>=3.11.4
+pyramid>=2.0
+pytest>=6.2.4
+pytest-celery
+redis>=3.5.3
+requests-mock
+sanic>=19.0.0,<21.9.0
+sqlalchemy>=1.4.15
+spyne>=2.13.16
+suds-jurko>=0.6
+
+uvicorn>=0.13.4
+urllib3[secure]!=1.25.0,!=1.25.1,<1.27,>=1.21.1


### PR DESCRIPTION
This PR enables the codebase to be tested on Python 3.10 in a CI loop,
so developers get fast feedback of test results on Python 3.10.