### PR TITLE
test: Require SQLAlchemy 2.0 for testing

### DIFF
--- a/tests/requirements-307.txt
+++ b/tests/requirements-307.txt
@@ -43,7 +43,7 @@ redis>=3.5.3
 requests-mock
 responses<=0.17.0
 sanic==21.6.2
-sqlalchemy<2.0.0,>=1.4.15
+sqlalchemy>=2.0.0
 spyne>=2.13.16
 tornado>=4.5.3,<6.0
 uvicorn>=0.13.4

--- a/tests/requirements-310-with-tornado.txt
+++ b/tests/requirements-310-with-tornado.txt
@@ -36,7 +36,7 @@ redis>=3.5.3
 requests-mock
 responses<=0.17.0
 sanic==21.6.2
-sqlalchemy<2.0.0,>=1.4.15
+sqlalchemy>=2.0.0
 spyne>=2.13.16
 
 uvicorn>=0.13.4

--- a/tests/requirements-310.txt
+++ b/tests/requirements-310.txt
@@ -37,7 +37,7 @@ redis>=3.5.3
 requests-mock
 responses<=0.17.0
 sanic==21.6.2
-sqlalchemy<2.0.0,>=1.4.15
+sqlalchemy>=2.0.0
 spyne>=2.13.16
 
 uvicorn>=0.13.4

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -34,7 +34,7 @@ redis>=3.5.3
 requests-mock
 responses<=0.17.0
 sanic==21.6.2
-sqlalchemy<2.0.0,>=1.4.15
+sqlalchemy>=2.0.0
 spyne>=2.13.16
 tornado>=4.5.3,<6.0
 uvicorn>=0.13.4


### PR DESCRIPTION
Sets the minimum required version to 2.0.0 for SQLAlchemy testing
The legacy branch can still test older SQLAlchemy versions.
Signed-off-by: Ferenc Géczi <ferenc.geczi@ibm.com>