### PR TITLE
refactor(tests): Clean up old PEP-249 tests

### DIFF
--- a/tests/clients/test_psycopg2.py
+++ b/tests/clients/test_psycopg2.py
@@ -64,8 +64,8 @@ class TestPsycoPG2(unittest.TestCase):
         return None
 
     def test_vanilla_query(self):
-        assert psycopg2.extras.register_uuid(None, self.db)
-        assert psycopg2.extras.register_uuid(None, self.db.cursor())
+        self.assertTrue(psycopg2.extras.register_uuid(None, self.db))
+        self.assertTrue(psycopg2.extras.register_uuid(None, self.db.cursor()))
 
         self.cursor.execute("""SELECT * from users""")
         result = self.cursor.fetchone()
@@ -84,14 +84,13 @@ class TestPsycoPG2(unittest.TestCase):
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
 
-        db_span = spans[0]
-        test_span = spans[1]
+        db_span, test_span = spans
 
         self.assertEqual("test", test_span.data["sdk"]["name"])
         self.assertEqual(test_span.t, db_span.t)
         self.assertEqual(db_span.p, test_span.s)
 
-        self.assertEqual(None, db_span.ec)
+        self.assertIsNone(db_span.ec)
 
         self.assertEqual(db_span.n, "postgres")
         self.assertEqual(db_span.data["pg"]["db"], testenv['postgresql_db'])
@@ -107,14 +106,13 @@ class TestPsycoPG2(unittest.TestCase):
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
 
-        db_span = spans[0]
-        test_span = spans[1]
+        db_span, test_span = spans
 
         self.assertEqual("test", test_span.data["sdk"]["name"])
         self.assertEqual(test_span.t, db_span.t)
         self.assertEqual(db_span.p, test_span.s)
 
-        self.assertEqual(None, db_span.ec)
+        self.assertIsNone(db_span.ec)
 
         self.assertEqual(db_span.n, "postgres")
         self.assertEqual(db_span.data["pg"]["db"], testenv['postgresql_db'])
@@ -124,7 +122,6 @@ class TestPsycoPG2(unittest.TestCase):
         self.assertEqual(db_span.data["pg"]["port"], testenv['postgresql_port'])
 
     def test_executemany(self):
-        result = None
         with tracer.start_active_span('test'):
             result = self.cursor.executemany("INSERT INTO users(name, email) VALUES(%s, %s)",
                                              [('beaker', 'beaker@muppets.com'), ('beaker', 'beaker@muppets.com')])
@@ -133,14 +130,13 @@ class TestPsycoPG2(unittest.TestCase):
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
 
-        db_span = spans[0]
-        test_span = spans[1]
+        db_span, test_span = spans
 
         self.assertEqual("test", test_span.data["sdk"]["name"])
         self.assertEqual(test_span.t, db_span.t)
         self.assertEqual(db_span.p, test_span.s)
 
-        self.assertEqual(None, db_span.ec)
+        self.assertIsNone(db_span.ec)
 
         self.assertEqual(db_span.n, "postgres")
         self.assertEqual(db_span.data["pg"]["db"], testenv['postgresql_db'])
@@ -150,23 +146,21 @@ class TestPsycoPG2(unittest.TestCase):
         self.assertEqual(db_span.data["pg"]["port"], testenv['postgresql_port'])
 
     def test_call_proc(self):
-        result = None
         with tracer.start_active_span('test'):
             result = self.cursor.callproc('test_proc', ('beaker',))
 
-        assert(type(result) is tuple)
+        self.assertIsInstance(result, tuple)
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
 
-        db_span = spans[0]
-        test_span = spans[1]
+        db_span, test_span = spans
 
         self.assertEqual("test", test_span.data["sdk"]["name"])
         self.assertEqual(test_span.t, db_span.t)
         self.assertEqual(db_span.p, test_span.s)
 
-        self.assertEqual(None, db_span.ec)
+        self.assertIsNone(db_span.ec)
 
         self.assertEqual(db_span.n, "postgres")
         self.assertEqual(db_span.data["pg"]["db"], testenv['postgresql_db'])
@@ -184,13 +178,12 @@ class TestPsycoPG2(unittest.TestCase):
         except Exception:
             pass
 
-        assert(result is None)
+        self.assertIsNone(result)
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
 
-        db_span = spans[0]
-        test_span = spans[1]
+        db_span, test_span = spans
 
         self.assertEqual("test", test_span.data["sdk"]["name"])
         self.assertEqual(test_span.t, db_span.t)
@@ -257,8 +250,7 @@ class TestPsycoPG2(unittest.TestCase):
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
 
-        db_span = spans[0]
-        test_span = spans[1]
+        db_span, test_span = spans
 
         self.assertEqual("test", test_span.data["sdk"]["name"])
         self.assertEqual(test_span.t, db_span.t)
@@ -282,8 +274,7 @@ class TestPsycoPG2(unittest.TestCase):
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
 
