### PR TITLE
Add context manager tests to db modules that conform to PEP-249

### DIFF
--- a/tests/clients/test_mysqlclient.py
+++ b/tests/clients/test_mysqlclient.py
@@ -18,8 +18,8 @@ else:
 
 logger = logging.getLogger(__name__)
 
-create_table_query = 'CREATE TABLE IF NOT EXISTS users(id serial primary key, \
-                      name varchar(40) NOT NULL, email varchar(40) NOT NULL)'
+create_table_query = "CREATE TABLE IF NOT EXISTS users(id serial primary key, \
+                      name varchar(40) NOT NULL, email varchar(40) NOT NULL)"
 
 create_proc_query = """
 CREATE PROCEDURE test_proc(IN t VARCHAR(255))
@@ -28,9 +28,13 @@ BEGIN
 END
 """
 
-db = MySQLdb.connect(host=testenv['mysql_host'], port=testenv['mysql_port'],
-                     user=testenv['mysql_user'], passwd=testenv['mysql_pw'],
-                     db=testenv['mysql_db'])
+db = MySQLdb.connect(
+    host=testenv["mysql_host"],
+    port=testenv["mysql_port"],
+    user=testenv["mysql_user"],
+    passwd=testenv["mysql_pw"],
+    db=testenv["mysql_db"],
+)
 
 cursor = db.cursor()
 cursor.execute(create_table_query)
@@ -38,7 +42,7 @@ cursor.execute(create_table_query)
 while cursor.nextset() is not None:
     pass
 
-cursor.execute('DROP PROCEDURE IF EXISTS test_proc')
+cursor.execute("DROP PROCEDURE IF EXISTS test_proc")
 
 while cursor.nextset() is not None:
     pass
@@ -54,16 +58,20 @@ db.close()
 
 class TestMySQLPython(unittest.TestCase):
     def setUp(self):
-        self.db = MySQLdb.connect(host=testenv['mysql_host'], port=testenv['mysql_port'],
-                                  user=testenv['mysql_user'], passwd=testenv['mysql_pw'],
-                                  db=testenv['mysql_db'])
+        self.db = MySQLdb.connect(
+            host=testenv["mysql_host"],
+            port=testenv["mysql_port"],
+            user=testenv["mysql_user"],
+            passwd=testenv["mysql_pw"],
+            db=testenv["mysql_db"],
+        )
         self.cursor = self.db.cursor()
         self.recorder = tracer.recorder
         self.recorder.clear_spans()
         tracer.cur_ctx = None
 
     def tearDown(self):
-        """ Do nothing for now """
+        """Do nothing for now"""
         return None
 
     def test_vanilla_query(self):
@@ -76,11 +84,11 @@ class TestMySQLPython(unittest.TestCase):
 
     def test_basic_query(self):
         result = None
-        with tracer.start_active_span('test'):
+        with tracer.start_active_span("test"):
             result = self.cursor.execute("""SELECT * from users""")
             self.cursor.fetchone()
 
-        assert(result >= 0)
+        assert result >= 0
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -95,18 +103,19 @@ class TestMySQLPython(unittest.TestCase):
         self.assertEqual(None, db_span.ec)
 
         self.assertEqual(db_span.n, "mysql")
-        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
-        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
-        self.assertEqual(db_span.data["mysql"]["stmt"], 'SELECT * from users')
-        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
-        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(db_span.data["mysql"]["stmt"], "SELECT * from users")
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])
 
     def test_basic_insert(self):
         result = None
-        with tracer.start_active_span('test'):
+        with tracer.start_active_span("test"):
             result = self.cursor.execute(
-                        """INSERT INTO users(name, email) VALUES(%s, %s)""",
-                        ('beaker', 'beaker@muppets.com'))
+                """INSERT INTO users(name, email) VALUES(%s, %s)""",
+                ("beaker", "beaker@muppets.com"),
+            )
 
         self.assertEqual(1, result)
 
@@ -123,17 +132,22 @@ class TestMySQLPython(unittest.TestCase):
         self.assertEqual(None, db_span.ec)
 
         self.assertEqual(db_span.n, "mysql")
-        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
-        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
-        self.assertEqual(db_span.data["mysql"]["stmt"], 'INSERT INTO users(name, email) VALUES(%s, %s)')
-        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
-        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(
+            db_span.data["mysql"]["stmt"],
+            "INSERT INTO users(name, email) VALUES(%s, %s)",
+        )
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])
 
     def test_executemany(self):
         result = None
