### PR TITLE
Enhance boto3 instrumentation to capture HTTP headers in all four flavours

### DIFF
--- a/instana/instrumentation/boto3_inst.py
+++ b/instana/instrumentation/boto3_inst.py
@@ -17,7 +17,7 @@ try:
     from boto3.s3 import inject
 
     def extract_custom_headers(span, headers):
-        if agent.options.extra_http_headers is None:
+        if agent.options.extra_http_headers is None or headers is None:
             return
         try:
             for custom_header in agent.options.extra_http_headers:

--- a/instana/instrumentation/boto3_inst.py
+++ b/instana/instrumentation/boto3_inst.py
@@ -46,16 +46,16 @@ try:
             logger.debug("non-fatal lambda_inject_context: ", exc_info=True)
 
 
-    @wrapt.patch_function_wrapper("botocore.hooks", "HierarchicalEmitter.emit")
-    def emit_request_created_with_instana(wrapped, instance, args, kwargs):
+    @wrapt.patch_function_wrapper("botocore.auth", "SigV4Auth.add_auth")
+    def emit_add_auth_with_instana(wrapped, instance, args, kwargs):
         active_tracer = get_active_tracer()
-        
-        # If we're not tracing or the event emitted is not request-created, just return;
-        if active_tracer is None or args[0].split(".")[0] != "request-created":
+
+        # If we're not tracing, just return;
+        if active_tracer is None:
             return wrapped(*args, **kwargs)
         
         span = active_tracer.active_span
-        extract_custom_headers(span, kwargs["request"].headers)
+        extract_custom_headers(span, args[0].headers)
 
         return wrapped(*args, **kwargs)
 

--- a/tests/clients/boto3/test_boto3_lambda.py
+++ b/tests/clients/boto3/test_boto3_lambda.py
@@ -16,7 +16,7 @@ else:
 from instana.singletons import tracer, agent
 from ...helpers import get_first_span_by_filter
 
-@unittest.skip(version_info < (3, 8), "Test skipped on Python < 3.8")
+@unittest.skipIf(version_info < (3, 8), "Test skipped on Python < 3.8")
 class TestLambda(unittest.TestCase):
     def setUp(self):
         """ Clear all spans before a test run """

--- a/tests/clients/boto3/test_boto3_lambda.py
+++ b/tests/clients/boto3/test_boto3_lambda.py
@@ -10,8 +10,6 @@ import boto3
 from sys import version_info
 if version_info >= (3, 8):
   from moto import mock_aws
-else:
-  from moto import mock_lambda as mock_aws
 
 from instana.singletons import tracer, agent
 from ...helpers import get_first_span_by_filter

--- a/tests/clients/boto3/test_boto3_lambda.py
+++ b/tests/clients/boto3/test_boto3_lambda.py
@@ -21,58 +21,29 @@ from instana.singletons import tracer
 from ...helpers import get_first_span_by_filter
 
 class TestLambda(unittest.TestCase):
-    def _get_role(self):
-        iam = boto3.client("iam", region_name=self.lambda_region)
-        return iam.create_role(
-            RoleName="my-role",
-            AssumeRolePolicyDocument="some policy"
-        )["Role"]["Arn"]
-        
-    def _process_lambda(self, func_str):
-        zip_output = BytesIO()
-        with ZipFile(zip_output, "w") as zip_file:
-            zip_file.writestr("lambda_function.py", func_str)
-        return zip_output.getvalue()
-    
-    def _get_test_zip_file(self):
-        pfunc = """
-def lambda_handler(event, context):
-    print("custom log event")
-    return {"message": "success"}
-"""
-        return self._process_lambda(pfunc)
-
     def setUp(self):
         """ Clear all spans before a test run """
         self.recorder = tracer.recorder
         self.recorder.clear_spans()
-        self.mock = mock_aws()
+        self.mock = mock_aws(config={"lambda": {"use_docker": False}})
         self.mock.start()
         self.lambda_region = "us-east-1"
         self.aws_lambda = boto3.client('lambda', region_name=self.lambda_region)
         self.function_name = "myfunc"
-        self.aws_lambda.create_function(
-            FunctionName=self.function_name,
-            Runtime="python3.9",
-            Role=self._get_role(),
-            Handler="lambda_function.lambda_handler",
-            Code={"ZipFile": self._get_test_zip_file()}
-        )
 
     def tearDown(self):
         # Stop Moto after each test
         self.mock.stop()
 
 
-    @pytest.mark.skip("Lambda mocking requires docker")
     def test_lambda_invoke(self):
         with tracer.start_active_span('test'):
-            result = self.aws_lambda.invoke(FunctionName=self.function_name)
+            result = self.aws_lambda.invoke(FunctionName=self.function_name, Payload=json.dumps({"message": "success"}))
 
         self.assertEqual(result["StatusCode"], 200)
-        payload = json.loads(result["Payload"].read().decode("utf-8"))
-        self.assertIn("message", payload)
-        self.assertEqual("success", payload["message"])
+        result_payload = json.loads(result["Payload"].read().decode("utf-8"))
+        self.assertIn("message", result_payload)
+        self.assertEqual("success", result_payload["message"])
 
         spans = tracer.recorder.queued_spans()
         self.assertEqual(2, len(spans))
@@ -94,7 +65,7 @@ def lambda_handler(event, context):
         self.assertEqual(boto_span.data['boto3']['op'], 'Invoke')
         endpoint = f'https://lambda.{self.lambda_region}.amazonaws.com'
         self.assertEqual(boto_span.data['boto3']['ep'], endpoint)
-        self.assertEqual(boto_span.data['boto3']['reg'], 'us-east-1')
+        self.assertEqual(boto_span.data['boto3']['reg'], self.lambda_region)
         self.assertIn('FunctionName', boto_span.data['boto3']['payload'])
         self.assertEqual(boto_span.data['boto3']['payload']['FunctionName'], self.function_name)
         self.assertEqual(boto_span.data['http']['status'], 200)

--- a/tests/clients/boto3/test_boto3_lambda.py
+++ b/tests/clients/boto3/test_boto3_lambda.py
@@ -2,24 +2,21 @@
 # (c) Copyright Instana Inc. 2020
 
 from __future__ import absolute_import
-from io import BytesIO
-from zipfile import ZipFile
 import unittest
 import json
 
 import boto3
-import pytest
-
 # TODO: Remove branching when we drop support for Python 3.7
-import sys
-if sys.version_info >= (3, 8):
+from sys import version_info
+if version_info >= (3, 8):
   from moto import mock_aws
 else:
   from moto import mock_lambda as mock_aws
 
-from instana.singletons import tracer
+from instana.singletons import tracer, agent
 from ...helpers import get_first_span_by_filter
 
+@unittest.skip(version_info < (3, 8), "Test skipped on Python < 3.8")
 class TestLambda(unittest.TestCase):
     def setUp(self):
         """ Clear all spans before a test run """
@@ -71,3 +68,190 @@ class TestLambda(unittest.TestCase):
         self.assertEqual(boto_span.data['http']['status'], 200)
         self.assertEqual(boto_span.data['http']['method'], 'POST')
         self.assertEqual(boto_span.data['http']['url'], f'{endpoint}:443/Invoke')
