### PR TITLE
Extend and improve unittests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ if LooseVersion(sys.version) < LooseVersion('3.5.3'):
     collect_ignore_glob.append("*test_tornado*")
     collect_ignore_glob.append("*test_grpc*")
     collect_ignore_glob.append("*test_boto3*")
+    collect_ignore_glob.append("*test_stan_recorder*")
 
 if "ASYNQP_TEST" not in os.environ:
 # if LooseVersion(sys.version) < LooseVersion('3.5.3') or LooseVersion(sys.version) >= LooseVersion('3.8.0'):

--- a/tests/frameworks/test_django.py
+++ b/tests/frameworks/test_django.py
@@ -23,7 +23,7 @@ class TestDjango(StaticLiveServerTestCase):
         self.http = urllib3.PoolManager()
 
     def tearDown(self):
-        """ Do nothing for now """
+        """ Clear the INSTANA_DISABLE_W3C_TRACE_CORRELATION environment variable """
         os.environ["INSTANA_DISABLE_W3C_TRACE_CORRELATION"] = ""
 
     def test_basic_request(self):

--- a/tests/recorder/test_stan_recorder.py
+++ b/tests/recorder/test_stan_recorder.py
@@ -1,0 +1,30 @@
+from instana.recorder import StanRecorder
+
+from multiprocessing import Queue
+from unittest import TestCase
+from unittest.mock import NonCallableMagicMock, PropertyMock
+
+class TestStanRecorderTC(TestCase):
+    def setUp(self):
+        mock_agent = NonCallableMagicMock()
+        mock_collector = NonCallableMagicMock(span_queue=Queue())
+        mock_agent.collector = mock_collector
+        self.recorder = StanRecorder(agent=mock_agent)
+        self.mock_suppressed_span = NonCallableMagicMock()
+        self.mock_suppressed_span.context = NonCallableMagicMock()
+        self.mock_suppressed_property = PropertyMock(return_value=True)
+        type(self.mock_suppressed_span.context).suppression = self.mock_suppressed_property
+
+    def test_record_span_with_suppression(self):
+        # Ensure that the queue is empty
+        self.assertEqual(self.recorder.queue_size(), 0)
+        self.recorder.record_span(self.mock_suppressed_span)
+        # Ensure that even after adding a suppressed span
+        # the queue remains empty
+        self.assertEqual(self.recorder.queue_size(), 0)
+        # Ensure that the no recorded spans can be retrieved
+        self.assertEqual(self.recorder.queued_spans(), [])
+
+        # Make sure that the success so far has indeed resulted after a getitem
+        # call to the 'suppression' property of the mock span context
+        self.mock_suppressed_property.assert_called_once_with()


### PR DESCRIPTION
* Adds unit test for StanRecorder with suppressed span
* Fixes a docstring in `test_django`
