### PR TITLE
refactor: Using context manager to handle threading.Lock

### DIFF
--- a/instana/collector/base.py
+++ b/instana/collector/base.py
@@ -150,16 +150,11 @@ class BaseCollector(object):
         Prepare and report the data payload.
         @return: Boolean
         """
-        if env_is_test is False:
-            lock_acquired = self.background_report_lock.acquire(False)
-            if lock_acquired:
-                try:
-                    payload = self.prepare_payload()
-                    self.agent.report_data_payload(payload)
-                finally:
-                    self.background_report_lock.release()
-            else:
-                logger.debug("prepare_and_report_data: Couldn't acquire lock")
+        if env_is_test:
+            return True
+        with self.background_report_lock:
+            payload = self.prepare_payload()
+            self.agent.report_data_payload(payload)
         return True
 
     def prepare_payload(self):


### PR DESCRIPTION
This PR solves the issue of the background report thread not releasing the lock when the application is manually instrumented and runs with multiple workers (uWSGI).