### PR TITLE
Django: capture responseHeadersOnEntrySpans

### DIFF
--- a/instana/instrumentation/django/middleware.py
+++ b/instana/instrumentation/django/middleware.py
@@ -29,6 +29,19 @@ class InstanaMiddleware(MiddlewareMixin):
         super(InstanaMiddleware, self).__init__(get_response)
         self.get_response = get_response
 
+    def _extract_custom_headers(self, span, headers, format):
+        try:
+            if agent.options.extra_http_headers is not None:
+                for custom_header in agent.options.extra_http_headers:
+                    # Headers are available in this format: HTTP_X_CAPTURE_THIS
+                    django_header = ('HTTP_' + custom_header.upper()).replace('-', '_') if format else custom_header
+
+                    if django_header in headers:
+                        span.set_tag("http.header.%s" % custom_header, headers[django_header])
+
+        except Exception:
+            logger.debug("extract_custom_headers: ", exc_info=True)
+
     def process_request(self, request):
         try:
             env = request.environ
@@ -36,12 +49,7 @@ class InstanaMiddleware(MiddlewareMixin):
             ctx = tracer.extract(ot.Format.HTTP_HEADERS, env)
             request.iscope = tracer.start_active_span('django', child_of=ctx)
 
-            if agent.options.extra_http_headers is not None:
-                for custom_header in agent.options.extra_http_headers:
-                    # Headers are available in this format: HTTP_X_CAPTURE_THIS
-                    django_header = ('HTTP_' + custom_header.upper()).replace('-', '_')
-                    if django_header in env:
-                        request.iscope.span.set_tag("http.header.%s" % custom_header, env[django_header])
+            self._extract_custom_headers(request.iscope.span, env, format=True)
 
             request.iscope.span.set_tag(ext.HTTP_METHOD, request.method)
             if 'PATH_INFO' in env:
@@ -75,7 +83,9 @@ class InstanaMiddleware(MiddlewareMixin):
                         path_tpl = None
                 if path_tpl:
                     request.iscope.span.set_tag("http.path_tpl", path_tpl)
+
                 request.iscope.span.set_tag(ext.HTTP_STATUS_CODE, response.status_code)
+                self._extract_custom_headers(request.iscope.span, response.headers, format=False)
                 tracer.inject(request.iscope.span.context, ot.Format.HTTP_HEADERS, response)
                 response['Server-Timing'] = "intid;desc=%s" % request.iscope.span.context.trace_id
         except Exception:

--- a/instana/instrumentation/django/middleware.py
+++ b/instana/instrumentation/django/middleware.py
@@ -30,14 +30,16 @@ class InstanaMiddleware(MiddlewareMixin):
         self.get_response = get_response
 
     def _extract_custom_headers(self, span, headers, format):
-        try:
-            if agent.options.extra_http_headers is not None:
-                for custom_header in agent.options.extra_http_headers:
-                    # Headers are available in this format: HTTP_X_CAPTURE_THIS
-                    django_header = ('HTTP_' + custom_header.upper()).replace('-', '_') if format else custom_header
+        if agent.options.extra_http_headers is None:
+            return
 
-                    if django_header in headers:
-                        span.set_tag("http.header.%s" % custom_header, headers[django_header])
+        try:            
+            for custom_header in agent.options.extra_http_headers:
+                # Headers are available in this format: HTTP_X_CAPTURE_THIS
+                django_header = ('HTTP_' + custom_header.upper()).replace('-', '_') if format else custom_header
+
+                if django_header in headers:
+                    span.set_tag("http.header.%s" % custom_header, headers[django_header])
 
         except Exception:
             logger.debug("extract_custom_headers: ", exc_info=True)

--- a/tests/apps/app_django.py
+++ b/tests/apps/app_django.py
@@ -126,9 +126,11 @@ def complex(request):
 
 
 def response_with_headers(request):
