### PR TITLE
refactor: Using context manager to handle threading.Lock

### DIFF
--- a/instana/collector/base.py
+++ b/instana/collector/base.py
@@ -151,15 +151,12 @@ class BaseCollector(object):
         @return: Boolean
         """
         if env_is_test is False:
-            lock_acquired = self.background_report_lock.acquire(False)
-            if lock_acquired:
+            with self.background_report_lock:
                 try:
                     payload = self.prepare_payload()
                     self.agent.report_data_payload(payload)
-                finally:
-                    self.background_report_lock.release()
-            else:
-                logger.debug("prepare_and_report_data: Couldn't acquire lock")
+                except:
+                    logger.debug("prepare_and_report_data: Couldn't acquire lock")
         return True
 
     def prepare_payload(self):
@@ -195,7 +192,6 @@ class BaseCollector(object):
             else:
                 spans.append(span)
         return spans
-
 
     def queued_profiles(self):
         """


### PR DESCRIPTION
This PR solves the issue of the background report thread not releasing the lock when the application is manually instrumented and runs with multiple workers (uWSGI).