### PR TITLE
fix: Start with an empty dict when package collection is enabled

### DIFF
--- a/instana/collector/helpers/runtime.py
+++ b/instana/collector/helpers/runtime.py
@@ -204,6 +204,7 @@ class RuntimeHelper(BaseHelper):
         if os.environ.get('INSTANA_DISABLE_PYTHON_PACKAGE_COLLECTION'):
             return {'instana': VERSION}
 
+        versions = {}
         try:
             sys_packages = sys.modules.copy()
 


### PR DESCRIPTION
Signed-off-by: Ferenc Géczi <ferenc.geczi@ibm.com>