### PR TITLE
fix(django): Detect running django based on the injected path

### DIFF
--- a/instana/instrumentation/django/middleware.py
+++ b/instana/instrumentation/django/middleware.py
@@ -168,7 +168,7 @@ try:
         logger.debug("Instrumenting django")
         wrapt.wrap_function_wrapper('django.core.handlers.base', 'BaseHandler.load_middleware', load_middleware_wrapper)
 
-        if 'INSTANA_MAGIC' in os.environ:
+        if '/tmp/.instana/python' in sys.path:
             # If we are instrumenting via AutoTrace (in an already running process), then the
             # WSGI middleware has to be live reloaded.
             from django.core.servers.basehttp import get_internal_wsgi_application

--- a/instana/version.py
+++ b/instana/version.py
@@ -3,4 +3,4 @@
 
 # Module version file.  Used by setup.py and snapshot reporting.
 
-VERSION = '1.37.3'
+VERSION = '1.37.4'


### PR DESCRIPTION
The old logic relied on markers placed by the decomissioned magic wand tool.
Now we base the detection on a custom path set by the injector.