+
+
+    def test_request_header_capture_before_call(self):
+        original_extra_http_headers = agent.options.extra_http_headers
+        agent.options.extra_http_headers = ['X-Capture-This', 'X-Capture-That']
+
+        # Access the event system on the S3 client
+        event_system = self.aws_lambda.meta.events
+
+        request_headers = {
+                'X-Capture-This': 'this',
+                'X-Capture-That': 'that'
+            }
+
+        # Create a function that adds custom headers
+        def add_custom_header_before_call(params, **kwargs):
+            params['headers'].update(request_headers)
+
+        # Register the function to before-call event.
+        event_system.register('before-call.lambda.Invoke', add_custom_header_before_call)
+
+        with tracer.start_active_span('test'):
+            result = self.aws_lambda.invoke(FunctionName=self.function_name, Payload=json.dumps({"message": "success"}))
+
+        self.assertEqual(result["StatusCode"], 200)
+        result_payload = json.loads(result["Payload"].read().decode("utf-8"))
+        self.assertIn("message", result_payload)
+        self.assertEqual("success", result_payload["message"])
+
+        spans = tracer.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        filter = lambda span: span.n == "sdk"
+        test_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(test_span)
+
+        filter = lambda span: span.n == "boto3"
+        boto_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(boto_span)
+
+        self.assertEqual(boto_span.t, test_span.t)
+        self.assertEqual(boto_span.p, test_span.s)
+
+        self.assertIsNone(test_span.ec)
+        self.assertIsNone(boto_span.ec)
+
+        self.assertEqual(boto_span.data['boto3']['op'], 'Invoke')
+        endpoint = f'https://lambda.{self.lambda_region}.amazonaws.com'
+        self.assertEqual(boto_span.data['boto3']['ep'], endpoint)
+        self.assertEqual(boto_span.data['boto3']['reg'], self.lambda_region)
+        self.assertIn('FunctionName', boto_span.data['boto3']['payload'])
+        self.assertEqual(boto_span.data['boto3']['payload']['FunctionName'], self.function_name)
+        self.assertEqual(boto_span.data['http']['status'], 200)
+        self.assertEqual(boto_span.data['http']['method'], 'POST')
+        self.assertEqual(boto_span.data['http']['url'], f'{endpoint}:443/Invoke')
+
+        self.assertIn("X-Capture-This", boto_span.data["http"]["header"])
+        self.assertEqual("this", boto_span.data["http"]["header"]["X-Capture-This"])
+        self.assertIn("X-Capture-That", boto_span.data["http"]["header"])
+        self.assertEqual("that", boto_span.data["http"]["header"]["X-Capture-That"])
+            
+        agent.options.extra_http_headers = original_extra_http_headers
+
+
+    def test_request_header_capture_before_sign(self):
+        original_extra_http_headers = agent.options.extra_http_headers
+        agent.options.extra_http_headers = ['X-Custom-1', 'X-Custom-2']
+
+        # Access the event system on the S3 client
+        event_system = self.aws_lambda.meta.events
+
+        request_headers = {
+                'X-Custom-1': 'Value1',
+                'X-Custom-2': 'Value2'
+            }
+
+        # Create a function that adds custom headers
+        def add_custom_header_before_sign(request, **kwargs):
+            for name, value in request_headers.items():
+                request.headers.add_header(name, value)
+
+        # Register the function to before-sign event.
+        event_system.register_first('before-sign.lambda.Invoke', add_custom_header_before_sign)
+
+        with tracer.start_active_span('test'):
+            result = self.aws_lambda.invoke(FunctionName=self.function_name, Payload=json.dumps({"message": "success"}))
+
+        self.assertEqual(result["StatusCode"], 200)
+        result_payload = json.loads(result["Payload"].read().decode("utf-8"))
+        self.assertIn("message", result_payload)
+        self.assertEqual("success", result_payload["message"])
+
+        spans = tracer.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        filter = lambda span: span.n == "sdk"
+        test_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(test_span)
+
+        filter = lambda span: span.n == "boto3"
+        boto_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(boto_span)
+
+        self.assertEqual(boto_span.t, test_span.t)
+        self.assertEqual(boto_span.p, test_span.s)
+
+        self.assertIsNone(test_span.ec)
+        self.assertIsNone(boto_span.ec)
+
+        self.assertEqual(boto_span.data['boto3']['op'], 'Invoke')
+        endpoint = f'https://lambda.{self.lambda_region}.amazonaws.com'
+        self.assertEqual(boto_span.data['boto3']['ep'], endpoint)
+        self.assertEqual(boto_span.data['boto3']['reg'], self.lambda_region)
+        self.assertIn('FunctionName', boto_span.data['boto3']['payload'])
+        self.assertEqual(boto_span.data['boto3']['payload']['FunctionName'], self.function_name)
+        self.assertEqual(boto_span.data['http']['status'], 200)
+        self.assertEqual(boto_span.data['http']['method'], 'POST')
+        self.assertEqual(boto_span.data['http']['url'], f'{endpoint}:443/Invoke')
+
+        self.assertIn("X-Custom-1", boto_span.data["http"]["header"])
+        self.assertEqual("Value1", boto_span.data["http"]["header"]["X-Custom-1"])
+        self.assertIn("X-Custom-2", boto_span.data["http"]["header"])
+        self.assertEqual("Value2", boto_span.data["http"]["header"]["X-Custom-2"])
+            
+        agent.options.extra_http_headers = original_extra_http_headers
+
+
+    def test_response_header_capture(self):
+        original_extra_http_headers = agent.options.extra_http_headers
+        agent.options.extra_http_headers = ['X-Capture-This-Too', 'X-Capture-That-Too']
+
+        # Access the event system on the S3 client
+        event_system = self.aws_lambda.meta.events
+        
+        response_headers = {
+            "X-Capture-This-Too": "this too",
+            "X-Capture-That-Too": "that too",
+        }
+
+        # Create a function that sets the custom headers in the after-call event.
+        def modify_after_call_args(parsed, **kwargs):
+            parsed['ResponseMetadata']['HTTPHeaders'].update(response_headers)
+
+        # Register the function to an event
+        event_system.register('after-call.lambda.Invoke', modify_after_call_args)
+
+        with tracer.start_active_span('test'):
+            result = self.aws_lambda.invoke(FunctionName=self.function_name, Payload=json.dumps({"message": "success"}))
+
+        self.assertEqual(result["StatusCode"], 200)
+        result_payload = json.loads(result["Payload"].read().decode("utf-8"))
+        self.assertIn("message", result_payload)
+        self.assertEqual("success", result_payload["message"])
+
+        spans = tracer.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        filter = lambda span: span.n == "sdk"
+        test_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(test_span)
+
+        filter = lambda span: span.n == "boto3"
+        boto_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(boto_span)
+
+        self.assertEqual(boto_span.t, test_span.t)
+        self.assertEqual(boto_span.p, test_span.s)
+
+        self.assertIsNone(test_span.ec)
+        self.assertIsNone(boto_span.ec)
+
+        self.assertEqual(boto_span.data['boto3']['op'], 'Invoke')
+        endpoint = f'https://lambda.{self.lambda_region}.amazonaws.com'
+        self.assertEqual(boto_span.data['boto3']['ep'], endpoint)
+        self.assertEqual(boto_span.data['boto3']['reg'], self.lambda_region)
+        self.assertIn('FunctionName', boto_span.data['boto3']['payload'])
+        self.assertEqual(boto_span.data['boto3']['payload']['FunctionName'], self.function_name)
+        self.assertEqual(boto_span.data['http']['status'], 200)
+        self.assertEqual(boto_span.data['http']['method'], 'POST')
+        self.assertEqual(boto_span.data['http']['url'], f'{endpoint}:443/Invoke')
+
+        self.assertIn("X-Capture-This-Too", boto_span.data["http"]["header"])
+        self.assertEqual("this too", boto_span.data["http"]["header"]["X-Capture-This-Too"])
+        self.assertIn("X-Capture-That-Too", boto_span.data["http"]["header"])
+        self.assertEqual("that too", boto_span.data["http"]["header"]["X-Capture-That-Too"])
+            
+        agent.options.extra_http_headers = original_extra_http_headers

