### PR TITLE
fix(w3c trace context): do not pass down unknown flags.

### DIFF
--- a/tests/frameworks/test_django.py
+++ b/tests/frameworks/test_django.py
@@ -338,7 +338,9 @@ class TestDjango(StaticLiveServerTestCase):
         self.assertEqual('1', response.headers['X-INSTANA-L'])
 
         assert ('traceparent' in response.headers)
-        self.assertEqual('01-4bf92f3577b34da6a3ce929d0e0e4736-{}-01'.format(django_span.s),
+        # The incoming traceparent header had version 01 (which does not exist at the time of writing), but since we
+        # support version 00, we also need to pass down 00 for the version field.
+        self.assertEqual('00-4bf92f3577b34da6a3ce929d0e0e4736-{}-01'.format(django_span.s),
                          response.headers['traceparent'])
 
         assert ('tracestate' in response.headers)

--- a/tests/propagators/test_http_propagator.py
+++ b/tests/propagators/test_http_propagator.py
@@ -28,7 +28,7 @@ class TestHTTPPropagatorTC(unittest.TestCase):
             'X-INSTANA-L': '1, correlationType=web; correlationId=1234567890abcdef'
         }
         mock_validate.return_value = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
-        mock_get_traceparent_fields.return_value = ["00", "4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7", "01"]
+        mock_get_traceparent_fields.return_value = ["00", "4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7", True]
         ctx = self.hptc.extract(carrier)
         self.assertEqual(ctx.correlation_id, '1234567890abcdef')
         self.assertEqual(ctx.correlation_type, "web")
@@ -54,7 +54,7 @@ class TestHTTPPropagatorTC(unittest.TestCase):
                    ('X-INSTANA-L', '1')]
 
         mock_validate.return_value = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
-        mock_get_traceparent_fields.return_value = ["00", "4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7", "01"]
+        mock_get_traceparent_fields.return_value = ["00", "4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7", True]
         ctx = self.hptc.extract(carrier)
         self.assertIsNone(ctx.correlation_id)
         self.assertIsNone(ctx.correlation_type)
@@ -124,7 +124,7 @@ class TestHTTPPropagatorTC(unittest.TestCase):
             'X-INSTANA-L': '1, correlationTypeweb; correlationId1234567890abcdef'
         }
         mock_validate.return_value = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
-        mock_get_traceparent_fields.return_value = ["00", "4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7", "01"]
+        mock_get_traceparent_fields.return_value = ["00", "4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7", True]
         ctx = self.hptc.extract(carrier)
         self.assertIsNone(ctx.correlation_id)
         self.assertIsNone(ctx.correlation_type)
@@ -156,7 +156,7 @@ class TestHTTPPropagatorTC(unittest.TestCase):
             'X-INSTANA-L': ['1']
         }
         mock_validate.return_value = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
-        mock_get_traceparent_fields.return_value = ["00", "4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7", "01"]
+        mock_get_traceparent_fields.return_value = ["00", "4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7", True]
         ctx = self.hptc.extract(carrier)
         self.assertIsNone(ctx.correlation_id)
         self.assertIsNone(ctx.correlation_type)

--- a/tests/w3c_trace_context/test_traceparent.py
+++ b/tests/w3c_trace_context/test_traceparent.py
@@ -23,21 +23,31 @@ class TestTraceparent(unittest.TestCase):
 
     def test_get_traceparent_fields(self):
         traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
-        version, trace_id, parent_id, trace_flags = self.tp.get_traceparent_fields(traceparent)
+        version, trace_id, parent_id, sampled_flag = self.tp.get_traceparent_fields(traceparent)
         self.assertEqual(trace_id, "4bf92f3577b34da6a3ce929d0e0e4736")
         self.assertEqual(parent_id, "00f067aa0ba902b7")
+        self.assertTrue(sampled_flag)
+
+    def test_get_traceparent_fields_unsampled(self):
+        traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"
+        version, trace_id, parent_id, sampled_flag = self.tp.get_traceparent_fields(traceparent)
+        self.assertEqual(trace_id, "4bf92f3577b34da6a3ce929d0e0e4736")
+        self.assertEqual(parent_id, "00f067aa0ba902b7")
+        self.assertFalse(sampled_flag)
 
     def test_get_traceparent_fields_None_input(self):
         traceparent = None
-        version, trace_id, parent_id, trace_flags = self.tp.get_traceparent_fields(traceparent)
+        version, trace_id, parent_id, sampled_flag = self.tp.get_traceparent_fields(traceparent)
         self.assertIsNone(trace_id)
         self.assertIsNone(parent_id)
+        self.assertFalse(sampled_flag)
 
     def test_get_traceparent_fields_string_input_no_dash(self):
         traceparent = "invalid"
-        version, trace_id, parent_id, trace_flags = self.tp.get_traceparent_fields(traceparent)
+        version, trace_id, parent_id, sampled_flag = self.tp.get_traceparent_fields(traceparent)
         self.assertIsNone(trace_id)
         self.assertIsNone(parent_id)
+        self.assertFalse(sampled_flag)
 
     def test_update_traceparent(self):
         traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"


### PR DESCRIPTION
The W3C trace context specification mandates that a participant must only send known flags downstream. See
https://www.w3.org/TR/trace-context/#other-flags: "The behavior of other flags, such as (00000100) is not defined and is reserved for future use. Vendors MUST set those to zero."