-        with tracer.start_active_span('test'):
-            result = self.cursor.executemany("INSERT INTO users(name, email) VALUES(%s, %s)",
-                                             [('beaker', 'beaker@muppets.com'), ('beaker', 'beaker@muppets.com')])
+        with tracer.start_active_span("test"):
+            result = self.cursor.executemany(
+                "INSERT INTO users(name, email) VALUES(%s, %s)",
+                [("beaker", "beaker@muppets.com"), ("beaker", "beaker@muppets.com")],
+            )
             self.db.commit()
 
         self.assertEqual(2, result)
@@ -151,18 +165,21 @@ class TestMySQLPython(unittest.TestCase):
         self.assertEqual(None, db_span.ec)
 
         self.assertEqual(db_span.n, "mysql")
-        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
-        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
-        self.assertEqual(db_span.data["mysql"]["stmt"], 'INSERT INTO users(name, email) VALUES(%s, %s)')
-        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
-        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(
+            db_span.data["mysql"]["stmt"],
+            "INSERT INTO users(name, email) VALUES(%s, %s)",
+        )
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])
 
     def test_call_proc(self):
         result = None
-        with tracer.start_active_span('test'):
-            result = self.cursor.callproc('test_proc', ('beaker',))
+        with tracer.start_active_span("test"):
+            result = self.cursor.callproc("test_proc", ("beaker",))
 
-        assert(result)
+        assert result
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -177,17 +194,17 @@ class TestMySQLPython(unittest.TestCase):
         self.assertEqual(None, db_span.ec)
 
         self.assertEqual(db_span.n, "mysql")
-        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
-        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
-        self.assertEqual(db_span.data["mysql"]["stmt"], 'test_proc')
-        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
-        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(db_span.data["mysql"]["stmt"], "test_proc")
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])
 
     def test_error_capture(self):
         result = None
         span = None
         try:
-            with tracer.start_active_span('test'):
+            with tracer.start_active_span("test"):
                 result = self.cursor.execute("""SELECT * from blah""")
                 self.cursor.fetchone()
         except Exception:
@@ -196,7 +213,7 @@ class TestMySQLPython(unittest.TestCase):
             if span:
                 span.finish()
 
-        assert(result is None)
+        assert result is None
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -209,11 +226,101 @@ class TestMySQLPython(unittest.TestCase):
         self.assertEqual(db_span.p, test_span.s)
 
         self.assertEqual(1, db_span.ec)
-        self.assertEqual(db_span.data["mysql"]["error"], '(1146, "Table \'%s.blah\' doesn\'t exist")' % testenv['mysql_db'])
+        self.assertEqual(
+            db_span.data["mysql"]["error"],
+            "(1146, \"Table '%s.blah' doesn't exist\")" % testenv["mysql_db"],
+        )
 
         self.assertEqual(db_span.n, "mysql")
-        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
-        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
-        self.assertEqual(db_span.data["mysql"]["stmt"], 'SELECT * from blah')
-        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
-        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(db_span.data["mysql"]["stmt"], "SELECT * from blah")
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])
+
+    def test_connect_cursor_ctx_mgr(self):
+        result = None
+        with tracer.start_active_span("test"):
+            with self.db as connection:
+                with connection.cursor() as cursor:
+                    result = cursor.execute("""SELECT * from users""")
+                    cursor.fetchone()
+
+        assert result >= 0
+
+        spans = self.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        db_span = spans[0]
+        test_span = spans[1]
+
+        self.assertEqual("test", test_span.data["sdk"]["name"])
+        self.assertEqual(test_span.t, db_span.t)
+        self.assertEqual(db_span.p, test_span.s)
+
+        self.assertEqual(None, db_span.ec)
+
+        self.assertEqual(db_span.n, "mysql")
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(db_span.data["mysql"]["stmt"], "SELECT * from users")
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])
+
+    def test_connect_ctx_mgr(self):
+        result = None
+        with tracer.start_active_span("test"):
+            with self.db as connection:
+                cursor = connection.cursor()
+                result = cursor.execute("""SELECT * from users""")
+                cursor.fetchone()
+
+        assert result >= 0
+
+        spans = self.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        db_span = spans[0]
+        test_span = spans[1]
+
+        self.assertEqual("test", test_span.data["sdk"]["name"])
+        self.assertEqual(test_span.t, db_span.t)
+        self.assertEqual(db_span.p, test_span.s)
+
+        self.assertEqual(None, db_span.ec)
+
+        self.assertEqual(db_span.n, "mysql")
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(db_span.data["mysql"]["stmt"], "SELECT * from users")
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])
+
+    def test_cursor_ctx_mgr(self):
+        result = None
+        with tracer.start_active_span("test"):
+            connection = self.db
+            with connection.cursor() as cursor:
+                result = cursor.execute("""SELECT * from users""")
+                cursor.fetchone()
+
+        assert result >= 0
+
+        spans = self.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        db_span = spans[0]
+        test_span = spans[1]
+
+        self.assertEqual("test", test_span.data["sdk"]["name"])
+        self.assertEqual(test_span.t, db_span.t)
+        self.assertEqual(db_span.p, test_span.s)
+
+        self.assertEqual(None, db_span.ec)
+
+        self.assertEqual(db_span.n, "mysql")
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(db_span.data["mysql"]["stmt"], "SELECT * from users")
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])