-    response = HttpResponse(content_type='')
-    response['X-Capture-This-Too'] = 'this too'
-    return response
+    headers = {
+        'X-Capture-This-Too': 'this too',
+        'X-Capture-That-Too': 'that too'
+    }
+    return HttpResponse('Stan wuz here with headers!', headers=headers)
 
 
 urlpatterns = [

--- a/tests/apps/app_django.py
+++ b/tests/apps/app_django.py
@@ -125,10 +125,17 @@ def complex(request):
     return HttpResponse('Stan wuz here!')
 
 
+def response_with_headers(request):
+    response = HttpResponse(content_type='')
+    response['X-Capture-This-Too'] = 'this too'
+    return response
+
+
 urlpatterns = [
     re_path(r'^$', index, name='index'),
     re_path(r'^cause_error$', cause_error, name='cause_error'),
     re_path(r'^another$', another),
     re_path(r'^not_found$', not_found, name='not_found'),
-    re_path(r'^complex$', complex, name='complex')
+    re_path(r'^complex$', complex, name='complex'),
+    re_path(r'^response_with_headers$', response_with_headers, name='response_with_headers')
 ]

--- a/tests/frameworks/test_django.py
+++ b/tests/frameworks/test_django.py
@@ -2,14 +2,14 @@
 # (c) Copyright Instana Inc. 2020
 
 from __future__ import absolute_import
+import os
 
 import urllib3
 from django.apps import apps
-from ..apps.app_django import INSTALLED_APPS
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-import os
-from instana.singletons import agent, tracer
 
+from ..apps.app_django import INSTALLED_APPS
+from instana.singletons import agent, tracer
 from ..helpers import fail_with_message_and_span_dump, get_first_span_by_filter, drop_log_spans_from_list
 
 apps.populate(INSTALLED_APPS)
@@ -30,7 +30,7 @@ class TestDjango(StaticLiveServerTestCase):
         with tracer.start_active_span('test'):
             response = self.http.request('GET', self.live_server_url + '/', fields={"test": 1})
 
-        assert response
+        self.assertTrue(response)
         self.assertEqual(200, response.status)
 
         spans = self.recorder.queued_spans()
@@ -40,19 +40,19 @@ class TestDjango(StaticLiveServerTestCase):
         urllib3_span = spans[1]
         django_span = spans[0]
 
-        assert ('X-INSTANA-T' in response.headers)
-        assert (int(response.headers['X-INSTANA-T'], 16))
+        self.assertIn('X-INSTANA-T', response.headers)
+        self.assertTrue(int(response.headers['X-INSTANA-T'], 16))
         self.assertEqual(django_span.t, response.headers['X-INSTANA-T'])
 
-        assert ('X-INSTANA-S' in response.headers)
-        assert (int(response.headers['X-INSTANA-S'], 16))
+        self.assertIn('X-INSTANA-S', response.headers)
+        self.assertTrue(int(response.headers['X-INSTANA-S'], 16))
         self.assertEqual(django_span.s, response.headers['X-INSTANA-S'])
 
-        assert ('X-INSTANA-L' in response.headers)
+        self.assertIn('X-INSTANA-L', response.headers)
         self.assertEqual('1', response.headers['X-INSTANA-L'])
 
         server_timing_value = "intid;desc=%s" % django_span.t
-        assert ('Server-Timing' in response.headers)
+        self.assertIn('Server-Timing', response.headers)
         self.assertEqual(server_timing_value, response.headers['Server-Timing'])
 
         self.assertEqual("test", test_span.data["sdk"]["name"])
@@ -86,7 +86,7 @@ class TestDjango(StaticLiveServerTestCase):
         with tracer.start_active_span('test'):
             response = self.http.request('GET', self.live_server_url + '/', headers=headers)
 
-        assert response
+        self.assertTrue(response)
         self.assertEqual(200, response.status)
 
         spans = self.recorder.queued_spans()
@@ -106,7 +106,7 @@ class TestDjango(StaticLiveServerTestCase):
         with tracer.start_active_span('test'):
             response = self.http.request('GET', self.live_server_url + '/cause_error')
 
-        assert response
+        self.assertTrue(response)
         self.assertEqual(500, response.status)
 
         spans = self.recorder.queued_spans()
@@ -119,29 +119,29 @@ class TestDjango(StaticLiveServerTestCase):
 
         filter = lambda span: span.n == 'sdk' and span.data['sdk']['name'] == 'test'
         test_span = get_first_span_by_filter(spans, filter)
-        assert (test_span)
+        self.assertTrue(test_span)
 
         filter = lambda span: span.n == 'urllib3'
         urllib3_span = get_first_span_by_filter(spans, filter)
-        assert (urllib3_span)
+        self.assertTrue(urllib3_span)
 
         filter = lambda span: span.n == 'django'
         django_span = get_first_span_by_filter(spans, filter)
-        assert (django_span)
+        self.assertTrue(django_span)
 
-        assert ('X-INSTANA-T' in response.headers)
-        assert (int(response.headers['X-INSTANA-T'], 16))
+        self.assertIn('X-INSTANA-T', response.headers)
+        self.assertTrue(int(response.headers['X-INSTANA-T'], 16))
         self.assertEqual(django_span.t, response.headers['X-INSTANA-T'])
 
-        assert ('X-INSTANA-S' in response.headers)
-        assert (int(response.headers['X-INSTANA-S'], 16))
+        self.assertIn('X-INSTANA-S', response.headers)
+        self.assertTrue(int(response.headers['X-INSTANA-S'], 16))
         self.assertEqual(django_span.s, response.headers['X-INSTANA-S'])
 
-        assert ('X-INSTANA-L' in response.headers)
+        self.assertIn('X-INSTANA-L', response.headers)
         self.assertEqual('1', response.headers['X-INSTANA-L'])
 
         server_timing_value = "intid;desc=%s" % django_span.t
-        assert ('Server-Timing' in response.headers)
+        self.assertIn('Server-Timing', response.headers)
         self.assertEqual(server_timing_value, response.headers['Server-Timing'])
 
         self.assertEqual("test", test_span.data["sdk"]["name"])
@@ -167,7 +167,7 @@ class TestDjango(StaticLiveServerTestCase):
         with tracer.start_active_span('test'):
             response = self.http.request('GET', self.live_server_url + '/not_found')
 
-        assert response
+        self.assertTrue(response)
         self.assertEqual(404, response.status)
 
         spans = self.recorder.queued_spans()
@@ -180,7 +180,7 @@ class TestDjango(StaticLiveServerTestCase):
 
         filter = lambda span: span.n == 'django'
         django_span = get_first_span_by_filter(spans, filter)
-        assert (django_span)
+        self.assertTrue(django_span)
 
         self.assertIsNone(django_span.ec)
         self.assertEqual(404, django_span.data["http"]["status"])
@@ -189,7 +189,7 @@ class TestDjango(StaticLiveServerTestCase):
         with tracer.start_active_span('test'):
             response = self.http.request('GET', self.live_server_url + '/no_route')
 
-        assert response
+        self.assertTrue(response)
         self.assertEqual(404, response.status)
 
         spans = self.recorder.queued_spans()
@@ -202,7 +202,7 @@ class TestDjango(StaticLiveServerTestCase):
 
         filter = lambda span: span.n == 'django'
         django_span = get_first_span_by_filter(spans, filter)
-        assert (django_span)
+        self.assertTrue(django_span)
         self.assertIsNone(django_span.data["http"]["path_tpl"])
         self.assertIsNone(django_span.ec)
         self.assertEqual(404, django_span.data["http"]["status"])
@@ -211,7 +211,7 @@ class TestDjango(StaticLiveServerTestCase):
         with tracer.start_active_span('test'):
             response = self.http.request('GET', self.live_server_url + '/complex')
 
-        assert response
+        self.assertTrue(response)
         self.assertEqual(200, response.status)
         spans = self.recorder.queued_spans()
         self.assertEqual(5, len(spans))
@@ -222,19 +222,19 @@ class TestDjango(StaticLiveServerTestCase):
         ot_span1 = spans[1]
         ot_span2 = spans[0]
 
-        assert ('X-INSTANA-T' in response.headers)
-        assert (int(response.headers['X-INSTANA-T'], 16))
+        self.assertIn('X-INSTANA-T', response.headers)
+        self.assertTrue(int(response.headers['X-INSTANA-T'], 16))
         self.assertEqual(django_span.t, response.headers['X-INSTANA-T'])
 
-        assert ('X-INSTANA-S' in response.headers)
-        assert (int(response.headers['X-INSTANA-S'], 16))
+        self.assertIn('X-INSTANA-S', response.headers)
+        self.assertTrue(int(response.headers['X-INSTANA-S'], 16))
         self.assertEqual(django_span.s, response.headers['X-INSTANA-S'])
 
-        assert ('X-INSTANA-L' in response.headers)
+        self.assertIn('X-INSTANA-L', response.headers)
         self.assertEqual('1', response.headers['X-INSTANA-L'])
 
         server_timing_value = "intid;desc=%s" % django_span.t
-        assert ('Server-Timing' in response.headers)
+        self.assertIn('Server-Timing', response.headers)
         self.assertEqual(server_timing_value, response.headers['Server-Timing'])
 
         self.assertEqual("test", test_span.data["sdk"]["name"])
@@ -266,15 +266,16 @@ class TestDjango(StaticLiveServerTestCase):
         original_extra_http_headers = agent.options.extra_http_headers
         agent.options.extra_http_headers = [u'X-Capture-This', u'X-Capture-That']
 
-        request_headers = dict()
-        request_headers['X-Capture-This'] = 'this'
-        request_headers['X-Capture-That'] = 'that'
+        request_headers = {
+            'X-Capture-This': 'this',
+            'X-Capture-That': 'that'
+        }
 
         with tracer.start_active_span('test'):
             response = self.http.request('GET', self.live_server_url + '/', headers=request_headers)
             # response = self.client.get('/')
 
-        assert response
+        self.assertTrue(response)
         self.assertEqual(200, response.status)
 
         spans = self.recorder.queued_spans()
@@ -302,9 +303,9 @@ class TestDjango(StaticLiveServerTestCase):
         self.assertEqual(200, django_span.data["http"]["status"])
         self.assertEqual('^$', django_span.data["http"]["path_tpl"])
 
-        assert "X-Capture-This" in django_span.data["http"]["header"]
+        self.assertIn("X-Capture-This", django_span.data["http"]["header"])
         self.assertEqual("this", django_span.data["http"]["header"]["X-Capture-This"])
-        assert "X-Capture-That" in django_span.data["http"]["header"]
+        self.assertIn("X-Capture-That", django_span.data["http"]["header"])
         self.assertEqual("that", django_span.data["http"]["header"]["X-Capture-That"])
 
         agent.options.extra_http_headers = original_extra_http_headers
@@ -312,12 +313,12 @@ class TestDjango(StaticLiveServerTestCase):
     def test_response_header_capture(self):
         # Hack together a manual custom headers list
         original_extra_http_headers = agent.options.extra_http_headers
-        agent.options.extra_http_headers = [u'X-Capture-This-Too']
+        agent.options.extra_http_headers = [u'X-Capture-This-Too', u'X-Capture-That-Too']
 
         with tracer.start_active_span('test'):
             response = self.http.request('GET', self.live_server_url + '/response_with_headers')
 
-        assert response
+        self.assertTrue(response)
         self.assertEqual(200, response.status)
 
         spans = self.recorder.queued_spans()
@@ -345,8 +346,10 @@ class TestDjango(StaticLiveServerTestCase):
         self.assertEqual(200, django_span.data["http"]["status"])
         self.assertEqual('^response_with_headers$', django_span.data["http"]["path_tpl"])
 
-        assert "X-Capture-This-Too" in django_span.data["http"]["header"]
+        self.assertIn("X-Capture-This-Too", django_span.data["http"]["header"])
         self.assertEqual("this too", django_span.data["http"]["header"]["X-Capture-This-Too"])
+        self.assertIn("X-Capture-That-Too", django_span.data["http"]["header"])
+        self.assertEqual("that too", django_span.data["http"]["header"]["X-Capture-That-Too"])
 
         agent.options.extra_http_headers = original_extra_http_headers
 
@@ -359,7 +362,7 @@ class TestDjango(StaticLiveServerTestCase):
 
         response = self.http.request('GET', self.live_server_url + '/', headers=request_headers)
 
-        assert response
+        self.assertTrue(response)
         self.assertEqual(200, response.status)
 
         spans = self.recorder.queued_spans()
@@ -370,29 +373,29 @@ class TestDjango(StaticLiveServerTestCase):
         self.assertEqual(django_span.t, '0000000000000001')
         self.assertEqual(django_span.p, '0000000000000001')
 
-        assert ('X-INSTANA-T' in response.headers)
-        assert (int(response.headers['X-INSTANA-T'], 16))
+        self.assertIn('X-INSTANA-T', response.headers)
+        self.assertTrue(int(response.headers['X-INSTANA-T'], 16))
         self.assertEqual(django_span.t, response.headers['X-INSTANA-T'])
 
-        assert ('X-INSTANA-S' in response.headers)
-        assert (int(response.headers['X-INSTANA-S'], 16))
+        self.assertIn('X-INSTANA-S', response.headers)
+        self.assertTrue(int(response.headers['X-INSTANA-S'], 16))
         self.assertEqual(django_span.s, response.headers['X-INSTANA-S'])
 
-        assert ('X-INSTANA-L' in response.headers)
+        self.assertIn('X-INSTANA-L', response.headers)
         self.assertEqual('1', response.headers['X-INSTANA-L'])
 
-        assert ('traceparent' in response.headers)
+        self.assertIn('traceparent', response.headers)
         # The incoming traceparent header had version 01 (which does not exist at the time of writing), but since we
         # support version 00, we also need to pass down 00 for the version field.
         self.assertEqual('00-4bf92f3577b34da6a3ce929d0e0e4736-{}-01'.format(django_span.s),
                          response.headers['traceparent'])
 
-        assert ('tracestate' in response.headers)
+        self.assertIn('tracestate', response.headers)
         self.assertEqual(
             'in={};{},rojo=00f067aa0ba902b7,congo=t61rcWkgMzE'.format(
                 django_span.t, django_span.s), response.headers['tracestate'])
         server_timing_value = "intid;desc=%s" % django_span.t
-        assert ('Server-Timing' in response.headers)
+        self.assertIn('Server-Timing', response.headers)
         self.assertEqual(server_timing_value, response.headers['Server-Timing'])
 
     def test_with_incoming_context_and_correlation(self):
@@ -405,7 +408,7 @@ class TestDjango(StaticLiveServerTestCase):
 
         response = self.http.request('GET', self.live_server_url + '/', headers=request_headers)
 
-        assert response
+        self.assertTrue(response)
         self.assertEqual(200, response.status)
 
         spans = self.recorder.queued_spans()
@@ -422,27 +425,28 @@ class TestDjango(StaticLiveServerTestCase):
         self.assertEqual(django_span.crtp, 'web')
         self.assertEqual(django_span.crid, '1234567890abcdef')
 
-        assert ('X-INSTANA-T' in response.headers)
-        assert (int(response.headers['X-INSTANA-T'], 16))
+        self.assertIn('X-INSTANA-T', response.headers)
+        self.assertTrue(int(response.headers['X-INSTANA-T'], 16))
         self.assertEqual(django_span.t, response.headers['X-INSTANA-T'])
 
-        assert ('X-INSTANA-S' in response.headers)
-        assert (int(response.headers['X-INSTANA-S'], 16))
+        self.assertIn('X-INSTANA-S', response.headers)
+        self.assertTrue(int(response.headers['X-INSTANA-S'], 16))
         self.assertEqual(django_span.s, response.headers['X-INSTANA-S'])
 
-        assert ('X-INSTANA-L' in response.headers)
+        self.assertIn('X-INSTANA-L', response.headers)
         self.assertEqual('1', response.headers['X-INSTANA-L'])
 
-        assert ('traceparent' in response.headers)
+        self.assertIn('traceparent', response.headers)
         self.assertEqual('00-4bf92f3577b34da6a3ce929d0e0e4736-{}-01'.format(django_span.s),
                          response.headers['traceparent'])
 
-        assert ('tracestate' in response.headers)
+        self.assertIn('tracestate', response.headers)
         self.assertEqual(
             'in={};{},rojo=00f067aa0ba902b7,congo=t61rcWkgMzE'.format(
                 django_span.t, django_span.s), response.headers['tracestate'])
+
         server_timing_value = "intid;desc=%s" % django_span.t
-        assert ('Server-Timing' in response.headers)
+        self.assertIn('Server-Timing', response.headers)
         self.assertEqual(server_timing_value, response.headers['Server-Timing'])
 
     def test_with_incoming_traceparent_tracestate(self):
@@ -452,7 +456,7 @@ class TestDjango(StaticLiveServerTestCase):
 
         response = self.http.request('GET', self.live_server_url + '/', headers=request_headers)
 
-        assert response
+        self.assertTrue(response)
         self.assertEqual(200, response.status)
 
         spans = self.recorder.queued_spans()
@@ -467,28 +471,28 @@ class TestDjango(StaticLiveServerTestCase):
         self.assertEqual(django_span.lt, '4bf92f3577b34da6a3ce929d0e0e4736')
         self.assertEqual(django_span.tp, True)
 
-        assert ('X-INSTANA-T' in response.headers)
-        assert (int(response.headers['X-INSTANA-T'], 16))
+        self.assertIn('X-INSTANA-T', response.headers)
+        self.assertTrue(int(response.headers['X-INSTANA-T'], 16))
         self.assertEqual(django_span.t, response.headers['X-INSTANA-T'])
 
-        assert ('X-INSTANA-S' in response.headers)
-        assert (int(response.headers['X-INSTANA-S'], 16))
+        self.assertIn('X-INSTANA-S', response.headers)
+        self.assertTrue(int(response.headers['X-INSTANA-S'], 16))
         self.assertEqual(django_span.s, response.headers['X-INSTANA-S'])
 
-        assert ('X-INSTANA-L' in response.headers)
+        self.assertIn('X-INSTANA-L', response.headers)
         self.assertEqual('1', response.headers['X-INSTANA-L'])
 
-        assert ('traceparent' in response.headers)
+        self.assertIn('traceparent', response.headers)
         self.assertEqual('00-4bf92f3577b34da6a3ce929d0e0e4736-{}-01'.format(django_span.s),
                          response.headers['traceparent'])
 
-        assert ('tracestate' in response.headers)
+        self.assertIn('tracestate', response.headers)
         self.assertEqual(
             'in=a3ce929d0e0e4736;{},rojo=00f067aa0ba902b7,congo=t61rcWkgMzE'.format(
                 django_span.s), response.headers['tracestate'])
 
         server_timing_value = "intid;desc=%s" % django_span.t
-        assert ('Server-Timing' in response.headers)
+        self.assertIn('Server-Timing', response.headers)
         self.assertEqual(server_timing_value, response.headers['Server-Timing'])
 
     def test_with_incoming_traceparent_tracestate_disable_traceparent(self):
@@ -499,7 +503,7 @@ class TestDjango(StaticLiveServerTestCase):
 
         response = self.http.request('GET', self.live_server_url + '/', headers=request_headers)
 
-        assert response
+        self.assertTrue(response)
         self.assertEqual(200, response.status)
 
         spans = self.recorder.queued_spans()
@@ -510,28 +514,28 @@ class TestDjango(StaticLiveServerTestCase):
         self.assertEqual(django_span.t, 'a3ce929d0e0e4736')  # last 16 chars from traceparent trace_id
         self.assertEqual(django_span.p, '8357ccd9da194656')
 
-        assert ('X-INSTANA-T' in response.headers)
-        assert (int(response.headers['X-INSTANA-T'], 16))
+        self.assertIn('X-INSTANA-T', response.headers)
+        self.assertTrue(int(response.headers['X-INSTANA-T'], 16))
         self.assertEqual(django_span.t, response.headers['X-INSTANA-T'])
 
-        assert ('X-INSTANA-S' in response.headers)
-        assert (int(response.headers['X-INSTANA-S'], 16))
+        self.assertIn('X-INSTANA-S', response.headers)
+        self.assertTrue(int(response.headers['X-INSTANA-S'], 16))
         self.assertEqual(django_span.s, response.headers['X-INSTANA-S'])
 
-        assert ('X-INSTANA-L' in response.headers)
+        self.assertIn('X-INSTANA-L', response.headers)
         self.assertEqual('1', response.headers['X-INSTANA-L'])
 
-        assert ('traceparent' in response.headers)
+        self.assertIn('traceparent', response.headers)
         self.assertEqual('00-4bf92f3577b34da6a3ce929d0e0e4736-{}-01'.format(django_span.s),
                          response.headers['traceparent'])
 
-        assert ('tracestate' in response.headers)
+        self.assertIn('tracestate', response.headers)
         self.assertEqual(
-            'in=a3ce929d0e0e4736;{},rojo=00f067aa0ba902b7,congo=t61rcWkgMzE'.format(
-                django_span.s), response.headers['tracestate'])
+            'in={};{},rojo=00f067aa0ba902b7,congo=t61rcWkgMzE'.format(
+                django_span.t, django_span.s), response.headers['tracestate'])
 
         server_timing_value = "intid;desc=%s" % django_span.t
