### PR TITLE
Add `dbname` as collecting parameter for PEP0249

### DIFF
--- a/instana/instrumentation/pep0249.py
+++ b/instana/instrumentation/pep0249.py
@@ -24,10 +24,9 @@ class CursorWrapper(wrapt.ObjectProxy):
         try:
             span.set_tag(ext.SPAN_KIND, 'exit')
 
-            if 'db' in self._connect_params[1]:
-                span.set_tag(ext.DATABASE_INSTANCE, self._connect_params[1]['db'])
-            elif 'database' in self._connect_params[1]:
-                span.set_tag(ext.DATABASE_INSTANCE, self._connect_params[1]['database'])
+            db_parameter_name = next((p for p in ('db', 'database', 'dbname') if p in self._connect_params[1]), None)
+            if db_parameter_name:
+                span.set_tag(ext.DATABASE_INSTANCE, self._connect_params[1][db_parameter_name])
 
             span.set_tag(ext.DATABASE_STATEMENT, sql_sanitizer(sql))
             span.set_tag(ext.DATABASE_USER, self._connect_params[1]['user'])


### PR DESCRIPTION
This PR contains two commits.

The first one, https://github.com/instana/python-sensor/commit/55e826e81ff311cefac112cd0d1fa4b111c91f23, adds `dbname` as a collecting parameter for PEP0249. When connecting to a PostgreSQL server, for example, using the psycopg2 module, the parameter `dbname` can be used to specify the database name to connect into, like the following piece of code:

```python
    conn = psycopg2.connect(
        host=os.environ['POSTGRES_HOST'],
        dbname=os.environ['POSTGRES_DB'],
        user=os.environ['POSTGRES_USER'],
        password=os.environ['POSTGRES_PASSWORD']
    )
```

Without this fix, the Instana UI is not able to display the database name when inspecting an EXIT span, as shown in the following image:

<img width="417" alt="before_commit_0f9434e02013" src="https://github.com/instana/python-sensor/assets/699330/0c16d519-9a2f-4fe8-8241-f6ce4d1a3c71">

With this fix, the name of the database is collected and displayed:

<img width="426" alt="after_commit_0f9434e02013" src="https://github.com/instana/python-sensor/assets/699330/a1459a21-4549-49c0-b36c-a958b91050e4">

The second commit, 221432e, adapts all the unit tests that use PEP0249 to guarantee that all options for database parameter names during the connection are tested.