--- a/tests/clients/test_psycopg2.py
+++ b/tests/clients/test_psycopg2.py
@@ -87,7 +87,6 @@ class TestPsycoPG2(unittest.TestCase):
         with tracer.start_active_span("test"):
             self.cursor.execute("""SELECT * from users""")
             self.cursor.fetchone()
-            self.db.commit()
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))

--- a/tests/clients/test_psycopg2.py
+++ b/tests/clients/test_psycopg2.py
@@ -87,6 +87,7 @@ class TestPsycoPG2(unittest.TestCase):
         with tracer.start_active_span("test"):
             self.cursor.execute("""SELECT * from users""")
             self.cursor.fetchone()
+            self.db.commit()
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))

--- a/tests/clients/test_psycopg2.py
+++ b/tests/clients/test_psycopg2.py
@@ -36,9 +36,13 @@ $$ LANGUAGE plpgsql;
 
 drop_proc_query = "DROP FUNCTION IF EXISTS test_proc(VARCHAR(70));"
 
-db = psycopg2.connect(host=testenv['postgresql_host'], port=testenv['postgresql_port'],
-                     user=testenv['postgresql_user'], password=testenv['postgresql_pw'],
-                     database=testenv['postgresql_db'])
+db = psycopg2.connect(
+    host=testenv["postgresql_host"],
+    port=testenv["postgresql_port"],
+    user=testenv["postgresql_user"],
+    password=testenv["postgresql_pw"],
+    database=testenv["postgresql_db"],
+)
 
 cursor = db.cursor()
 cursor.execute(create_table_query)
@@ -51,16 +55,20 @@ db.close()
 
 class TestPsycoPG2(unittest.TestCase):
     def setUp(self):
-        self.db = psycopg2.connect(host=testenv['postgresql_host'], port=testenv['postgresql_port'],
-                                   user=testenv['postgresql_user'], password=testenv['postgresql_pw'],
-                                   database=testenv['postgresql_db'])
+        self.db = psycopg2.connect(
+            host=testenv["postgresql_host"],
+            port=testenv["postgresql_port"],
+            user=testenv["postgresql_user"],
+            password=testenv["postgresql_pw"],
+            database=testenv["postgresql_db"],
+        )
         self.cursor = self.db.cursor()
         self.recorder = tracer.recorder
         self.recorder.clear_spans()
         tracer.cur_ctx = None
 
     def tearDown(self):
-        """ Do nothing for now """
+        """Do nothing for now"""
         return None
 
     def test_vanilla_query(self):
@@ -76,7 +84,7 @@ class TestPsycoPG2(unittest.TestCase):
         self.assertEqual(0, len(spans))
 
     def test_basic_query(self):
-        with tracer.start_active_span('test'):
+        with tracer.start_active_span("test"):
             self.cursor.execute("""SELECT * from users""")
             self.cursor.fetchone()
             self.db.commit()
@@ -94,15 +102,18 @@ class TestPsycoPG2(unittest.TestCase):
         self.assertEqual(None, db_span.ec)
 
         self.assertEqual(db_span.n, "postgres")
-        self.assertEqual(db_span.data["pg"]["db"], testenv['postgresql_db'])
-        self.assertEqual(db_span.data["pg"]["user"], testenv['postgresql_user'])
-        self.assertEqual(db_span.data["pg"]["stmt"], 'SELECT * from users')
-        self.assertEqual(db_span.data["pg"]["host"], testenv['postgresql_host'])
-        self.assertEqual(db_span.data["pg"]["port"], testenv['postgresql_port'])
+        self.assertEqual(db_span.data["pg"]["db"], testenv["postgresql_db"])
+        self.assertEqual(db_span.data["pg"]["user"], testenv["postgresql_user"])
+        self.assertEqual(db_span.data["pg"]["stmt"], "SELECT * from users")
+        self.assertEqual(db_span.data["pg"]["host"], testenv["postgresql_host"])
+        self.assertEqual(db_span.data["pg"]["port"], testenv["postgresql_port"])
 
     def test_basic_insert(self):
