### PR TITLE
fix: The spec doesn't set upper limit for ec=1 if code>=500

### DIFF
--- a/instana/instrumentation/aiohttp/client.py
+++ b/instana/instrumentation/aiohttp/client.py
@@ -51,7 +51,7 @@ try:
                         if custom_header in params.response.headers:
                             scope.span.set_tag("http.header.%s" % custom_header, params.response.headers[custom_header])
 
-                if 500 <= params.response.status <= 599:
+                if 500 <= params.response.status:
                     scope.span.mark_as_errored({"http.error": params.response.reason})
 
                 scope.close()

--- a/instana/instrumentation/aiohttp/server.py
+++ b/instana/instrumentation/aiohttp/server.py
@@ -52,7 +52,7 @@ try:
 
             if response is not None:
                 # Mark 500 responses as errored
-                if 500 <= response.status <= 511:
+                if 500 <= response.status:
                     scope.span.mark_as_errored()
 
                 scope.span.set_tag("http.status_code", response.status)

--- a/instana/instrumentation/asgi.py
+++ b/instana/instrumentation/asgi.py
@@ -78,7 +78,7 @@ class InstanaASGIMiddleware:
                     try:
                         status_code = response.get('status')
                         if status_code is not None:
-                            if 500 <= int(status_code) <= 511:
+                            if 500 <= int(status_code):
                                 span.mark_as_errored()
                             span.set_tag('http.status_code', status_code)
 

--- a/instana/instrumentation/django/middleware.py
+++ b/instana/instrumentation/django/middleware.py
@@ -58,7 +58,7 @@ class InstanaMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         try:
             if request.iscope is not None:
-                if 500 <= response.status_code <= 511:
+                if 500 <= response.status_code:
                     request.iscope.span.assure_errored()
                 # for django >= 2.2
                 if request.resolver_match is not None and hasattr(request.resolver_match, 'route'):

--- a/instana/instrumentation/fastapi_inst.py
+++ b/instana/instrumentation/fastapi_inst.py
@@ -35,7 +35,7 @@ try:
             span = async_tracer.active_span
 
             if span is not None:
-                if hasattr(exc, 'detail') and (500 <= exc.status_code <= 599):
+                if hasattr(exc, 'detail') and 500 <= exc.status_code:
                     span.set_tag('http.error', exc.detail)
                 span.set_tag('http.status_code', exc.status_code)
         except Exception:

--- a/instana/instrumentation/flask/common.py
+++ b/instana/instrumentation/flask/common.py
@@ -58,7 +58,7 @@ def handle_user_exception_with_instana(wrapped, instance, argv, kwargs):
                     else:
                         status_code = response.status_code
 
-                if 500 <= status_code <= 511:
+                if 500 <= status_code:
                     span.log_exception(exc)
 
                 span.set_tag(ext.HTTP_STATUS_CODE, int(status_code))

--- a/instana/instrumentation/flask/vanilla.py
+++ b/instana/instrumentation/flask/vanilla.py
@@ -64,7 +64,7 @@ def after_request_with_instana(response):
         if scope is not None:
             span = scope.span
 
-            if 500 <= response.status_code <= 511:
+            if 500 <= response.status_code:
                 span.mark_as_errored()
 
             span.set_tag(ext.HTTP_STATUS_CODE, int(response.status_code))

--- a/instana/instrumentation/flask/with_blinker.py
+++ b/instana/instrumentation/flask/with_blinker.py
@@ -64,7 +64,7 @@ def request_finished_with_instana(sender, response, **extra):
         if scope is not None:
             span = scope.span
 
-            if 500 <= response.status_code <= 511:
+            if 500 <= response.status_code:
                 span.mark_as_errored()
 
             span.set_tag(ext.HTTP_STATUS_CODE, int(response.status_code))

--- a/instana/instrumentation/pyramid/tweens.py
+++ b/instana/instrumentation/pyramid/tweens.py
@@ -65,7 +65,7 @@ class InstanaTweenFactory(object):
             if response:
                 scope.span.set_tag("http.status", response.status_int)
 
-                if 500 <= response.status_int <= 511:
+                if 500 <= response.status_int:
                     if response.exception is not None:
                         message = str(response.exception)
                         scope.span.log_exception(response.exception)

--- a/instana/instrumentation/sanic_inst.py
+++ b/instana/instrumentation/sanic_inst.py
@@ -22,7 +22,7 @@ try:
             status_code = kwargs.get("status_code")
             span = async_tracer.active_span
 
-            if all([span, status_code, message]) and (500 <= status_code <= 599):
+            if all([span, status_code, message]) and 500 <= status_code:
                 span.set_tag("http.error", message)
                 try:
                     wrapped(*args, **kwargs)
@@ -39,7 +39,7 @@ try:
         try:
             status_code = response.status
             if status_code is not None:
-                if 500 <= int(status_code) <= 511:
+                if 500 <= int(status_code):
                     span.mark_as_errored()
                 span.set_tag('http.status_code', status_code)
 

--- a/instana/instrumentation/tornado/server.py
+++ b/instana/instrumentation/tornado/server.py
@@ -85,7 +85,7 @@ try:
             status_code = instance.get_status()
 
             # Mark 500 responses as errored
-            if 500 <= status_code <= 511:
+            if 500 <= status_code:
                 scope.span.mark_as_errored()
 
             scope.span.set_tag("http.status_code", status_code)

--- a/instana/instrumentation/urllib3.py
+++ b/instana/instrumentation/urllib3.py
@@ -60,7 +60,7 @@ try:
                     if custom_header in response.headers:
                         scope.span.set_tag("http.header.%s" % custom_header, response.headers[custom_header])
 
-            if 500 <= response.status <= 599:
+            if 500 <= response.status:
                 scope.span.mark_as_errored()
         except Exception:
             logger.debug("collect_response", exc_info=True)

--- a/instana/instrumentation/wsgi.py
+++ b/instana/instrumentation/wsgi.py
@@ -28,7 +28,7 @@ class InstanaWSGIMiddleware(object):
             res = start_response(status, headers, exc_info)
 
             sc = status.split(' ')[0]
-            if 500 <= int(sc) <= 511:
+            if 500 <= int(sc):
                 self.scope.span.mark_as_errored()
 
             self.scope.span.set_tag(tags.HTTP_STATUS_CODE, sc)


### PR DESCRIPTION
Quote from the [spec](
https://github.ibm.com/instana/technical-documentation/tree/master/tracing/specification#capturing-errors-on-http-spans):

> For HTTP exit and entry spans alike, if a full request/response cycle has happened (which implies that an HTTP status code is present): If the HTTP status code is >= 500, the associated span MUST be marked as an error via span.ec.

This means that there is no upper limit, and this should apply to custom status codes as well, which might be above `511`, or even `599`.
