### PR TITLE
Fix AttributeError when extracting tags from pika

### DIFF
--- a/instana/instrumentation/pika.py
+++ b/instana/instrumentation/pika.py
@@ -32,7 +32,6 @@ try:
     def _extract_consumer_tags(span, conn, queue):
         _extract_broker_tags(span, conn)
 
-        span.set_tag("address", "%s:%d" % (conn.params.host, conn.params.port))
         span.set_tag("sort", "consume")
         span.set_tag("queue", queue)
 

--- a/instana/instrumentation/pika.py
+++ b/instana/instrumentation/pika.py
@@ -119,7 +119,7 @@ try:
             with tracer.start_active_span("rabbitmq", child_of=parent_span) as scope:
                 try:
                     _extract_consumer_tags(scope.span,
-                                           conn=instance.connection,
+                                           conn=instance.connection._impl,
                                            queue=queue)
                 except:
                     logger.debug("basic_consume_with_instana: ", exc_info=True)

--- a/instana/version.py
+++ b/instana/version.py
@@ -3,4 +3,4 @@
 
 # Module version file.  Used by setup.py and snapshot reporting.
 
-VERSION = '1.36.2'
+VERSION = '1.36.3'

--- a/tests/clients/test_pika.py
+++ b/tests/clients/test_pika.py
@@ -3,14 +3,12 @@
 
 from __future__ import absolute_import
 
-import os
 import pika
 import unittest
 import mock
 import threading
 import time
 
-from ..helpers import testenv
 from instana.singletons import tracer
 
 

--- a/tests/clients/test_pika.py
+++ b/tests/clients/test_pika.py
@@ -376,10 +376,6 @@ class TestPikaBlockingChannel(_TestPika):
 
 
 class TestPikaBlockingChannelBlockingConnection(_TestPika):
-
-    DEFAULT_HOST = pika.connection.Parameters.DEFAULT_HOST
-    DEFAULT_PORT = pika.connection.Parameters.DEFAULT_PORT
-
     @mock.patch('pika.adapters.blocking_connection.BlockingConnection', autospec=True)
     def _create_connection(self, connection=None):
         connection._impl = mock.create_autospec(pika.connection.Connection)

--- a/tests/clients/test_pika.py
+++ b/tests/clients/test_pika.py
@@ -375,18 +375,16 @@ class TestPikaBlockingChannel(_TestPika):
         self.assertNotEqual(rabbitmq_span.p, rabbitmq_span.s)
 
 
-class _TestPikaBlockingConnection(_TestPika):
+class TestPikaBlockingChannelBlockingConnection(_TestPika):
+
+    DEFAULT_HOST = pika.connection.Parameters.DEFAULT_HOST
+    DEFAULT_PORT = pika.connection.Parameters.DEFAULT_PORT
+
     @mock.patch('pika.adapters.blocking_connection.BlockingConnection', autospec=True)
     def _create_connection(self, connection=None):
         connection._impl = mock.create_autospec(pika.connection.Connection)
         connection._impl.params = pika.connection.Parameters()
         return connection
-
-
-class TestPikaBlockingChannelBlockingConnection(_TestPikaBlockingConnection):
-
-    DEFAULT_HOST = pika.connection.Parameters.DEFAULT_HOST
-    DEFAULT_PORT = pika.connection.Parameters.DEFAULT_PORT
 
     @mock.patch('pika.channel.Channel', spec=pika.channel.Channel)
     def _create_obj(self, channel_impl):


### PR DESCRIPTION
Resolves #354.

Also removes duplicate call to `span.set_tag` as it seems to already be done at `_extract_broker_tags`.