-        with tracer.start_active_span('test'):
-            self.cursor.execute("""INSERT INTO users(name, email) VALUES(%s, %s)""", ('beaker', 'beaker@muppets.com'))
+        with tracer.start_active_span("test"):
+            self.cursor.execute(
+                """INSERT INTO users(name, email) VALUES(%s, %s)""",
+                ("beaker", "beaker@muppets.com"),
+            )
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -117,17 +128,21 @@ class TestPsycoPG2(unittest.TestCase):
         self.assertEqual(None, db_span.ec)
 
         self.assertEqual(db_span.n, "postgres")
-        self.assertEqual(db_span.data["pg"]["db"], testenv['postgresql_db'])
-        self.assertEqual(db_span.data["pg"]["user"], testenv['postgresql_user'])
-        self.assertEqual(db_span.data["pg"]["stmt"], 'INSERT INTO users(name, email) VALUES(%s, %s)')
-        self.assertEqual(db_span.data["pg"]["host"], testenv['postgresql_host'])
-        self.assertEqual(db_span.data["pg"]["port"], testenv['postgresql_port'])
+        self.assertEqual(db_span.data["pg"]["db"], testenv["postgresql_db"])
+        self.assertEqual(db_span.data["pg"]["user"], testenv["postgresql_user"])
+        self.assertEqual(
+            db_span.data["pg"]["stmt"], "INSERT INTO users(name, email) VALUES(%s, %s)"
+        )
+        self.assertEqual(db_span.data["pg"]["host"], testenv["postgresql_host"])
+        self.assertEqual(db_span.data["pg"]["port"], testenv["postgresql_port"])
 
     def test_executemany(self):
         result = None
-        with tracer.start_active_span('test'):
-            result = self.cursor.executemany("INSERT INTO users(name, email) VALUES(%s, %s)",
-                                             [('beaker', 'beaker@muppets.com'), ('beaker', 'beaker@muppets.com')])
+        with tracer.start_active_span("test"):
+            result = self.cursor.executemany(
+                "INSERT INTO users(name, email) VALUES(%s, %s)",
+                [("beaker", "beaker@muppets.com"), ("beaker", "beaker@muppets.com")],
+            )
             self.db.commit()
 
         spans = self.recorder.queued_spans()
@@ -143,18 +158,20 @@ class TestPsycoPG2(unittest.TestCase):
         self.assertEqual(None, db_span.ec)
 
         self.assertEqual(db_span.n, "postgres")
-        self.assertEqual(db_span.data["pg"]["db"], testenv['postgresql_db'])
-        self.assertEqual(db_span.data["pg"]["user"], testenv['postgresql_user'])
-        self.assertEqual(db_span.data["pg"]["stmt"], 'INSERT INTO users(name, email) VALUES(%s, %s)')
-        self.assertEqual(db_span.data["pg"]["host"], testenv['postgresql_host'])
-        self.assertEqual(db_span.data["pg"]["port"], testenv['postgresql_port'])
+        self.assertEqual(db_span.data["pg"]["db"], testenv["postgresql_db"])
+        self.assertEqual(db_span.data["pg"]["user"], testenv["postgresql_user"])
+        self.assertEqual(
+            db_span.data["pg"]["stmt"], "INSERT INTO users(name, email) VALUES(%s, %s)"
+        )
+        self.assertEqual(db_span.data["pg"]["host"], testenv["postgresql_host"])
+        self.assertEqual(db_span.data["pg"]["port"], testenv["postgresql_port"])
 
     def test_call_proc(self):
         result = None
-        with tracer.start_active_span('test'):
-            result = self.cursor.callproc('test_proc', ('beaker',))
+        with tracer.start_active_span("test"):
+            result = self.cursor.callproc("test_proc", ("beaker",))
 
-        assert(type(result) is tuple)
+        assert type(result) is tuple
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -169,22 +186,22 @@ class TestPsycoPG2(unittest.TestCase):
         self.assertEqual(None, db_span.ec)
 
         self.assertEqual(db_span.n, "postgres")
