### PR TITLE
fix: Backport handle when the announce response has no fields

### DIFF
--- a/instana/agent/host.py
+++ b/instana/agent/host.py
@@ -202,6 +202,10 @@ class HostAgent(BaseAgent):
             logger.debug("announce: response is not JSON: (%s)", raw_json)
             return None
 
+        if not hasattr(payload, 'get'):
+            logger.debug("announce: response payload has no fields: (%s)", payload)
+            return None
+
         if not payload.get('pid'):
             logger.debug("announce: response payload has no pid: (%s)", payload)
             return None

--- a/instana/version.py
+++ b/instana/version.py
@@ -3,4 +3,4 @@
 
 # Module version file.  Used by setup.py and snapshot reporting.
 
-VERSION = '1.38.1'
+VERSION = '1.38.2'

--- a/tests/requirements-307.txt
+++ b/tests/requirements-307.txt
@@ -43,7 +43,7 @@ redis>=3.5.3
 requests-mock
 responses<=0.17.0
 sanic==21.6.2
-sqlalchemy>=1.4.15
+sqlalchemy<2.0.0,>=1.4.15
 spyne>=2.13.16
 tornado>=4.5.3,<6.0
 uvicorn>=0.13.4

--- a/tests/requirements-310.txt
+++ b/tests/requirements-310.txt
@@ -46,7 +46,7 @@ redis>=3.5.3
 requests-mock
 responses<=0.17.0
 sanic==21.6.2
-sqlalchemy>=1.4.15
+sqlalchemy<2.0.0,>=1.4.15
 spyne>=2.13.16
 suds-jurko>=0.6
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -34,7 +34,7 @@ redis>=3.5.3
 requests-mock
 responses<=0.17.0
 sanic>=19.0.0,<21.9.0
-sqlalchemy>=1.4.15
+sqlalchemy<2.0.0,>=1.4.15
 spyne>=2.13.16
 suds-jurko>=0.6
 tornado>=4.5.3,<6.0


### PR DESCRIPTION
Backport fix in `f6e8383`