### PR TITLE
Use latest urllib3 without secure extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(name='instana',
                         'protobuf<5.0.0',
                         'requests>=2.6.0',
                         'six>=1.12.0',
-                        'urllib3>=1.26.18',],
+                        'urllib3>=1.26.5',],
       entry_points={
                     'instana':  ['string = instana:load'],
                     'flask':    ['string = instana:load'],  # deprecated: use same as 'instana'

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(name='instana',
                         'protobuf<5.0.0',
                         'requests>=2.6.0',
                         'six>=1.12.0',
-                        'urllib3<1.27,>=1.26.5',],
+                        'urllib3>=1.26.18',],
       entry_points={
                     'instana':  ['string = instana:load'],
                     'flask':    ['string = instana:load'],  # deprecated: use same as 'instana'

--- a/tests/requirements-307.txt
+++ b/tests/requirements-307.txt
@@ -46,4 +46,4 @@ sqlalchemy>=2.0.0
 spyne>=2.14.0
 tornado>=4.5.3,<6.0
 uvicorn>=0.13.4
-urllib3>=1.26.18
+urllib3>=1.26.5

--- a/tests/requirements-307.txt
+++ b/tests/requirements-307.txt
@@ -46,4 +46,4 @@ sqlalchemy>=2.0.0
 spyne>=2.14.0
 tornado>=4.5.3,<6.0
 uvicorn>=0.13.4
-urllib3[secure]<1.27,>=1.26.5
+urllib3>=1.26.18

--- a/tests/requirements-310-with-tornado.txt
+++ b/tests/requirements-310-with-tornado.txt
@@ -36,4 +36,4 @@ sqlalchemy>=2.0.0
 spyne>=2.14.0
 
 uvicorn>=0.13.4
-urllib3[secure]<1.27,>=1.26.5
+urllib3>=1.26.18

--- a/tests/requirements-310-with-tornado.txt
+++ b/tests/requirements-310-with-tornado.txt
@@ -36,4 +36,4 @@ sqlalchemy>=2.0.0
 spyne>=2.14.0
 
 uvicorn>=0.13.4
-urllib3>=1.26.18
+urllib3>=1.26.5

--- a/tests/requirements-310.txt
+++ b/tests/requirements-310.txt
@@ -38,4 +38,4 @@ sqlalchemy>=2.0.0
 spyne>=2.14.0
 
 uvicorn>=0.13.4
-urllib3[secure]<1.27,>=1.26.5
+urllib3>=1.26.18

--- a/tests/requirements-310.txt
+++ b/tests/requirements-310.txt
@@ -38,4 +38,4 @@ sqlalchemy>=2.0.0
 spyne>=2.14.0
 
 uvicorn>=0.13.4
-urllib3>=1.26.18
+urllib3>=1.26.5

--- a/tests/requirements-312.txt
+++ b/tests/requirements-312.txt
@@ -42,4 +42,4 @@ sqlalchemy>=2.0.0
 spyne>=2.14.0
 
 uvicorn>=0.13.4
-urllib3>=1.26.18
+urllib3>=1.26.5

--- a/tests/requirements-312.txt
+++ b/tests/requirements-312.txt
@@ -42,4 +42,4 @@ sqlalchemy>=2.0.0
 spyne>=2.14.0
 
 uvicorn>=0.13.4
-urllib3[secure]<1.27,>=1.26.5
+urllib3>=1.26.18

--- a/tests/requirements-cassandra.txt
+++ b/tests/requirements-cassandra.txt
@@ -2,4 +2,4 @@ cassandra-driver>=3.20.2
 coverage>=5.5
 mock>=2.0.0
 pytest>=4.6
-urllib3>=1.26.18
+urllib3>=1.26.5

--- a/tests/requirements-cassandra.txt
+++ b/tests/requirements-cassandra.txt
@@ -2,4 +2,4 @@ cassandra-driver>=3.20.2
 coverage>=5.5
 mock>=2.0.0
 pytest>=4.6
-urllib3[secure]<1.27,>=1.26.5
+urllib3>=1.26.18

--- a/tests/requirements-gevent.txt
+++ b/tests/requirements-gevent.txt
@@ -4,4 +4,4 @@ gevent>=1.4.0
 mock>=2.0.0
 pyramid>=2.0.1
 pytest>=4.6
-urllib3>=1.26.18
+urllib3>=1.26.5

--- a/tests/requirements-gevent.txt
+++ b/tests/requirements-gevent.txt
@@ -4,4 +4,4 @@ gevent>=1.4.0
 mock>=2.0.0
 pyramid>=2.0.1
 pytest>=4.6
-urllib3[secure]<1.27,>=1.26.5
+urllib3>=1.26.18

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -37,4 +37,4 @@ sqlalchemy>=2.0.0
 spyne>=2.14.0
 tornado>=4.5.3,<6.0
 uvicorn>=0.13.4
-urllib3>=1.26.18
+urllib3>=1.26.5

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -37,4 +37,4 @@ sqlalchemy>=2.0.0
 spyne>=2.14.0
 tornado>=4.5.3,<6.0
 uvicorn>=0.13.4
-urllib3[secure]<1.27,>=1.26.5
+urllib3>=1.26.18


### PR DESCRIPTION
Signed-off-by: Varsha GS varsha.gs@ibm.com

- Use urllib3>=1.26.18
- Remove secure extra feature ([more info](https://github.com/urllib3/urllib3/issues/2680))