-        self.assertEqual(db_span.data["pg"]["db"], testenv['postgresql_db'])
-        self.assertEqual(db_span.data["pg"]["user"], testenv['postgresql_user'])
-        self.assertEqual(db_span.data["pg"]["stmt"], 'test_proc')
-        self.assertEqual(db_span.data["pg"]["host"], testenv['postgresql_host'])
-        self.assertEqual(db_span.data["pg"]["port"], testenv['postgresql_port'])
+        self.assertEqual(db_span.data["pg"]["db"], testenv["postgresql_db"])
+        self.assertEqual(db_span.data["pg"]["user"], testenv["postgresql_user"])
+        self.assertEqual(db_span.data["pg"]["stmt"], "test_proc")
+        self.assertEqual(db_span.data["pg"]["host"], testenv["postgresql_host"])
+        self.assertEqual(db_span.data["pg"]["port"], testenv["postgresql_port"])
 
     def test_error_capture(self):
         result = None
         try:
-            with tracer.start_active_span('test'):
+            with tracer.start_active_span("test"):
                 result = self.cursor.execute("""SELECT * from blah""")
                 self.cursor.fetchone()
         except Exception:
             pass
 
-        assert(result is None)
+        assert result is None
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -197,14 +214,17 @@ class TestPsycoPG2(unittest.TestCase):
         self.assertEqual(db_span.p, test_span.s)
 
         self.assertEqual(1, db_span.ec)
-        self.assertEqual(db_span.data["pg"]["error"], 'relation "blah" does not exist\nLINE 1: SELECT * from blah\n                      ^\n')
+        self.assertEqual(
+            db_span.data["pg"]["error"],
+            'relation "blah" does not exist\nLINE 1: SELECT * from blah\n                      ^\n',
+        )
 
         self.assertEqual(db_span.n, "postgres")
-        self.assertEqual(db_span.data["pg"]["db"], testenv['postgresql_db'])
-        self.assertEqual(db_span.data["pg"]["user"], testenv['postgresql_user'])
-        self.assertEqual(db_span.data["pg"]["stmt"], 'SELECT * from blah')
-        self.assertEqual(db_span.data["pg"]["host"], testenv['postgresql_host'])
-        self.assertEqual(db_span.data["pg"]["port"], testenv['postgresql_port'])
+        self.assertEqual(db_span.data["pg"]["db"], testenv["postgresql_db"])
+        self.assertEqual(db_span.data["pg"]["user"], testenv["postgresql_user"])
+        self.assertEqual(db_span.data["pg"]["stmt"], "SELECT * from blah")
+        self.assertEqual(db_span.data["pg"]["host"], testenv["postgresql_host"])
+        self.assertEqual(db_span.data["pg"]["port"], testenv["postgresql_port"])
 
     # Added to validate unicode support and register_type.
     def test_unicode(self):
@@ -242,9 +262,85 @@ class TestPsycoPG2(unittest.TestCase):
         oid1 = 2950
         oid2 = 2951
 
-        ext.UUID = ext.new_type((oid1,), "UUID", lambda data, cursor: data and uuid.UUID(data) or None)
+        ext.UUID = ext.new_type(
+            (oid1,), "UUID", lambda data, cursor: data and uuid.UUID(data) or None
+        )
         ext.UUIDARRAY = ext.new_array_type((oid2,), "UUID[]", ext.UUID)
 
         ext.register_type(ext.UUID, self.cursor)
         ext.register_type(ext.UUIDARRAY, self.cursor)
 