-        assert ('Server-Timing' in response.headers)
+        self.assertIn('Server-Timing', response.headers)
         self.assertEqual(server_timing_value, response.headers['Server-Timing'])
 
     def test_with_incoming_mixed_case_context(self):
@@ -541,7 +545,7 @@ class TestDjango(StaticLiveServerTestCase):
 
         response = self.http.request('GET', self.live_server_url + '/', headers=request_headers)
 
-        assert response
+        self.assertTrue(response)
         self.assertEqual(200, response.status)
 
         spans = self.recorder.queued_spans()
@@ -552,17 +556,17 @@ class TestDjango(StaticLiveServerTestCase):
         self.assertEqual(django_span.t, '0000000000000001')
         self.assertEqual(django_span.p, '0000000000000001')
 
-        assert ('X-INSTANA-T' in response.headers)
-        assert (int(response.headers['X-INSTANA-T'], 16))
+        self.assertIn('X-INSTANA-T', response.headers)
+        self.assertTrue(int(response.headers['X-INSTANA-T'], 16))
         self.assertEqual(django_span.t, response.headers['X-INSTANA-T'])
 
-        assert ('X-INSTANA-S' in response.headers)
-        assert (int(response.headers['X-INSTANA-S'], 16))
+        self.assertIn('X-INSTANA-S', response.headers)
+        self.assertTrue(int(response.headers['X-INSTANA-S'], 16))
         self.assertEqual(django_span.s, response.headers['X-INSTANA-S'])
 
-        assert ('X-INSTANA-L' in response.headers)
+        self.assertIn('X-INSTANA-L', response.headers)
         self.assertEqual('1', response.headers['X-INSTANA-L'])
 
         server_timing_value = "intid;desc=%s" % django_span.t
-        assert ('Server-Timing' in response.headers)
+        self.assertIn('Server-Timing', response.headers)
         self.assertEqual(server_timing_value, response.headers['Server-Timing'])


### PR DESCRIPTION
Django: capture responseHeadersOnEntrySpans

Signed-off-by: Varsha GS [varsha.gs@ibm.com](mailto:varsha.gs@ibm.com)