### PR TITLE
fix(blinker): Always set 500 on exception signal

### DIFF
--- a/instana/instrumentation/flask/with_blinker.py
+++ b/instana/instrumentation/flask/with_blinker.py
@@ -82,6 +82,12 @@ def log_exception_with_instana(sender, exception, **extra):
         scope = flask.g.scope
         if scope.span is not None:
             scope.span.log_exception(exception)
+            # As of Flask 2.3.x:
+            # https://github.com/pallets/flask/blob/
+            # d0bf462866289ad8bfe29b6e4e1e0f531003ab34/src/flask/app.py#L1379
+            # The `got_request_exception` signal, is only sent by
+            # the `handle_exception` method which "always causes a 500"
+            scope.span.set_tag(ext.HTTP_STATUS_CODE, 500)
         scope.close()
 
 

--- a/tests/clients/test_urllib3.py
+++ b/tests/clients/test_urllib3.py
@@ -501,8 +501,7 @@ class TestUrllib3(unittest.TestCase):
         self.assertEqual('127.0.0.1:' + str(testenv["wsgi_port"]), wsgi_span.data["http"]["host"])
         self.assertEqual('/exception', wsgi_span.data["http"]["url"])
         self.assertEqual('GET', wsgi_span.data["http"]["method"])
-        # TODO: Investigate the missing status code in a separate commit
-        #self.assertEqual(500, wsgi_span.data["http"]["status"])
+        self.assertEqual(500, wsgi_span.data["http"]["status"])
         if with_blinker:
           self.assertEqual('fake error', wsgi_span.data["http"]["error"])
         else:


### PR DESCRIPTION
Removes a `TODO` item, and re-enables the assertion of the status code being `500` on the `wsgi` span.