--- a/tests/clients/boto3/test_boto3_s3.py
+++ b/tests/clients/boto3/test_boto3_s3.py
@@ -14,7 +14,7 @@ if sys.version_info >= (3, 8):
 else:
   from moto import mock_s3 as mock_aws
 
-from instana.singletons import tracer
+from instana.singletons import tracer, agent
 from ...helpers import get_first_span_by_filter
 
 pwd = os.path.dirname(os.path.abspath(__file__))
@@ -95,7 +95,7 @@ def test_s3_list_buckets(s3):
 
     result = s3.list_buckets()
     assert len(result['Buckets']) == 0
-    assert result['ResponseMetadata']['HTTPStatusCode'] is 200
+    assert result['ResponseMetadata']['HTTPStatusCode'] == 200
 
     spans = tracer.recorder.queued_spans()
     assert len(spans) == 2
@@ -276,3 +276,125 @@ def test_s3_download_file_obj(s3):
     assert boto_span.data['boto3']['reg'] == 'us-east-1'
     assert boto_span.data['http']['method'] == 'POST'
     assert boto_span.data['http']['url'] == 'https://s3.amazonaws.com:443/download_fileobj'
+
+
+def test_request_header_capture(s3):
+
+    original_extra_http_headers = agent.options.extra_http_headers
+    agent.options.extra_http_headers = ['X-Capture-This', 'X-Capture-That']
+
+    # Access the event system on the S3 client
+    event_system = s3.meta.events
+
+    request_headers = {
+            'X-Capture-This': 'this',
+            'X-Capture-That': 'that'
+        }
+    
+    # We set the custom headers in the request context instead of params 
+    # because later in the processing of the request, there is a parameter validation step, 
+    # which doesn't allow for custom arguments. 
+    def process_custom_arguments(params, context, **kwargs):
+        if "custom_request_headers" not in context:
+            context["custom_request_headers"] = request_headers
+    
+    event_system.register('before-parameter-build', process_custom_arguments)
+
+    with tracer.start_active_span('test'):
+        result = s3.create_bucket(Bucket="aws_bucket_name")
+   
+    result = s3.list_buckets()
+    assert len(result['Buckets']) == 1
+    assert result['Buckets'][0]['Name'] == 'aws_bucket_name'
+
+    spans = tracer.recorder.queued_spans()
+    assert len(spans) == 2
+
+    filter = lambda span: span.n == "sdk"
+    test_span = get_first_span_by_filter(spans, filter)
+    assert (test_span)
+
+    filter = lambda span: span.n == "boto3"
+    boto_span = get_first_span_by_filter(spans, filter)
+    assert (boto_span)
+
+    assert (boto_span.t == test_span.t)
+    assert (boto_span.p == test_span.s)
+
+    assert (test_span.ec is None)
+    assert (boto_span.ec is None)
+
+    assert boto_span.data['boto3']['op'] == 'CreateBucket'
+    assert boto_span.data['boto3']['ep'] == 'https://s3.amazonaws.com'
+    assert boto_span.data['boto3']['reg'] == 'us-east-1'
+    assert boto_span.data['boto3']['payload'] == {'Bucket': 'aws_bucket_name'}
+    assert boto_span.data['http']['status'] == 200
+    assert boto_span.data['http']['method'] == 'POST'
+    assert boto_span.data['http']['url'] == 'https://s3.amazonaws.com:443/CreateBucket'
+
+    assert ("X-Capture-This" in boto_span.data["http"]["header"])
+    assert ("this" == boto_span.data["http"]["header"]["X-Capture-This"])
+    assert ("X-Capture-That" in boto_span.data["http"]["header"])
+    assert ("that" == boto_span.data["http"]["header"]["X-Capture-That"])
+        
+    agent.options.extra_http_headers = original_extra_http_headers
+
+
+def test_response_header_capture(s3):
+
+    original_extra_http_headers = agent.options.extra_http_headers
+    agent.options.extra_http_headers = ['X-Capture-This-Too', 'X-Capture-That-Too']
+
+    # Access the event system on the S3 client
+    event_system = s3.meta.events
+    
+    response_headers = {
+        "X-Capture-This-Too": "this too",
+        "X-Capture-That-Too": "that too",
+    }
+
+    # Create a function that sets the custom headers in the after-call event.
+    def modify_after_call_args(parsed, **kwargs):
+        parsed['ResponseMetadata']['HTTPHeaders'].update(response_headers)
+
+    # Register the function to an event
+    event_system.register('after-call', modify_after_call_args)
+
+    with tracer.start_active_span('test'):
+        result = s3.create_bucket(Bucket="aws_bucket_name")
+
+    result = s3.list_buckets()
+    assert len(result['Buckets']) == 1
+    assert result['Buckets'][0]['Name'] == 'aws_bucket_name'
+
+    spans = tracer.recorder.queued_spans()
+    assert len(spans) == 2
+
+    filter = lambda span: span.n == "sdk"
+    test_span = get_first_span_by_filter(spans, filter)
+    assert (test_span)
+
+    filter = lambda span: span.n == "boto3"
+    boto_span = get_first_span_by_filter(spans, filter)
+    assert (boto_span)
+
+    assert (boto_span.t == test_span.t)
+    assert (boto_span.p == test_span.s)
+
+    assert (test_span.ec is None)
+    assert (boto_span.ec is None)
+
+    assert boto_span.data['boto3']['op'] == 'CreateBucket'
+    assert boto_span.data['boto3']['ep'] == 'https://s3.amazonaws.com'
+    assert boto_span.data['boto3']['reg'] == 'us-east-1'
+    assert boto_span.data['boto3']['payload'] == {'Bucket': 'aws_bucket_name'}
+    assert boto_span.data['http']['status'] == 200
+    assert boto_span.data['http']['method'] == 'POST'
+    assert boto_span.data['http']['url'] == 'https://s3.amazonaws.com:443/CreateBucket'
+
+    assert ("X-Capture-This-Too" in boto_span.data["http"]["header"])
+    assert ("this too" == boto_span.data["http"]["header"]["X-Capture-This-Too"])
+    assert ("X-Capture-That-Too" in boto_span.data["http"]["header"])
+    assert ("that too" == boto_span.data["http"]["header"]["X-Capture-That-Too"])
+        
+    agent.options.extra_http_headers = original_extra_http_headers

