### PR TITLE
Fork missing spans fix

### DIFF
--- a/instana/agent/host.py
+++ b/instana/agent/host.py
@@ -115,7 +115,6 @@ class HostAgent(BaseAgent):
             self._boot_pid = current_pid
             logger.debug("Fork detected; Handling like a pro...")
             self.handle_fork()
-            return False
 
         if self.machine.fsm.current in ["wait4init", "good2go"]:
             return True

--- a/instana/collector/base.py
+++ b/instana/collector/base.py
@@ -35,7 +35,7 @@ class BaseCollector(object):
         if env_is_test:
             # Override span queue with a multiprocessing version
             # The test suite runs background applications - some in background threads,
-            # others in background processes.  This multiprocess queue allows us to collect
+            # others in background processes.  This multiprocessing queue allows us to collect
             # up spans from all sources.
             import multiprocessing
             self.span_queue = multiprocessing.Queue()
@@ -59,8 +59,8 @@ class BaseCollector(object):
         # List of helpers that help out in data collection
         self.helpers = []
 
-        # Lock used syncronize reporting - no updates when sending
-        # Used by the background reporting thread.  Used to syncronize report attempts and so
+        # Lock used synchronize reporting - no updates when sending
+        # Used by the background reporting thread.  Used to synchronize report attempts and so
         # that we never have two in progress at once.
         self.background_report_lock = threading.Lock()
 
@@ -70,7 +70,7 @@ class BaseCollector(object):
         # Flag to indicate if start/shutdown state
         self.started = False
 
-        # Startime of fetching metadata
+        # Start time of fetching metadata
         self.fetching_start_time = 0
 
     def is_reporting_thread_running(self):
@@ -95,7 +95,7 @@ class BaseCollector(object):
                 timer.name = "Collector Timed Start"
                 timer.start()
                 return
-            logger.debug("Collecter.start non-fatal: call but thread already running (started: %s)", self.started)
+            logger.debug("BaseCollector.start non-fatal: call but thread already running (started: %s)", self.started)
             return
 
         if self.agent.can_send():

--- a/instana/collector/base.py
+++ b/instana/collector/base.py
@@ -115,9 +115,9 @@ class BaseCollector(object):
         e.g. If the host agent disappeared, we won't be able to report final data.
         @return: None
         """
-        logger.debug("Collector.shutdown: Reporting final data.")
         self.thread_shutdown.set()
         if report_final is True:
+            logger.debug("Collector.shutdown: Reporting final data.")
             self.prepare_and_report_data()
         self.started = False
 


### PR DESCRIPTION
In multithreaded applications (services), only the first or master process is announced to the Agent when the service starts, but if a not announced forked process handles the (HTTP) ENTRY requests and it contains one or more EXIT spans created during the first request, those EXIT spans are missed and not reported. 

This PR has a fix that returns `True` when the `agent.host.can_send()` method is called and detects the state machine is in `wait4init` or `good2go` states, which happens after the current process is announced to the Agent.

