### PR TITLE
test[fix]: Pass parameters to aiohttp correctly

### DIFF
--- a/tests/frameworks/test_aiohttp_client.py
+++ b/tests/frameworks/test_aiohttp_client.py
@@ -16,9 +16,9 @@ from ..helpers import testenv
 
 class TestAiohttp(unittest.TestCase):
 
-    async def fetch(self, session, url, headers=None):
+    async def fetch(self, session, url, headers=None, params=None):
         try:
-            async with session.get(url, headers=headers) as response:
+            async with session.get(url, headers=headers, params=params) as response:
                 return response
         except aiohttp.web_exceptions.HTTPException:
             pass
@@ -296,7 +296,7 @@ class TestAiohttp(unittest.TestCase):
         async def test():
             with async_tracer.start_active_span('test'):
                 async with aiohttp.ClientSession() as session:
-                    return await self.fetch(session, testenv["wsgi_server"] + "/?secret=yeah")
+                    return await self.fetch(session, testenv["wsgi_server"], params={"secret": "yeah"})
 
         response = self.loop.run_until_complete(test())
 

--- a/tests/frameworks/test_aiohttp_server.py
+++ b/tests/frameworks/test_aiohttp_server.py
@@ -15,9 +15,9 @@ from instana.singletons import async_tracer, agent
 
 class TestAiohttpServer(unittest.TestCase):
 
-    async def fetch(self, session, url, headers=None):
+    async def fetch(self, session, url, headers=None, params=None):
         try:
-            async with session.get(url, headers=headers) as response:
+            async with session.get(url, headers=headers, params=params) as response:
                 return response
         except aiohttp.web_exceptions.HTTPException:
             pass
@@ -185,7 +185,7 @@ class TestAiohttpServer(unittest.TestCase):
         async def test():
             with async_tracer.start_active_span('test'):
                 async with aiohttp.ClientSession() as session:
-                    return await self.fetch(session, testenv["aiohttp_server"] + "/?secret=iloveyou")
+                    return await self.fetch(session, testenv["aiohttp_server"], params={"secret": "iloveyou"})
 
         response = self.loop.run_until_complete(test())
 
@@ -254,7 +254,7 @@ class TestAiohttpServer(unittest.TestCase):
                     headers['X-Capture-This'] = 'this'
                     headers['X-Capture-That'] = 'that'
 
-                    return await self.fetch(session, testenv["aiohttp_server"] + "/?secret=iloveyou", headers=headers)
+                    return await self.fetch(session, testenv["aiohttp_server"], headers=headers, params={"secret": "iloveyou"})
 
         response = self.loop.run_until_complete(test())
 

--- a/tests/frameworks/test_tornado_server.py
+++ b/tests/frameworks/test_tornado_server.py
@@ -18,9 +18,9 @@ from ..helpers import testenv, get_first_span_by_name, get_first_span_by_filter
 
 
 class TestTornadoServer(unittest.TestCase):
-    async def fetch(self, session, url, headers=None):
+    async def fetch(self, session, url, headers=None, params=None):
         try:
-            async with session.get(url, headers=headers) as response:
+            async with session.get(url, headers=headers, params=params) as response:
                 return response
         except aiohttp.web_exceptions.HTTPException:
             pass
@@ -456,7 +456,7 @@ class TestTornadoServer(unittest.TestCase):
         async def test():
             with async_tracer.start_active_span('test'):
                 async with aiohttp.ClientSession() as session:
-                    return await self.fetch(session, testenv["tornado_server"] + "/?secret=yeah")
+                    return await self.fetch(session, testenv["tornado_server"], params={"secret": "yeah"})
 
         response = tornado.ioloop.IOLoop.current().run_sync(test)
 
@@ -525,7 +525,7 @@ class TestTornadoServer(unittest.TestCase):
                     headers['X-Capture-This'] = 'this'
                     headers['X-Capture-That'] = 'that'
 
-                    return await self.fetch(session, testenv["tornado_server"] + "/?secret=iloveyou", headers=headers)
+                    return await self.fetch(session, testenv["tornado_server"], headers=headers, params={"secret": "iloveyou"})
 
         response = tornado.ioloop.IOLoop.current().run_sync(test)
 

--- a/tests/requirements-307.txt
+++ b/tests/requirements-307.txt
@@ -48,4 +48,3 @@ spyne>=2.14.0
 tornado>=4.5.3,<6.0
 uvicorn>=0.13.4
 urllib3[secure]<1.27,>=1.26.5
-yarl==1.8.2

--- a/tests/requirements-310-with-tornado.txt
+++ b/tests/requirements-310-with-tornado.txt
@@ -38,4 +38,3 @@ spyne>=2.14.0
 
 uvicorn>=0.13.4
 urllib3[secure]<1.27,>=1.26.5
-yarl==1.8.2

--- a/tests/requirements-310.txt
+++ b/tests/requirements-310.txt
@@ -40,4 +40,3 @@ spyne>=2.14.0
 
 uvicorn>=0.13.4
 urllib3[secure]<1.27,>=1.26.5
-yarl==1.8.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -39,4 +39,3 @@ spyne>=2.14.0
 tornado>=4.5.3,<6.0
 uvicorn>=0.13.4
 urllib3[secure]<1.27,>=1.26.5
-yarl==1.8.2


### PR DESCRIPTION
Apparently the parameter passing in our `aiohttp` tests were incorrect, and was depending on a `yarl` bug [1] that was fixed [2] in `1.9.0`, and with this new yarl version, our tests started to fail. This fix corrects the parameter passing, so we can use the latest `yarl`.

[1] https://github.com/aio-libs/yarl/issues/723
[2] https://github.com/aio-libs/yarl/pull/792