### PR TITLE
fix(w3c trace context): consider traceparent format version ff invalid

### DIFF
--- a/instana/w3c_trace_context/traceparent.py
+++ b/instana/w3c_trace_context/traceparent.py
@@ -9,7 +9,7 @@ SAMPLED_BITMASK = 0b1;
 
 class Traceparent:
     SPECIFICATION_VERSION = "00"
-    TRACEPARENT_REGEX = re.compile("^[0-9a-f]{2}-(?!0{32})([0-9a-f]{32})-(?!0{16})([0-9a-f]{16})-[0-9a-f]{2}")
+    TRACEPARENT_REGEX = re.compile("^[0-9a-f][0-9a-e]-(?!0{32})([0-9a-f]{32})-(?!0{16})([0-9a-f]{16})-[0-9a-f]{2}")
 
     def validate(self, traceparent):
         """

--- a/tests/w3c_trace_context/test_traceparent.py
+++ b/tests/w3c_trace_context/test_traceparent.py
@@ -16,12 +16,16 @@ class TestTraceparent(unittest.TestCase):
     def test_validate_newer_version(self):
         # Although the incoming traceparent header sports a newer version number, we should still be able to parse the
         # parts that we understand (and consider it valid).
-        traceparent = "ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-12345-abcd"
+        traceparent = "fe-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-12345-abcd"
         self.assertEqual(traceparent, self.tp.validate(traceparent))
 
     def test_validate_unknown_flags(self):
         traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-ee"
         self.assertEqual(traceparent, self.tp.validate(traceparent))
+
+    def test_validate_invalid_traceparent_version(self):
+        traceparent = "ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        self.assertIsNone(self.tp.validate(traceparent))
 
     def test_validate_invalid_traceparent(self):
         traceparent = "00-4bxxxxx3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
@@ -48,7 +52,7 @@ class TestTraceparent(unittest.TestCase):
     def test_get_traceparent_fields_newer_version(self):
         # Although the incoming traceparent header sports a newer version number, we should still be able to parse the
         # parts that we understand (and consider it valid).
-        traceparent = "ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-12345-abcd"
+        traceparent = "fe-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-12345-abcd"
         version, trace_id, parent_id, sampled_flag = self.tp.get_traceparent_fields(traceparent)
         self.assertEqual(trace_id, "4bf92f3577b34da6a3ce929d0e0e4736")
         self.assertEqual(parent_id, "00f067aa0ba902b7")


### PR DESCRIPTION
This is a follow up to commit
f283a4beb4d2b7ccb9b5aae55d076c7a5156e1d0
which added some tests for parsing newer versions. One of the tests used format version "ff", which the W3C trace context specification explicitly defines as invalid. This commit fixes that test and also the regex used for parsing the traceparent header, so that a header with version ff will be rejected as invalid.