### PR TITLE
fix(sqlalchemy): Stand down before tracing has started (#362)

### DIFF
--- a/instana/instrumentation/sqlalchemy.py
+++ b/instana/instrumentation/sqlalchemy.py
@@ -73,6 +73,9 @@ try:
     @event.listens_for(Engine, error_event, named=True)
     def receive_handle_db_error(**kw):
 
+        if get_active_tracer() is None:
+            return
+
         # support older db error event
         if error_event == "dbapi_error":
             context = kw.get('context')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ if LooseVersion(sys.version) < LooseVersion('3.5.3'):
     collect_ignore_glob.append("*test_grpc*")
     collect_ignore_glob.append("*test_boto3*")
     collect_ignore_glob.append("*test_stan_recorder*")
+    collect_ignore_glob.append("*test_sqlalchemy*")
 
 if "ASYNQP_TEST" not in os.environ:
 # if LooseVersion(sys.version) < LooseVersion('3.5.3') or LooseVersion(sys.version) >= LooseVersion('3.8.0'):


### PR DESCRIPTION
The root cause of the AttributeError described in https://github.com/instana/python-sensor/issues/362,
appears to be a faulty assumption, that when an error occurs, the tracing must be active.
In this fix if the tracing is not active then the error event handler simply does an early return.