--- a/tests/clients/boto3/test_boto3_s3.py
+++ b/tests/clients/boto3/test_boto3_s3.py
@@ -22,33 +22,17 @@ download_target_filename = os.path.abspath(pwd + '/../../data/boto3/download_tar
 
 
 class TestS3(unittest.TestCase):
-    def set_aws_credentials(self):
-        """ Mocked AWS Credentials for moto """
-        for variable_name in self.variable_names:
-            os.environ[variable_name] = "testing"
-
     def setUp(self):
         """ Clear all spans before a test run """
         self.recorder = tracer.recorder
         self.recorder.clear_spans()
-        self.variable_names = (
-                "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
-                "AWS_SECURITY_TOKEN", "AWS_SESSION_TOKEN"
-                )
-        self.set_aws_credentials()
         self.mock = mock_aws()
         self.mock.start()
         self.s3 = boto3.client('s3', region_name='us-east-1')
 
-    def unset_aws_credentials(self):
-        """ Reset all environment variables of consequence """
-        for variable_name in self.variable_names:
-            os.environ.pop(variable_name, None)
-
     def tearDown(self):
         # Stop Moto after each test
         self.mock.stop()
-        self.unset_aws_credentials()
 
 
     def test_vanilla_create_bucket(self):

--- a/tests/clients/boto3/test_boto3_s3.py
+++ b/tests/clients/boto3/test_boto3_s3.py
@@ -296,8 +296,15 @@ class TestS3(unittest.TestCase):
         def add_custom_header_before_call(params, **kwargs):
             params['headers'].update(request_headers)
 
-        # Register the function to an event.
-        event_system.register('before-call.s3.CreateBucket', add_custom_header_before_call)
+        # # Register the function to before-call event.
+        # event_system.register('before-call.s3.CreateBucket', add_custom_header_before_call)
+
+        def _add_header(request, **kwargs):
+            for name, value in request_headers.items():
+                request.headers.add_header(name, value)
+
+        # Register the function to before-sign event.
+        event_system.register_first('before-sign.s3.CreateBucket', _add_header)
 
         with tracer.start_active_span('test'):
             result = self.s3.create_bucket(Bucket="aws_bucket_name")

--- a/tests/clients/boto3/test_boto3_ses.py
+++ b/tests/clients/boto3/test_boto3_ses.py
@@ -20,33 +20,17 @@ from ...helpers import get_first_span_by_filter
 pwd = os.path.dirname(os.path.abspath(__file__))
 
 class TestSes(unittest.TestCase):
-    def set_aws_credentials(self):
-        """ Mocked AWS Credentials for moto """
-        for variable_name in self.variable_names:
-            os.environ[variable_name] = "testing"
-
     def setUp(self):
         """ Clear all spans before a test run """
         self.recorder = tracer.recorder
         self.recorder.clear_spans()
-        self.variable_names = (
-                "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
-                "AWS_SECURITY_TOKEN", "AWS_SESSION_TOKEN"
-                )
-        self.set_aws_credentials()
         self.mock = mock_aws()
         self.mock.start()
         self.ses = boto3.client('ses', region_name='us-east-1')
 
-    def unset_aws_credentials(self):
-        """ Reset all environment variables of consequence """
-        for variable_name in self.variable_names:
-            os.environ.pop(variable_name, None)
-
     def tearDown(self):
         # Stop Moto after each test
         self.mock.stop()
-        self.unset_aws_credentials()
 
 
     def test_vanilla_verify_email(self):

--- a/tests/clients/boto3/test_boto3_ses.py
+++ b/tests/clients/boto3/test_boto3_ses.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 import os
 import boto3
-import pytest
+import unittest
 
 # TODO: Remove branching when we drop support for Python 3.7
 import sys
@@ -14,66 +14,248 @@ if sys.version_info >= (3, 8):
 else:
   from moto import mock_ses as mock_aws
 
-from instana.singletons import tracer
+from instana.singletons import tracer, agent
 from ...helpers import get_first_span_by_filter
 
 pwd = os.path.dirname(os.path.abspath(__file__))
 
-def setup_method():
-    """ Clear all spans before a test run """
-    tracer.recorder.clear_spans()
+class TestSes(unittest.TestCase):
+    def set_aws_credentials(self):
+        """ Mocked AWS Credentials for moto """
+        for variable_name in self.variable_names:
+            os.environ[variable_name] = "testing"
+
+    def setUp(self):
+        """ Clear all spans before a test run """
+        self.recorder = tracer.recorder
+        self.recorder.clear_spans()
+        self.variable_names = (
+                "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+                "AWS_SECURITY_TOKEN", "AWS_SESSION_TOKEN"
+                )
+        self.set_aws_credentials()
+        self.mock = mock_aws()
+        self.mock.start()
+        self.ses = boto3.client('ses', region_name='us-east-1')
+
+    def unset_aws_credentials(self):
+        """ Reset all environment variables of consequence """
+        for variable_name in self.variable_names:
+            os.environ.pop(variable_name, None)
+
+    def tearDown(self):
+        # Stop Moto after each test
+        self.mock.stop()
+        self.unset_aws_credentials()
 
 
-@pytest.fixture(scope='function')
-def aws_credentials():
-    """Mocked AWS Credentials for moto."""
-    os.environ['AWS_ACCESS_KEY_ID'] = 'testing'
-    os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
-    os.environ['AWS_SECURITY_TOKEN'] = 'testing'
-    os.environ['AWS_SESSION_TOKEN'] = 'testing'
+    def test_vanilla_verify_email(self):
+        result = self.ses.verify_email_identity(EmailAddress='pglombardo+instana299@tuta.io')
+        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 200)
 
 
-@pytest.fixture(scope='function')
-def ses(aws_credentials):
-    with mock_aws():
-        yield boto3.client('ses', region_name='us-east-1')
+    def test_verify_email(self):
+        with tracer.start_active_span('test'):
+            result = self.ses.verify_email_identity(EmailAddress='pglombardo+instana299@tuta.io')
+
+        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 200)
+
+        spans = tracer.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        filter = lambda span: span.n == "sdk"
+        test_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(test_span)
+
+        filter = lambda span: span.n == "boto3"
+        boto_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(boto_span)
+
+        self.assertEqual(boto_span.t, test_span.t)
+        self.assertEqual(boto_span.p, test_span.s)
+
+        self.assertIsNone(test_span.ec)
+
+        self.assertEqual(boto_span.data['boto3']['op'], 'VerifyEmailIdentity')
+        self.assertEqual(boto_span.data['boto3']['ep'], 'https://email.us-east-1.amazonaws.com')
+        self.assertEqual(boto_span.data['boto3']['reg'], 'us-east-1')
+        self.assertDictEqual(boto_span.data['boto3']['payload'], {'EmailAddress': 'pglombardo+instana299@tuta.io'})
+
+        self.assertEqual(boto_span.data['http']['status'], 200)
+        self.assertEqual(boto_span.data['http']['method'], 'POST')
+        self.assertEqual(boto_span.data['http']['url'], 'https://email.us-east-1.amazonaws.com:443/VerifyEmailIdentity')
 
 
-def test_vanilla_verify_email(ses):
-    result = ses.verify_email_identity(EmailAddress='pglombardo+instana299@tuta.io')
-    assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+    def test_request_header_capture_before_call(self):
+
+        original_extra_http_headers = agent.options.extra_http_headers
+        agent.options.extra_http_headers = ['X-Capture-This', 'X-Capture-That']
+
+        # Access the event system on the S3 client
+        event_system = self.ses.meta.events
+
+        request_headers = {
+                'X-Capture-This': 'this',
+                'X-Capture-That': 'that'
+            }
+
+        # Create a function that adds custom headers
+        def add_custom_header_before_call(params, **kwargs):
+            params['headers'].update(request_headers)
+
+        # Register the function to before-call event.
+        event_system.register('before-call.ses.VerifyEmailIdentity', add_custom_header_before_call)
+
+        with tracer.start_active_span('test'):
+            result = self.ses.verify_email_identity(EmailAddress='pglombardo+instana299@tuta.io')
+
+        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 200)
+
+        spans = tracer.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        filter = lambda span: span.n == "sdk"
+        test_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(test_span)
+
+        filter = lambda span: span.n == "boto3"
+        boto_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(boto_span)
+
+        self.assertEqual(boto_span.t, test_span.t)
+        self.assertEqual(boto_span.p, test_span.s)
+
+        self.assertIsNone(test_span.ec)
+
+        self.assertEqual(boto_span.data['boto3']['op'], 'VerifyEmailIdentity')
+        self.assertEqual(boto_span.data['boto3']['ep'], 'https://email.us-east-1.amazonaws.com')
+        self.assertEqual(boto_span.data['boto3']['reg'], 'us-east-1')
+        self.assertDictEqual(boto_span.data['boto3']['payload'], {'EmailAddress': 'pglombardo+instana299@tuta.io'})
+
+        self.assertEqual(boto_span.data['http']['status'], 200)
+        self.assertEqual(boto_span.data['http']['method'], 'POST')
+        self.assertEqual(boto_span.data['http']['url'], 'https://email.us-east-1.amazonaws.com:443/VerifyEmailIdentity')
+
+        self.assertIn("X-Capture-This", boto_span.data["http"]["header"])
+        self.assertEqual("this", boto_span.data["http"]["header"]["X-Capture-This"])
+        self.assertIn("X-Capture-That", boto_span.data["http"]["header"])
+        self.assertEqual("that", boto_span.data["http"]["header"]["X-Capture-That"])
+            
+        agent.options.extra_http_headers = original_extra_http_headers
 
 
-def test_verify_email(ses):
-    result = None
+    def test_request_header_capture_before_sign(self):
 