+    def test_connect_cursor_ctx_mgr(self):
+        with tracer.start_active_span("test"):
+            with self.db as connection:
+                with connection.cursor() as cursor:
+                    cursor.execute("""SELECT * from users""")
+
+        spans = self.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        db_span = spans[0]
+        test_span = spans[1]
+
+        self.assertEqual("test", test_span.data["sdk"]["name"])
+        self.assertEqual(test_span.t, db_span.t)
+        self.assertEqual(db_span.p, test_span.s)
+
+        self.assertEqual(None, db_span.ec)
+
+        self.assertEqual(db_span.n, "postgres")
+        self.assertEqual(db_span.data["pg"]["db"], testenv["postgresql_db"])
+        self.assertEqual(db_span.data["pg"]["user"], testenv["postgresql_user"])
+        self.assertEqual(db_span.data["pg"]["stmt"], "SELECT * from users")
+        self.assertEqual(db_span.data["pg"]["host"], testenv["postgresql_host"])
+        self.assertEqual(db_span.data["pg"]["port"], testenv["postgresql_port"])
+
+    def test_connect_ctx_mgr(self):
+        with tracer.start_active_span("test"):
+            with self.db as connection:
+                cursor = connection.cursor()
+                cursor.execute("""SELECT * from users""")
+
+        spans = self.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        db_span = spans[0]
+        test_span = spans[1]
+
+        self.assertEqual("test", test_span.data["sdk"]["name"])
+        self.assertEqual(test_span.t, db_span.t)
+        self.assertEqual(db_span.p, test_span.s)
+
+        self.assertEqual(None, db_span.ec)
+
+        self.assertEqual(db_span.n, "postgres")
+        self.assertEqual(db_span.data["pg"]["db"], testenv["postgresql_db"])
+        self.assertEqual(db_span.data["pg"]["user"], testenv["postgresql_user"])
+        self.assertEqual(db_span.data["pg"]["stmt"], "SELECT * from users")
+        self.assertEqual(db_span.data["pg"]["host"], testenv["postgresql_host"])
+        self.assertEqual(db_span.data["pg"]["port"], testenv["postgresql_port"])
+
+    def test_cursor_ctx_mgr(self):
+        with tracer.start_active_span("test"):
+            connection = self.db
+            with connection.cursor() as cursor:
+                cursor.execute("""SELECT * from users""")
+
+        spans = self.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        db_span = spans[0]
+        test_span = spans[1]
+
+        self.assertEqual("test", test_span.data["sdk"]["name"])
+        self.assertEqual(test_span.t, db_span.t)
+        self.assertEqual(db_span.p, test_span.s)
+
+        self.assertEqual(None, db_span.ec)
+
+        self.assertEqual(db_span.n, "postgres")
+        self.assertEqual(db_span.data["pg"]["db"], testenv["postgresql_db"])
+        self.assertEqual(db_span.data["pg"]["user"], testenv["postgresql_user"])
+        self.assertEqual(db_span.data["pg"]["stmt"], "SELECT * from users")
+        self.assertEqual(db_span.data["pg"]["host"], testenv["postgresql_host"])
+        self.assertEqual(db_span.data["pg"]["port"], testenv["postgresql_port"])

--- a/tests/clients/test_pymysql.py
+++ b/tests/clients/test_pymysql.py
@@ -12,8 +12,8 @@ from instana.singletons import tracer
 
 logger = logging.getLogger(__name__)
 
-create_table_query = 'CREATE TABLE IF NOT EXISTS users(id serial primary key, \
-                      name varchar(40) NOT NULL, email varchar(40) NOT NULL)'
+create_table_query = "CREATE TABLE IF NOT EXISTS users(id serial primary key, \
+                      name varchar(40) NOT NULL, email varchar(40) NOT NULL)"
 
 create_proc_query = """
 CREATE PROCEDURE test_proc(IN t VARCHAR(255))
@@ -22,9 +22,13 @@ BEGIN
 END
 """
 
-db = pymysql.connect(host=testenv['mysql_host'], port=testenv['mysql_port'],
-                     user=testenv['mysql_user'], passwd=testenv['mysql_pw'],
-                     db=testenv['mysql_db'])
+db = pymysql.connect(
+    host=testenv["mysql_host"],
+    port=testenv["mysql_port"],
+    user=testenv["mysql_user"],
+    passwd=testenv["mysql_pw"],
+    db=testenv["mysql_db"],
+)
 
 cursor = db.cursor()
 cursor.execute(create_table_query)
@@ -32,7 +36,7 @@ cursor.execute(create_table_query)
 while cursor.nextset() is not None:
     pass
 
-cursor.execute('DROP PROCEDURE IF EXISTS test_proc')
+cursor.execute("DROP PROCEDURE IF EXISTS test_proc")
 
 while cursor.nextset() is not None:
     pass
@@ -48,16 +52,20 @@ db.close()
 
 class TestPyMySQL(unittest.TestCase):
     def setUp(self):
-        self.db = pymysql.connect(host=testenv['mysql_host'], port=testenv['mysql_port'],
-                                  user=testenv['mysql_user'], passwd=testenv['mysql_pw'],
-                                  db=testenv['mysql_db'])
+        self.db = pymysql.connect(
+            host=testenv["mysql_host"],
+            port=testenv["mysql_port"],
+            user=testenv["mysql_user"],
+            passwd=testenv["mysql_pw"],
+            db=testenv["mysql_db"],
+        )
         self.cursor = self.db.cursor()
         self.recorder = tracer.recorder
         self.recorder.clear_spans()
         tracer.cur_ctx = None
 
     def tearDown(self):
-        """ Do nothing for now """
+        """Do nothing for now"""
         return None
 
     def test_vanilla_query(self):