-        db_span = spans[0]
-        test_span = spans[1]
+        db_span, test_span = spans
 
         self.assertEqual("test", test_span.data["sdk"]["name"])
         self.assertEqual(test_span.t, db_span.t)
@@ -307,8 +298,7 @@ class TestPsycoPG2(unittest.TestCase):
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
 
-        db_span = spans[0]
-        test_span = spans[1]
+        db_span, test_span = spans
 
         self.assertEqual("test", test_span.data["sdk"]["name"])
         self.assertEqual(test_span.t, db_span.t)

--- a/tests/clients/test_psycopg2.py
+++ b/tests/clients/test_psycopg2.py
@@ -210,32 +210,27 @@ class TestPsycoPG2(unittest.TestCase):
     # Added to validate unicode support and register_type.
     def test_unicode(self):
         ext.register_type(ext.UNICODE, self.cursor)
-        #
-        # Python 2 chokes on Unicode and CircleCI tests are hanging (but pass locally).
-        # Disable these tests for now as we want to really just test register_type
-        # anyways
-        #
-        # snowman = "\u2603"
-        #
-        # self.cursor.execute("delete from users where id in (1,2,3)")
-        #
-        # # unicode in statement
-        # psycopg2.extras.execute_batch(self.cursor,
-        #     "insert into users (id, name) values (%%s, %%s) -- %s" % snowman, [(1, 'x')])
-        # self.cursor.execute("select id, name from users where id = 1")
-        # self.assertEqual(self.cursor.fetchone(), (1, 'x'))
-        #
-        # # unicode in data
-        # psycopg2.extras.execute_batch(self.cursor,
-        #     "insert into users (id, name) values (%s, %s)", [(2, snowman)])
-        # self.cursor.execute("select id, name from users where id = 2")
-        # self.assertEqual(self.cursor.fetchone(), (2, snowman))
-        #
-        # # unicode in both
-        # psycopg2.extras.execute_batch(self.cursor,
-        #     "insert into users (id, name) values (%%s, %%s) -- %s" % snowman, [(3, snowman)])
-        # self.cursor.execute("select id, name from users where id = 3")
-        # self.assertEqual(self.cursor.fetchone(), (3, snowman))
+        snowman = "\u2603"
+
+        self.cursor.execute("delete from users where id in (1,2,3)")
+
+        # unicode in statement
+        psycopg2.extras.execute_batch(self.cursor,
+            "insert into users (id, name) values (%%s, %%s) -- %s" % snowman, [(1, 'x')])
+        self.cursor.execute("select id, name from users where id = 1")
+        self.assertEqual(self.cursor.fetchone(), (1, 'x'))
+
+        # unicode in data
+        psycopg2.extras.execute_batch(self.cursor,
+            "insert into users (id, name) values (%s, %s)", [(2, snowman)])
+        self.cursor.execute("select id, name from users where id = 2")
+        self.assertEqual(self.cursor.fetchone(), (2, snowman))
+
+        # unicode in both
+        psycopg2.extras.execute_batch(self.cursor,
+            "insert into users (id, name) values (%%s, %%s) -- %s" % snowman, [(3, snowman)])
+        self.cursor.execute("select id, name from users where id = 3")
+        self.assertEqual(self.cursor.fetchone(), (3, snowman))
 
     def test_register_type(self):
         import uuid

--- a/tests/clients/test_pymysql.py
+++ b/tests/clients/test_pymysql.py
@@ -12,56 +12,44 @@ from instana.singletons import tracer
 
 logger = logging.getLogger(__name__)
 
-create_table_query = 'CREATE TABLE IF NOT EXISTS users(id serial primary key, \
-                      name varchar(40) NOT NULL, email varchar(40) NOT NULL)'
-
-create_proc_query = """
-CREATE PROCEDURE test_proc(IN t VARCHAR(255))
-BEGIN
-    SELECT name FROM users WHERE name = t;
-END
-"""
-
-db = pymysql.connect(host=testenv['mysql_host'], port=testenv['mysql_port'],
-                     user=testenv['mysql_user'], passwd=testenv['mysql_pw'],
-                     db=testenv['mysql_db'])
-
-cursor = db.cursor()
-cursor.execute(create_table_query)
-
-while cursor.nextset() is not None:
-    pass
-
-cursor.execute('DROP PROCEDURE IF EXISTS test_proc')
-
-while cursor.nextset() is not None:
-    pass
-
-cursor.execute(create_proc_query)
-
-while cursor.nextset() is not None:
-    pass
-
-cursor.close()
-db.close()
-
 
 class TestPyMySQL(unittest.TestCase):
     def setUp(self):
         self.db = pymysql.connect(host=testenv['mysql_host'], port=testenv['mysql_port'],
                                   user=testenv['mysql_user'], passwd=testenv['mysql_pw'],
                                   db=testenv['mysql_db'])