-    with tracer.start_active_span('test'):
-        result = ses.verify_email_identity(EmailAddress='pglombardo+instana299@tuta.io')
+        original_extra_http_headers = agent.options.extra_http_headers
+        agent.options.extra_http_headers = ['X-Custom-1', 'X-Custom-2']
 
-    assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        # Access the event system on the S3 client
+        event_system = self.ses.meta.events
 
-    spans = tracer.recorder.queued_spans()
-    assert len(spans) == 2
+        request_headers = {
+                'X-Custom-1': 'Value1',
+                'X-Custom-2': 'Value2'
+            }
 
-    filter = lambda span: span.n == "sdk"
-    test_span = get_first_span_by_filter(spans, filter)
-    assert(test_span)
+        # Create a function that adds custom headers
+        def add_custom_header_before_sign(request, **kwargs):
+            for name, value in request_headers.items():
+                request.headers.add_header(name, value)
 
-    filter = lambda span: span.n == "boto3"
-    boto_span = get_first_span_by_filter(spans, filter)
-    assert(boto_span)
+        # Register the function to before-sign event.
+        event_system.register_first('before-sign.ses.VerifyEmailIdentity', add_custom_header_before_sign)
 
-    assert(boto_span.t == test_span.t)
-    assert(boto_span.p == test_span.s)
+        with tracer.start_active_span('test'):
+            result = self.ses.verify_email_identity(EmailAddress='pglombardo+instana299@tuta.io')
 
-    assert(test_span.ec is None)
-    assert(boto_span.ec is None)
+        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 200)
 
-    assert boto_span.data['boto3']['op'] == 'VerifyEmailIdentity'
-    assert boto_span.data['boto3']['ep'] == 'https://email.us-east-1.amazonaws.com'
-    assert boto_span.data['boto3']['reg'] == 'us-east-1'
-    assert boto_span.data['boto3']['payload'] == {'EmailAddress': 'pglombardo+instana299@tuta.io'}
-   
-    assert boto_span.data['http']['status'] == 200
-    assert boto_span.data['http']['method'] == 'POST'
-    assert boto_span.data['http']['url'] == 'https://email.us-east-1.amazonaws.com:443/VerifyEmailIdentity'
+        spans = tracer.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        filter = lambda span: span.n == "sdk"
+        test_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(test_span)
+
+        filter = lambda span: span.n == "boto3"
+        boto_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(boto_span)
+
+        self.assertEqual(boto_span.t, test_span.t)
+        self.assertEqual(boto_span.p, test_span.s)
+
+        self.assertIsNone(test_span.ec)
+
+        self.assertEqual(boto_span.data['boto3']['op'], 'VerifyEmailIdentity')
+        self.assertEqual(boto_span.data['boto3']['ep'], 'https://email.us-east-1.amazonaws.com')
+        self.assertEqual(boto_span.data['boto3']['reg'], 'us-east-1')
+        self.assertDictEqual(boto_span.data['boto3']['payload'], {'EmailAddress': 'pglombardo+instana299@tuta.io'})
+
+        self.assertEqual(boto_span.data['http']['status'], 200)
+        self.assertEqual(boto_span.data['http']['method'], 'POST')
+        self.assertEqual(boto_span.data['http']['url'], 'https://email.us-east-1.amazonaws.com:443/VerifyEmailIdentity')
+
+        self.assertIn("X-Custom-1", boto_span.data["http"]["header"])
+        self.assertEqual("Value1", boto_span.data["http"]["header"]["X-Custom-1"])
+        self.assertIn("X-Custom-2", boto_span.data["http"]["header"])
+        self.assertEqual("Value2", boto_span.data["http"]["header"]["X-Custom-2"])
+            
+        agent.options.extra_http_headers = original_extra_http_headers
+
+
+    def test_response_header_capture(self):
+
+        original_extra_http_headers = agent.options.extra_http_headers
+        agent.options.extra_http_headers = ['X-Capture-This-Too', 'X-Capture-That-Too']
+
+        # Access the event system on the S3 client
+        event_system = self.ses.meta.events
+        
+        response_headers = {
+            "X-Capture-This-Too": "this too",
+            "X-Capture-That-Too": "that too",
+        }
+
+        # Create a function that sets the custom headers in the after-call event.
+        def modify_after_call_args(parsed, **kwargs):
+            parsed['ResponseMetadata']['HTTPHeaders'].update(response_headers)
+
+        # Register the function to an event
+        event_system.register('after-call.ses.VerifyEmailIdentity', modify_after_call_args)
+
+        with tracer.start_active_span('test'):
+            result = self.ses.verify_email_identity(EmailAddress='pglombardo+instana299@tuta.io')
+
+        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 200)
+
+        spans = tracer.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        filter = lambda span: span.n == "sdk"
+        test_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(test_span)
+
+        filter = lambda span: span.n == "boto3"
+        boto_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(boto_span)
+
+        self.assertEqual(boto_span.t, test_span.t)
+        self.assertEqual(boto_span.p, test_span.s)
+
+        self.assertIsNone(test_span.ec)
+
+        self.assertEqual(boto_span.data['boto3']['op'], 'VerifyEmailIdentity')
+        self.assertEqual(boto_span.data['boto3']['ep'], 'https://email.us-east-1.amazonaws.com')
+        self.assertEqual(boto_span.data['boto3']['reg'], 'us-east-1')
+        self.assertDictEqual(boto_span.data['boto3']['payload'], {'EmailAddress': 'pglombardo+instana299@tuta.io'})
+
+        self.assertEqual(boto_span.data['http']['status'], 200)
+        self.assertEqual(boto_span.data['http']['method'], 'POST')
+        self.assertEqual(boto_span.data['http']['url'], 'https://email.us-east-1.amazonaws.com:443/VerifyEmailIdentity')
+
+        self.assertIn("X-Capture-This-Too", boto_span.data["http"]["header"])
+        self.assertEqual("this too", boto_span.data["http"]["header"]["X-Capture-This-Too"])
+        self.assertIn("X-Capture-That-Too", boto_span.data["http"]["header"])
+        self.assertEqual("that too", boto_span.data["http"]["header"]["X-Capture-That-Too"])
+            
+        agent.options.extra_http_headers = original_extra_http_headers