@@ -70,11 +78,11 @@ class TestPyMySQL(unittest.TestCase):
 
     def test_basic_query(self):
         result = None
-        with tracer.start_active_span('test'):
+        with tracer.start_active_span("test"):
             result = self.cursor.execute("""SELECT * from users""")
             self.cursor.fetchone()
 
-        assert(result >= 0)
+        assert result >= 0
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -89,19 +97,19 @@ class TestPyMySQL(unittest.TestCase):
         self.assertEqual(None, db_span.ec)
 
         self.assertEqual(db_span.n, "mysql")
-        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
-        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
-        self.assertEqual(db_span.data["mysql"]["stmt"], 'SELECT * from users')
-        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
-        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(db_span.data["mysql"]["stmt"], "SELECT * from users")
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])
 
     def test_query_with_params(self):
         result = None
-        with tracer.start_active_span('test'):
+        with tracer.start_active_span("test"):
             result = self.cursor.execute("""SELECT * from users where id=1""")
             self.cursor.fetchone()
 
-        assert(result >= 0)
+        assert result >= 0
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -116,18 +124,21 @@ class TestPyMySQL(unittest.TestCase):
         self.assertEqual(None, db_span.ec)
 
         self.assertEqual(db_span.n, "mysql")
-        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
-        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
-        self.assertEqual(db_span.data["mysql"]["stmt"], 'SELECT * from users where id=?')
-        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
-        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(
+            db_span.data["mysql"]["stmt"], "SELECT * from users where id=?"
+        )
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])
 
     def test_basic_insert(self):
         result = None
-        with tracer.start_active_span('test'):
+        with tracer.start_active_span("test"):
             result = self.cursor.execute(
-                        """INSERT INTO users(name, email) VALUES(%s, %s)""",
-                        ('beaker', 'beaker@muppets.com'))
+                """INSERT INTO users(name, email) VALUES(%s, %s)""",
+                ("beaker", "beaker@muppets.com"),
+            )
 
         self.assertEqual(1, result)
 
@@ -144,17 +155,22 @@ class TestPyMySQL(unittest.TestCase):
         self.assertEqual(None, db_span.ec)
 
         self.assertEqual(db_span.n, "mysql")
-        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
-        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
-        self.assertEqual(db_span.data["mysql"]["stmt"], 'INSERT INTO users(name, email) VALUES(%s, %s)')
-        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
-        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(
+            db_span.data["mysql"]["stmt"],
+            "INSERT INTO users(name, email) VALUES(%s, %s)",
+        )
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])
 
     def test_executemany(self):
         result = None
-        with tracer.start_active_span('test'):
-            result = self.cursor.executemany("INSERT INTO users(name, email) VALUES(%s, %s)",
-                                             [('beaker', 'beaker@muppets.com'), ('beaker', 'beaker@muppets.com')])
+        with tracer.start_active_span("test"):
+            result = self.cursor.executemany(
+                "INSERT INTO users(name, email) VALUES(%s, %s)",
+                [("beaker", "beaker@muppets.com"), ("beaker", "beaker@muppets.com")],
+            )
             self.db.commit()
 
         self.assertEqual(2, result)
@@ -172,18 +188,21 @@ class TestPyMySQL(unittest.TestCase):
         self.assertEqual(None, db_span.ec)
 
         self.assertEqual(db_span.n, "mysql")
-        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
-        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
-        self.assertEqual(db_span.data["mysql"]["stmt"], 'INSERT INTO users(name, email) VALUES(%s, %s)')
-        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
-        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(
+            db_span.data["mysql"]["stmt"],
+            "INSERT INTO users(name, email) VALUES(%s, %s)",
+        )
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])
 
     def test_call_proc(self):
         result = None
-        with tracer.start_active_span('test'):
-            result = self.cursor.callproc('test_proc', ('beaker',))
+        with tracer.start_active_span("test"):
+            result = self.cursor.callproc("test_proc", ("beaker",))
 
-        assert(result)
+        assert result
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -198,17 +217,17 @@ class TestPyMySQL(unittest.TestCase):
         self.assertEqual(None, db_span.ec)
 
         self.assertEqual(db_span.n, "mysql")
-        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
-        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
-        self.assertEqual(db_span.data["mysql"]["stmt"], 'test_proc')
-        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
-        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(db_span.data["mysql"]["stmt"], "test_proc")
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])
 
     def test_error_capture(self):
         result = None
         span = None
         try:
