### PR TITLE
test: Add tests for CTX manager usage on PEP0249.

### DIFF
--- a/tests/clients/test_mysqlclient.py
+++ b/tests/clients/test_mysqlclient.py
@@ -217,3 +217,93 @@ class TestMySQLPython(unittest.TestCase):
         self.assertEqual(db_span.data["mysql"]["stmt"], 'SELECT * from blah')
         self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
         self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+
+    def test_connect_ctx_mngr(self):
+        result = None
+
+        with tracer.start_active_span('test'):
+            with self.db as conn:
+                cursor = conn.cursor()
+                result = cursor.execute("""SELECT * from users""")
+                cursor.fetchone()
+
+        assert(result >= 0)
+
+        spans = self.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        db_span = spans[0]
+        test_span = spans[1]
+
+        self.assertEqual("test", test_span.data["sdk"]["name"])
+        self.assertEqual(test_span.t, db_span.t)
+        self.assertEqual(db_span.p, test_span.s)
+
+        self.assertEqual(None, db_span.ec)
+
+        self.assertEqual(db_span.n, "mysql")
+        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
+        self.assertEqual(db_span.data["mysql"]["stmt"], 'SELECT * from users')
+        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+
+    def test_cursor_ctx_mngr(self):
+        result = None
+
+        with tracer.start_active_span('test'):
+            with self.db.cursor() as cursor:
+                result = cursor.execute("""SELECT * from users""")
+                cursor.fetchone()
+            self.db.close()
+
+        assert(result >= 0)
+
+        spans = self.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        db_span = spans[0]
+        test_span = spans[1]
+
+        self.assertEqual("test", test_span.data["sdk"]["name"])
+        self.assertEqual(test_span.t, db_span.t)
+        self.assertEqual(db_span.p, test_span.s)
+
+        self.assertEqual(None, db_span.ec)
+
+        self.assertEqual(db_span.n, "mysql")
+        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
+        self.assertEqual(db_span.data["mysql"]["stmt"], 'SELECT * from users')
+        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+
+    def test_connect_cursor_ctx_mngr(self):
+        result = None
+
+        with tracer.start_active_span('test'):
+            with self.db as conn:
+                with conn.cursor() as cursor:
+                    result = cursor.execute("""SELECT * from users""")
+                    cursor.fetchone()
+
+        assert(result >= 0)
+
+        spans = self.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        db_span = spans[0]
+        test_span = spans[1]
+
+        self.assertEqual("test", test_span.data["sdk"]["name"])
+        self.assertEqual(test_span.t, db_span.t)
+        self.assertEqual(db_span.p, test_span.s)
+
+        self.assertEqual(None, db_span.ec)
+
+        self.assertEqual(db_span.n, "mysql")
+        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
+        self.assertEqual(db_span.data["mysql"]["stmt"], 'SELECT * from users')
+        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])

--- a/tests/clients/test_pymysql.py
+++ b/tests/clients/test_pymysql.py
@@ -243,3 +243,93 @@ class TestPyMySQL(unittest.TestCase):
         self.assertEqual(db_span.data["mysql"]["stmt"], 'SELECT * from blah')
         self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
         self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+
+    def test_connect_ctx_mngr(self):
+        result = None
+
+        with tracer.start_active_span('test'):
+            with self.db as conn:
+                cursor = conn.cursor()
+                result = cursor.execute("""SELECT * from users""")
+                cursor.fetchone()
+
+        assert(result >= 0)
+
+        spans = self.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        db_span = spans[0]
+        test_span = spans[1]
+
+        self.assertEqual("test", test_span.data["sdk"]["name"])
+        self.assertEqual(test_span.t, db_span.t)
+        self.assertEqual(db_span.p, test_span.s)
+
+        self.assertEqual(None, db_span.ec)
+
+        self.assertEqual(db_span.n, "mysql")
+        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
+        self.assertEqual(db_span.data["mysql"]["stmt"], 'SELECT * from users')
+        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+
+    def test_cursor_ctx_mngr(self):
+        result = None
+
+        with tracer.start_active_span('test'):
+            with self.db.cursor() as cursor:
+                result = cursor.execute("""SELECT * from users""")
+                cursor.fetchone()
+            self.db.close()
+
+        assert(result >= 0)
+
+        spans = self.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        db_span = spans[0]
+        test_span = spans[1]
+
+        self.assertEqual("test", test_span.data["sdk"]["name"])
+        self.assertEqual(test_span.t, db_span.t)
+        self.assertEqual(db_span.p, test_span.s)
+
+        self.assertEqual(None, db_span.ec)
+
+        self.assertEqual(db_span.n, "mysql")
+        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
+        self.assertEqual(db_span.data["mysql"]["stmt"], 'SELECT * from users')
+        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+
+    def test_connect_cursor_ctx_mngr(self):
+        result = None
+
+        with tracer.start_active_span('test'):
+            with self.db as conn:
+                with conn.cursor() as cursor:
+                    result = cursor.execute("""SELECT * from users""")
+                    cursor.fetchone()
+
+        assert(result >= 0)
+
+        spans = self.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        db_span = spans[0]
+        test_span = spans[1]
+
+        self.assertEqual("test", test_span.data["sdk"]["name"])
+        self.assertEqual(test_span.t, db_span.t)
+        self.assertEqual(db_span.p, test_span.s)
+
+        self.assertEqual(None, db_span.ec)
+
+        self.assertEqual(db_span.n, "mysql")
+        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
+        self.assertEqual(db_span.data["mysql"]["stmt"], 'SELECT * from users')
+        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])


### PR DESCRIPTION
Add the test_connect_ctx_mngr UT to test the span creation when using the psycopg2 connect with context manager, and the test_connect_cursor_ctx_mngr UT when using the psycopg2 connect and cursos context manager.