--- a/tests/clients/boto3/test_boto3_sqs.py
+++ b/tests/clients/boto3/test_boto3_sqs.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 import os
 import boto3
-import pytest
+import unittest
 import urllib3
 
 # TODO: Remove branching when we drop support for Python 3.7
@@ -16,144 +16,400 @@ else:
   from moto import mock_sqs as mock_aws
 
 import tests.apps.flask_app
-from instana.singletons import tracer
+from instana.singletons import tracer, agent
 from ...helpers import get_first_span_by_filter, testenv
 
 pwd = os.path.dirname(os.path.abspath(__file__))
 
 
-def setup_method():
-    """ Clear all spans before a test run """
-    tracer.recorder.clear_spans()
+class TestSqs(unittest.TestCase):
+    def set_aws_credentials(self):
+        """ Mocked AWS Credentials for moto """
+        for variable_name in self.variable_names:
+            os.environ[variable_name] = "testing"
+
+    def setUp(self):
+        """ Clear all spans before a test run """
+        self.recorder = tracer.recorder
+        self.recorder.clear_spans()
+        self.variable_names = (
+                "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+                "AWS_SECURITY_TOKEN", "AWS_SESSION_TOKEN"
+                )
+        self.set_aws_credentials()
+        self.mock = mock_aws()
+        self.mock.start()
+        self.sqs = boto3.client('sqs', region_name='us-east-1')
+        self.http_client = urllib3.PoolManager()
+
+    def unset_aws_credentials(self):
+        """ Reset all environment variables of consequence """
+        for variable_name in self.variable_names:
+            os.environ.pop(variable_name, None)
+
+    def tearDown(self):
+        # Stop Moto after each test
+        self.mock.stop()
+        self.unset_aws_credentials()
 
 
-@pytest.fixture(scope='function')
-def aws_credentials():
-    """Mocked AWS Credentials for moto."""
-    os.environ['AWS_ACCESS_KEY_ID'] = 'testing'
-    os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
-    os.environ['AWS_SECURITY_TOKEN'] = 'testing'
-    os.environ['AWS_SESSION_TOKEN'] = 'testing'
+    def test_vanilla_create_queue(self):
+        result = self.sqs.create_queue(
+            QueueName='SQS_QUEUE_NAME',
+            Attributes={
+                'DelaySeconds': '60',
+                'MessageRetentionPeriod': '86400'
+            })
+        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 200)
 
 
-@pytest.fixture(scope='function')
-def http_client():
-    yield urllib3.PoolManager()
-
-
-@pytest.fixture(scope='function')
-def sqs(aws_credentials):
-    with mock_aws():
-        yield boto3.client('sqs', region_name='us-east-1')
-
-
-def test_vanilla_create_queue(sqs):
-    result = sqs.create_queue(
-        QueueName='SQS_QUEUE_NAME',
-        Attributes={
-            'DelaySeconds': '60',
-            'MessageRetentionPeriod': '86400'
-        })
-    assert result['ResponseMetadata']['HTTPStatusCode'] == 200
-
-
-def test_send_message(sqs):
-    response = None
-
-    # Create the Queue:
-    response = sqs.create_queue(
-        QueueName='SQS_QUEUE_NAME',
-        Attributes={
-            'DelaySeconds': '60',
-            'MessageRetentionPeriod': '600'
-        }
-    )
-    assert response['QueueUrl']
-    queue_url = response['QueueUrl']
-
-    with tracer.start_active_span('test'):
-        response = sqs.send_message(
-            QueueUrl=queue_url,
-            DelaySeconds=10,
-            MessageAttributes={
-                'Website': {
-                    'DataType': 'String',
-                    'StringValue': 'https://www.instana.com'
-                },
-            },
-            MessageBody=('Monitor any application, service, or request '
-                         'with Instana Application Performance Monitoring')
+    def test_send_message(self):
+        # Create the Queue:
+        response = self.sqs.create_queue(
+            QueueName='SQS_QUEUE_NAME',
+            Attributes={
+                'DelaySeconds': '60',
+                'MessageRetentionPeriod': '600'
+            }
         )
 
-    assert response['MessageId']
+        self.assertTrue(response['QueueUrl'])
+        queue_url = response['QueueUrl']
 
-    spans = tracer.recorder.queued_spans()
-    assert len(spans) == 2
+        with tracer.start_active_span('test'):
+            response = self.sqs.send_message(
+                QueueUrl=queue_url,
+                DelaySeconds=10,
+                MessageAttributes={
+                    'Website': {
+                        'DataType': 'String',
+                        'StringValue': 'https://www.instana.com'
+                    },
+                },
+                MessageBody=('Monitor any application, service, or request '
+                            'with Instana Application Performance Monitoring')
+            )
 
-    filter = lambda span: span.n == "sdk"
-    test_span = get_first_span_by_filter(spans, filter)
-    assert (test_span)
+        self.assertTrue(response['MessageId'])
 
-    filter = lambda span: span.n == "boto3"
-    boto_span = get_first_span_by_filter(spans, filter)
-    assert (boto_span)
+        spans = tracer.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
 
-    assert (boto_span.t == test_span.t)
-    assert (boto_span.p == test_span.s)
+        filter = lambda span: span.n == "sdk"
+        test_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(test_span)
 
-    assert (test_span.ec is None)
-    assert (boto_span.ec is None)
+        filter = lambda span: span.n == "boto3"
+        boto_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(boto_span)
 
-    assert boto_span.data['boto3']['op'] == 'SendMessage'
-    assert boto_span.data['boto3']['ep'] == 'https://sqs.us-east-1.amazonaws.com'
-    assert boto_span.data['boto3']['reg'] == 'us-east-1'
+        self.assertEqual(boto_span.t, test_span.t)
+        self.assertEqual(boto_span.p, test_span.s)
 
-    payload = {'QueueUrl': 'https://sqs.us-east-1.amazonaws.com/123456789012/SQS_QUEUE_NAME', 'DelaySeconds': 10,
-               'MessageAttributes': {'Website': {'DataType': 'String', 'StringValue': 'https://www.instana.com'}},
-               'MessageBody': 'Monitor any application, service, or request with Instana Application Performance Monitoring'}
-    assert boto_span.data['boto3']['payload'] == payload
+        self.assertIsNone(test_span.ec)
 
-    assert boto_span.data['http']['status'] == 200
-    assert boto_span.data['http']['method'] == 'POST'
-    assert boto_span.data['http']['url'] == 'https://sqs.us-east-1.amazonaws.com:443/SendMessage'
+        self.assertEqual(boto_span.data['boto3']['op'], 'SendMessage')
+        self.assertEqual(boto_span.data['boto3']['ep'], 'https://sqs.us-east-1.amazonaws.com')
+        self.assertEqual(boto_span.data['boto3']['reg'], 'us-east-1')
+
+        payload = {'QueueUrl': 'https://sqs.us-east-1.amazonaws.com/123456789012/SQS_QUEUE_NAME', 'DelaySeconds': 10,
+                'MessageAttributes': {'Website': {'DataType': 'String', 'StringValue': 'https://www.instana.com'}},
+                'MessageBody': 'Monitor any application, service, or request with Instana Application Performance Monitoring'}
+        self.assertDictEqual(boto_span.data['boto3']['payload'], payload)
+
+        self.assertEqual(boto_span.data['http']['status'], 200)
+        self.assertEqual(boto_span.data['http']['method'], 'POST')
+        self.assertEqual(boto_span.data['http']['url'], 'https://sqs.us-east-1.amazonaws.com:443/SendMessage')
 
 
-@mock_aws
-def test_app_boto3_sqs(http_client):
-    with tracer.start_active_span('test'):
-        response = http_client.request('GET', testenv["wsgi_server"] + '/boto3/sqs')
+    def test_app_boto3_sqs(self):
+        with tracer.start_active_span('test'):
+            self.http_client.request('GET', testenv["wsgi_server"] + '/boto3/sqs')
 
-    spans = tracer.recorder.queued_spans()
-    assert len(spans) == 5
+        spans = tracer.recorder.queued_spans()
+        self.assertEqual(5, len(spans))
 
-    filter = lambda span: span.n == "sdk"
-    test_span = get_first_span_by_filter(spans, filter)
-    assert test_span
+        filter = lambda span: span.n == "sdk"
+        test_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(test_span)
 
-    filter = lambda span: span.n == "urllib3"
-    http_span = get_first_span_by_filter(spans, filter)
-    assert http_span
+        filter = lambda span: span.n == "urllib3"
+        http_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(http_span)
 
-    filter = lambda span: span.n == "wsgi"
-    wsgi_span = get_first_span_by_filter(spans, filter)
-    assert wsgi_span
+        filter = lambda span: span.n == "wsgi"
+        wsgi_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(wsgi_span)
 
-    filter = lambda span: span.n == "boto3" and span.data['boto3']['op'] == 'CreateQueue'
-    bcq_span = get_first_span_by_filter(spans, filter)
-    assert bcq_span
+        filter = lambda span: span.n == "boto3" and span.data['boto3']['op'] == 'CreateQueue'
+        bcq_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(bcq_span)
 
-    filter = lambda span: span.n == "boto3" and span.data['boto3']['op'] == 'SendMessage'
-    bsm_span = get_first_span_by_filter(spans, filter)
-    assert bsm_span
+        filter = lambda span: span.n == "boto3" and span.data['boto3']['op'] == 'SendMessage'
+        bsm_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(bsm_span)
 
-    assert http_span.t == test_span.t
-    assert http_span.p == test_span.s
+        self.assertEqual(http_span.t, test_span.t)
+        self.assertEqual(http_span.p, test_span.s)
 
-    assert wsgi_span.t == test_span.t
-    assert wsgi_span.p == http_span.s
+        self.assertEqual(wsgi_span.t, test_span.t)
+        self.assertEqual(wsgi_span.p, http_span.s)
 
-    assert bcq_span.t == test_span.t
-    assert bcq_span.p == wsgi_span.s
+        self.assertEqual(bcq_span.t, test_span.t)
+        self.assertEqual(bcq_span.p, wsgi_span.s)
 
-    assert bsm_span.t == test_span.t
-    assert bsm_span.p == wsgi_span.s
+        self.assertEqual(bsm_span.t, test_span.t)
+        self.assertEqual(bsm_span.p, wsgi_span.s)
+
+
+    def test_request_header_capture_before_call(self):
+        # Create the Queue:
+        response = self.sqs.create_queue(
+            QueueName='SQS_QUEUE_NAME',
+            Attributes={
+                'DelaySeconds': '60',
+                'MessageRetentionPeriod': '600'
+            }
+        )
+
+        self.assertTrue(response['QueueUrl'])
+
+        original_extra_http_headers = agent.options.extra_http_headers
+        agent.options.extra_http_headers = ['X-Capture-This', 'X-Capture-That']
+
+        # Access the event system on the S3 client
+        event_system = self.sqs.meta.events
+
+        request_headers = {
+                'X-Capture-This': 'this',
+                'X-Capture-That': 'that'
+            }
+
+        # Create a function that adds custom headers
+        def add_custom_header_before_call(params, **kwargs):
+            params['headers'].update(request_headers)
+
+        # Register the function to before-call event.
+        event_system.register('before-call.sqs.SendMessage', add_custom_header_before_call)
+
+        queue_url = response['QueueUrl']
+        with tracer.start_active_span('test'):
+            response = self.sqs.send_message(
+                QueueUrl=queue_url,
+                DelaySeconds=10,
+                MessageAttributes={
+                    'Website': {
+                        'DataType': 'String',
+                        'StringValue': 'https://www.instana.com'
+                    },
+                },
+                MessageBody=('Monitor any application, service, or request '
+                            'with Instana Application Performance Monitoring')
+            )
+
+        self.assertTrue(response['MessageId'])
+
+        spans = tracer.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        filter = lambda span: span.n == "sdk"
+        test_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(test_span)
+
+        filter = lambda span: span.n == "boto3"
+        boto_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(boto_span)
+
+        self.assertEqual(boto_span.t, test_span.t)
+        self.assertEqual(boto_span.p, test_span.s)
+
+        self.assertIsNone(test_span.ec)
+
+        self.assertEqual(boto_span.data['boto3']['op'], 'SendMessage')
+        self.assertEqual(boto_span.data['boto3']['ep'], 'https://sqs.us-east-1.amazonaws.com')
+        self.assertEqual(boto_span.data['boto3']['reg'], 'us-east-1')
+
+        payload = {'QueueUrl': 'https://sqs.us-east-1.amazonaws.com/123456789012/SQS_QUEUE_NAME', 'DelaySeconds': 10,
+                'MessageAttributes': {'Website': {'DataType': 'String', 'StringValue': 'https://www.instana.com'}},
+                'MessageBody': 'Monitor any application, service, or request with Instana Application Performance Monitoring'}
+        self.assertDictEqual(boto_span.data['boto3']['payload'], payload)
+
+        self.assertEqual(boto_span.data['http']['status'], 200)
+        self.assertEqual(boto_span.data['http']['method'], 'POST')
+        self.assertEqual(boto_span.data['http']['url'], 'https://sqs.us-east-1.amazonaws.com:443/SendMessage')
+
+        self.assertIn("X-Capture-This", boto_span.data["http"]["header"])
+        self.assertEqual("this", boto_span.data["http"]["header"]["X-Capture-This"])
+        self.assertIn("X-Capture-That", boto_span.data["http"]["header"])
+        self.assertEqual("that", boto_span.data["http"]["header"]["X-Capture-That"])
+            
+        agent.options.extra_http_headers = original_extra_http_headers
+
+
+    def test_request_header_capture_before_sign(self):
+        # Create the Queue:
+        response = self.sqs.create_queue(
+            QueueName='SQS_QUEUE_NAME',
+            Attributes={
+                'DelaySeconds': '60',
+                'MessageRetentionPeriod': '600'
+            }
+        )
+
+        self.assertTrue(response['QueueUrl'])
+
+        original_extra_http_headers = agent.options.extra_http_headers
+        agent.options.extra_http_headers = ['X-Custom-1', 'X-Custom-2']
+
+        # Access the event system on the S3 client
+        event_system = self.sqs.meta.events
+
+        request_headers = {
+                'X-Custom-1': 'Value1',
+                'X-Custom-2': 'Value2'
+            }
+
+        # Create a function that adds custom headers
+        def add_custom_header_before_sign(request, **kwargs):
+            for name, value in request_headers.items():
+                request.headers.add_header(name, value)
+
+        # Register the function to before-sign event.
+        event_system.register_first('before-sign.sqs.SendMessage', add_custom_header_before_sign)
+
+        queue_url = response['QueueUrl']
+        with tracer.start_active_span('test'):
+            response = self.sqs.send_message(
+                QueueUrl=queue_url,
+                DelaySeconds=10,
+                MessageAttributes={
+                    'Website': {
+                        'DataType': 'String',
+                        'StringValue': 'https://www.instana.com'
+                    },
+                },
+                MessageBody=('Monitor any application, service, or request '
+                            'with Instana Application Performance Monitoring')
+            )
+
+        self.assertTrue(response['MessageId'])
+
+        spans = tracer.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        filter = lambda span: span.n == "sdk"
+        test_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(test_span)
+
+        filter = lambda span: span.n == "boto3"
+        boto_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(boto_span)
+
+        self.assertEqual(boto_span.t, test_span.t)
+        self.assertEqual(boto_span.p, test_span.s)
+
+        self.assertIsNone(test_span.ec)
+
+        self.assertEqual(boto_span.data['boto3']['op'], 'SendMessage')
+        self.assertEqual(boto_span.data['boto3']['ep'], 'https://sqs.us-east-1.amazonaws.com')
+        self.assertEqual(boto_span.data['boto3']['reg'], 'us-east-1')
+
+        payload = {'QueueUrl': 'https://sqs.us-east-1.amazonaws.com/123456789012/SQS_QUEUE_NAME', 'DelaySeconds': 10,
+                'MessageAttributes': {'Website': {'DataType': 'String', 'StringValue': 'https://www.instana.com'}},
+                'MessageBody': 'Monitor any application, service, or request with Instana Application Performance Monitoring'}
+        self.assertDictEqual(boto_span.data['boto3']['payload'], payload)
+
+        self.assertEqual(boto_span.data['http']['status'], 200)
+        self.assertEqual(boto_span.data['http']['method'], 'POST')
+        self.assertEqual(boto_span.data['http']['url'], 'https://sqs.us-east-1.amazonaws.com:443/SendMessage')
+
+        self.assertIn("X-Custom-1", boto_span.data["http"]["header"])
+        self.assertEqual("Value1", boto_span.data["http"]["header"]["X-Custom-1"])
+        self.assertIn("X-Custom-2", boto_span.data["http"]["header"])
+        self.assertEqual("Value2", boto_span.data["http"]["header"]["X-Custom-2"])
+            
+        agent.options.extra_http_headers = original_extra_http_headers
+
+
+    def test_response_header_capture(self):
+        # Create the Queue:
+        response = self.sqs.create_queue(
+            QueueName='SQS_QUEUE_NAME',
+            Attributes={
+                'DelaySeconds': '60',
+                'MessageRetentionPeriod': '600'
+            }
+        )
+
+        self.assertTrue(response['QueueUrl'])
+
+        original_extra_http_headers = agent.options.extra_http_headers
+        agent.options.extra_http_headers = ['X-Capture-This-Too', 'X-Capture-That-Too']
+
+        # Access the event system on the S3 client
+        event_system = self.sqs.meta.events
+        
+        response_headers = {
+            "X-Capture-This-Too": "this too",
+            "X-Capture-That-Too": "that too",
+        }
+
+        # Create a function that sets the custom headers in the after-call event.
+        def modify_after_call_args(parsed, **kwargs):
+            parsed['ResponseMetadata']['HTTPHeaders'].update(response_headers)
+
+        # Register the function to an event
+        event_system.register('after-call.sqs.SendMessage', modify_after_call_args)
+
+        queue_url = response['QueueUrl']
+        with tracer.start_active_span('test'):
+            response = self.sqs.send_message(
+                QueueUrl=queue_url,
+                DelaySeconds=10,
+                MessageAttributes={
+                    'Website': {
+                        'DataType': 'String',
+                        'StringValue': 'https://www.instana.com'
+                    },
+                },
+                MessageBody=('Monitor any application, service, or request '
+                            'with Instana Application Performance Monitoring')
+            )
+
+        self.assertTrue(response['MessageId'])
+
+        spans = tracer.recorder.queued_spans()
+        self.assertEqual(2, len(spans))
+
+        filter = lambda span: span.n == "sdk"
+        test_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(test_span)
+
+        filter = lambda span: span.n == "boto3"
+        boto_span = get_first_span_by_filter(spans, filter)
+        self.assertTrue(boto_span)
+
+        self.assertEqual(boto_span.t, test_span.t)
+        self.assertEqual(boto_span.p, test_span.s)
+
+        self.assertIsNone(test_span.ec)
+
+        self.assertEqual(boto_span.data['boto3']['op'], 'SendMessage')
+        self.assertEqual(boto_span.data['boto3']['ep'], 'https://sqs.us-east-1.amazonaws.com')
+        self.assertEqual(boto_span.data['boto3']['reg'], 'us-east-1')
+
+        payload = {'QueueUrl': 'https://sqs.us-east-1.amazonaws.com/123456789012/SQS_QUEUE_NAME', 'DelaySeconds': 10,
+                'MessageAttributes': {'Website': {'DataType': 'String', 'StringValue': 'https://www.instana.com'}},
+                'MessageBody': 'Monitor any application, service, or request with Instana Application Performance Monitoring'}
+        self.assertDictEqual(boto_span.data['boto3']['payload'], payload)
+
+        self.assertEqual(boto_span.data['http']['status'], 200)
+        self.assertEqual(boto_span.data['http']['method'], 'POST')
+        self.assertEqual(boto_span.data['http']['url'], 'https://sqs.us-east-1.amazonaws.com:443/SendMessage')
+
+        self.assertIn("X-Capture-This-Too", boto_span.data["http"]["header"])
+        self.assertEqual("this too", boto_span.data["http"]["header"]["X-Capture-This-Too"])
+        self.assertIn("X-Capture-That-Too", boto_span.data["http"]["header"])
+        self.assertEqual("that too", boto_span.data["http"]["header"]["X-Capture-That-Too"])
+            
+        agent.options.extra_http_headers = original_extra_http_headers

--- a/tests/clients/boto3/test_boto3_sqs.py
+++ b/tests/clients/boto3/test_boto3_sqs.py
@@ -23,34 +23,18 @@ pwd = os.path.dirname(os.path.abspath(__file__))
 
 
 class TestSqs(unittest.TestCase):
-    def set_aws_credentials(self):
-        """ Mocked AWS Credentials for moto """
-        for variable_name in self.variable_names:
-            os.environ[variable_name] = "testing"
-
     def setUp(self):
         """ Clear all spans before a test run """
         self.recorder = tracer.recorder
         self.recorder.clear_spans()
-        self.variable_names = (
-                "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
-                "AWS_SECURITY_TOKEN", "AWS_SESSION_TOKEN"
-                )
-        self.set_aws_credentials()
         self.mock = mock_aws()
         self.mock.start()
         self.sqs = boto3.client('sqs', region_name='us-east-1')
         self.http_client = urllib3.PoolManager()
 
-    def unset_aws_credentials(self):
-        """ Reset all environment variables of consequence """
-        for variable_name in self.variable_names:
-            os.environ.pop(variable_name, None)
-
     def tearDown(self):
         # Stop Moto after each test
         self.mock.stop()
-        self.unset_aws_credentials()
 
 
     def test_vanilla_create_queue(self):


### PR DESCRIPTION
## What

Enhance boto3 instrumentation to capture HTTP headers in all four flavours

Signed-off-by: Varsha GS <varsha.gs@ibm.com>

### References

- [Kanbanize Card](https://instana.kanbanize.com/ctrl_board/197/cards/150067/details/)

## Why

According to [our spec](https://github.ibm.com/instana/technical-documentation/tree/master/tracing/specification#capturing-headers-on-http-spans), tracers SHOULD capture all four flavours of HTTP headers.