+        database_setup_query = """
+        DROP TABLE IF EXISTS users; |
+        CREATE TABLE users(
+            id serial primary key,
+            name varchar(40) NOT NULL,
+            email varchar(40) NOT NULL
+        ); |
+        INSERT INTO users(name, email) VALUES('kermit', 'kermit@muppets.com'); |
+        DROP PROCEDURE IF EXISTS test_proc; |
+        CREATE PROCEDURE test_proc(IN t VARCHAR(255))
+        BEGIN
+            SELECT name FROM users WHERE name = t;
+        END
+        """
+        setup_cursor = self.db.cursor()
+        for s in database_setup_query.split('|'):
+          setup_cursor.execute(s)
+
         self.cursor = self.db.cursor()
         self.recorder = tracer.recorder
         self.recorder.clear_spans()
         tracer.cur_ctx = None
 
     def tearDown(self):
-        """ Do nothing for now """
-        return None
+        if self.cursor and self.cursor.connection.open:
+          self.cursor.close()
+        if self.db and self.db.open:
+          self.db.close()
 
     def test_vanilla_query(self):
-        self.cursor.execute("""SELECT * from users""")
+        affected_rows = self.cursor.execute("""SELECT * from users""")
+        self.assertEqual(1, affected_rows)
         result = self.cursor.fetchone()
         self.assertEqual(3, len(result))
 
@@ -70,10 +58,11 @@ class TestPyMySQL(unittest.TestCase):
 
     def test_basic_query(self):
         with tracer.start_active_span('test'):
-            result = self.cursor.execute("""SELECT * from users""")
-            self.cursor.fetchone()
+            affected_rows = self.cursor.execute("""SELECT * from users""")
+            result = self.cursor.fetchone()
 
-        self.assertTrue(result >= 0)
+        self.assertEqual(1, affected_rows)
+        self.assertEqual(3, len(result))
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -95,10 +84,11 @@ class TestPyMySQL(unittest.TestCase):
 
     def test_query_with_params(self):
         with tracer.start_active_span('test'):
-            result = self.cursor.execute("""SELECT * from users where id=1""")
-            self.cursor.fetchone()
+            affected_rows = self.cursor.execute("""SELECT * from users where id=1""")
+            result = self.cursor.fetchone()
 
-        self.assertTrue(result >= 0)
+        self.assertEqual(1, affected_rows)
+        self.assertEqual(3, len(result))
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -120,11 +110,11 @@ class TestPyMySQL(unittest.TestCase):
 
     def test_basic_insert(self):
         with tracer.start_active_span('test'):
-            result = self.cursor.execute(
+            affected_rows = self.cursor.execute(
                         """INSERT INTO users(name, email) VALUES(%s, %s)""",
                         ('beaker', 'beaker@muppets.com'))
 
-        self.assertEqual(1, result)
+        self.assertEqual(1, affected_rows)
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -146,11 +136,11 @@ class TestPyMySQL(unittest.TestCase):
 
     def test_executemany(self):
         with tracer.start_active_span('test'):
-            result = self.cursor.executemany("INSERT INTO users(name, email) VALUES(%s, %s)",
+            affected_rows  = self.cursor.executemany("INSERT INTO users(name, email) VALUES(%s, %s)",
                                              [('beaker', 'beaker@muppets.com'), ('beaker', 'beaker@muppets.com')])
             self.db.commit()
 
-        self.assertEqual(2, result)
+        self.assertEqual(2, affected_rows)
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -172,9 +162,9 @@ class TestPyMySQL(unittest.TestCase):
 
     def test_call_proc(self):
         with tracer.start_active_span('test'):
-            result = self.cursor.callproc('test_proc', ('beaker',))
+            callproc_result = self.cursor.callproc('test_proc', ('beaker',))
 
-        self.assertTrue(result)
+        self.assertIsInstance(callproc_result, tuple)
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -195,15 +185,14 @@ class TestPyMySQL(unittest.TestCase):
         self.assertEqual(db_span.data["mysql"]["port"], testenv['mysql_port'])
 
     def test_error_capture(self):
-        result = None
+        affected_rows = None
         try:
             with tracer.start_active_span('test'):
-                result = self.cursor.execute("""SELECT * from blah""")
-                self.cursor.fetchone()
+                affected_rows = self.cursor.execute("""SELECT * from blah""")
         except Exception:
             pass
 
-        self.assertIsNone(result)
+        self.assertIsNone(affected_rows)
 
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -228,8 +217,9 @@ class TestPyMySQL(unittest.TestCase):
         with tracer.start_active_span("test"):
             with self.db as connection:
                 with connection.cursor() as cursor:
-                    cursor.execute("""SELECT * from users""")
+                    affected_rows = cursor.execute("""SELECT * from users""")
 
+        self.assertEqual(1, affected_rows)
         spans = self.recorder.queued_spans()
         self.assertEqual(2, len(spans))
 


### PR DESCRIPTION
* Use the `unittest` module's `assert` in unit tests.
* Drop legacy branching for unsupported 2.7
* Eliminate unused variables
* Remove superfluous initializations
* Use unpack assignments