-            with tracer.start_active_span('test'):
+            with tracer.start_active_span("test"):
                 result = self.cursor.execute("""SELECT * from blah""")
                 self.cursor.fetchone()
         except Exception:
@@ -217,7 +236,7 @@ class TestPyMySQL(unittest.TestCase):
             if span:
                 span.finish()
 
-        assert(result is None)
+        assert result is None
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -232,14 +251,107 @@ class TestPyMySQL(unittest.TestCase):
 
         if sys.version_info[0] >= 3:
             # Python 3
-            self.assertEqual(db_span.data["mysql"]["error"], u'(1146, "Table \'%s.blah\' doesn\'t exist")' % testenv['mysql_db'])
+            self.assertEqual(
+                db_span.data["mysql"]["error"],
+                "(1146, \"Table '%s.blah' doesn't exist\")" % testenv["mysql_db"],
+            )
         else:
             # Python 2
-            self.assertEqual(db_span.data["mysql"]["error"], u'(1146, u"Table \'%s.blah\' doesn\'t exist")' % testenv['mysql_db'])
+            self.assertEqual(
+                db_span.data["mysql"]["error"],
+                "(1146, u\"Table '%s.blah' doesn't exist\")" % testenv["mysql_db"],
+            )
 
         self.assertEqual(db_span.n, "mysql")
-        self.assertEqual(db_span.data["mysql"]["db"], testenv['mysql_db'])
-        self.assertEqual(db_span.data["mysql"]["user"], testenv['mysql_user'])
-        self.assertEqual(db_span.data["mysql"]["stmt"], 'SELECT * from blah')
-        self.assertEqual(db_span.data["mysql"]["host"], testenv['mysql_host'])
-        self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(db_span.data["mysql"]["stmt"], "SELECT * from blah")
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])
+
+    def test_connect_cursor_ctx_mgr(self):
+        result = None
+        with tracer.start_active_span("test"):
+            with self.db as connection:
+                with connection.cursor() as cursor:
+                    result = cursor.execute("""SELECT * from users""")
+                    cursor.fetchone()
+
+        assert result >= 0
+
+        spans = self.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        db_span = spans[0]
+        test_span = spans[1]
+
+        self.assertEqual("test", test_span.data["sdk"]["name"])
+        self.assertEqual(test_span.t, db_span.t)
+        self.assertEqual(db_span.p, test_span.s)
+
+        self.assertEqual(None, db_span.ec)
+
+        self.assertEqual(db_span.n, "mysql")
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(db_span.data["mysql"]["stmt"], "SELECT * from users")
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])
+
+    def test_connect_ctx_mgr(self):
+        result = None
+        with tracer.start_active_span("test"):
+            with self.db as connection:
+                cursor = connection.cursor()
+                result = cursor.execute("""SELECT * from users""")
+                cursor.fetchone()
+
+        assert result >= 0
+
+        spans = self.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        db_span = spans[0]
+        test_span = spans[1]
+
+        self.assertEqual("test", test_span.data["sdk"]["name"])
+        self.assertEqual(test_span.t, db_span.t)
+        self.assertEqual(db_span.p, test_span.s)
+
+        self.assertEqual(None, db_span.ec)
+
+        self.assertEqual(db_span.n, "mysql")
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(db_span.data["mysql"]["stmt"], "SELECT * from users")
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])
+
+    def test_cursor_ctx_mgr(self):
+        result = None
+        with tracer.start_active_span("test"):
+            connection = self.db
+            with connection.cursor() as cursor:
+                result = cursor.execute("""SELECT * from users""")
+                cursor.fetchone()
+
+        assert result >= 0
+
+        spans = self.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        db_span = spans[0]
+        test_span = spans[1]
+
+        self.assertEqual("test", test_span.data["sdk"]["name"])
+        self.assertEqual(test_span.t, db_span.t)
+        self.assertEqual(db_span.p, test_span.s)
+
+        self.assertEqual(None, db_span.ec)
+
+        self.assertEqual(db_span.n, "mysql")
+        self.assertEqual(db_span.data["mysql"]["db"], testenv["mysql_db"])
+        self.assertEqual(db_span.data["mysql"]["user"], testenv["mysql_user"])
+        self.assertEqual(db_span.data["mysql"]["stmt"], "SELECT * from users")
+        self.assertEqual(db_span.data["mysql"]["host"], testenv["mysql_host"])
+        self.assertEqual(db_span.data["mysql"]["port"], testenv["mysql_port"])


### PR DESCRIPTION
Add context manager tests to db modules that conform to PEP-249

- psycopg2
- pymysql
- mysqlclient