### PR TITLE
refactor: Remove superfluous absolute_import

### DIFF
--- a/instana/__init__.py
+++ b/instana/__init__.py
@@ -14,7 +14,6 @@ Documentation: https://www.instana.com/docs/
 Source Code: https://github.com/instana/python-sensor
 """
 
-from __future__ import absolute_import
 
 import os
 import sys

--- a/instana/agent/host.py
+++ b/instana/agent/host.py
@@ -5,7 +5,6 @@
 The in-process Instana agent (for host based processes) that manages
 monitoring state and reporting that data.
 """
-from __future__ import absolute_import
 
 import os
 import json

--- a/instana/configurator.py
+++ b/instana/configurator.py
@@ -5,7 +5,6 @@
 This file contains a config object that will hold configuration options for the package.
 Defaults are set and can be overridden after package load.
 """
-from __future__ import absolute_import
 from .util import DictionaryOfStan
 
 # La Protagonista

--- a/instana/fsm.py
+++ b/instana/fsm.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2016
 
-from __future__ import absolute_import
 
 import os
 import re

--- a/instana/hooks/hook_uwsgi.py
+++ b/instana/hooks/hook_uwsgi.py
@@ -6,7 +6,6 @@ The uwsgi and uwsgidecorators packages are added automatically to the Python env
 when running under uWSGI.  Here we attempt to detect the presence of these packages and
 then use the appropriate hooks.
 """
-from __future__ import absolute_import
 
 from ..log import logger
 from ..singletons import agent

--- a/instana/instrumentation/aiohttp/client.py
+++ b/instana/instrumentation/aiohttp/client.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2019
 
-from __future__ import absolute_import
 
 import opentracing
 import wrapt

--- a/instana/instrumentation/aiohttp/server.py
+++ b/instana/instrumentation/aiohttp/server.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2019
 
-from __future__ import absolute_import
 
 import opentracing
 import wrapt

--- a/instana/instrumentation/asyncio.py
+++ b/instana/instrumentation/asyncio.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2019
 
-from __future__ import absolute_import
 
 import wrapt
 

--- a/instana/instrumentation/boto3_inst.py
+++ b/instana/instrumentation/boto3_inst.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2020
 
-from __future__ import absolute_import
 
 import json
 import wrapt

--- a/instana/instrumentation/cassandra_inst.py
+++ b/instana/instrumentation/cassandra_inst.py
@@ -6,7 +6,6 @@ cassandra instrumentation
 https://docs.datastax.com/en/developer/python-driver/3.20/
 https://github.com/datastax/python-driver
 """
-from __future__ import absolute_import
 import wrapt
 from ..log import logger
 from ..util.traceutils import get_active_tracer

--- a/instana/instrumentation/celery/catalog.py
+++ b/instana/instrumentation/celery/catalog.py
@@ -10,7 +10,6 @@ These methods allow pushing and pop'ing of scopes on Task objects.
 
 WeakValueDictionary allows for lost scopes to be garbage collected.
 """
-from __future__ import absolute_import
 
 from weakref import WeakValueDictionary
 

--- a/instana/instrumentation/celery/hooks.py
+++ b/instana/instrumentation/celery/hooks.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2020
 
-from __future__ import absolute_import
 
 import opentracing
 from ...log import logger

--- a/instana/instrumentation/couchbase_inst.py
+++ b/instana/instrumentation/couchbase_inst.py
@@ -5,7 +5,6 @@
 couchbase instrumentation - This instrumentation supports the Python CouchBase 2.3.4 --> 2.5.x SDK currently:
 https://docs.couchbase.com/python-sdk/2.5/start-using-sdk.html
 """
-from __future__ import absolute_import
 
 import wrapt
 

--- a/instana/instrumentation/django/middleware.py
+++ b/instana/instrumentation/django/middleware.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2018
 
-from __future__ import absolute_import
 
 import os
 import sys

--- a/instana/instrumentation/flask/__init__.py
+++ b/instana/instrumentation/flask/__init__.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2019
 
-from __future__ import absolute_import
 
 try:
     import flask

--- a/instana/instrumentation/flask/common.py
+++ b/instana/instrumentation/flask/common.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2019
 
-from __future__ import absolute_import
 
 import wrapt
 import flask

--- a/instana/instrumentation/flask/vanilla.py
+++ b/instana/instrumentation/flask/vanilla.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2019
 
-from __future__ import absolute_import
 
 import re
 import flask

--- a/instana/instrumentation/flask/with_blinker.py
+++ b/instana/instrumentation/flask/with_blinker.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2019
 
-from __future__ import absolute_import
 
 import re
 import wrapt

--- a/instana/instrumentation/gevent_inst.py
+++ b/instana/instrumentation/gevent_inst.py
@@ -4,7 +4,6 @@
 """
 Instrumentation for the gevent package.
 """
-from __future__ import absolute_import
 
 import sys
 from ..log import logger

--- a/instana/instrumentation/google/cloud/pubsub.py
+++ b/instana/instrumentation/google/cloud/pubsub.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2021
 
-from __future__ import absolute_import
 
 import json
 import wrapt

--- a/instana/instrumentation/google/cloud/storage.py
+++ b/instana/instrumentation/google/cloud/storage.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2020
 
-from __future__ import absolute_import
 
 import wrapt
 import re

--- a/instana/instrumentation/grpcio.py
+++ b/instana/instrumentation/grpcio.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2019
 
-from __future__ import absolute_import
 
 import wrapt
 import opentracing

--- a/instana/instrumentation/logging.py
+++ b/instana/instrumentation/logging.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2019
 
-from __future__ import absolute_import
 
 import sys
 import wrapt

--- a/instana/instrumentation/mysqlclient.py
+++ b/instana/instrumentation/mysqlclient.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2019
 
-from __future__ import absolute_import
 
 from ..log import logger
 from .pep0249 import ConnectionFactory

--- a/instana/instrumentation/pika.py
+++ b/instana/instrumentation/pika.py
@@ -3,7 +3,6 @@
 # (c) Copyright Instana Inc. 2021
 
 
-from __future__ import absolute_import
 
 import wrapt
 import opentracing

--- a/instana/instrumentation/psycopg2.py
+++ b/instana/instrumentation/psycopg2.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2019
 
-from __future__ import absolute_import
 
 import copy
 import wrapt

--- a/instana/instrumentation/pymongo.py
+++ b/instana/instrumentation/pymongo.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2020
 
-from __future__ import absolute_import
 
 from ..log import logger
 from ..util.traceutils import get_active_tracer

--- a/instana/instrumentation/pymysql.py
+++ b/instana/instrumentation/pymysql.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2019
 
-from __future__ import absolute_import
 
 from ..log import logger
 from .pep0249 import ConnectionFactory

--- a/instana/instrumentation/pyramid/tweens.py
+++ b/instana/instrumentation/pyramid/tweens.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2020
 
-from __future__ import absolute_import
 
 from pyramid.httpexceptions import HTTPException
 

--- a/instana/instrumentation/redis.py
+++ b/instana/instrumentation/redis.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2018
 
-from __future__ import absolute_import
 
 import wrapt
 

--- a/instana/instrumentation/sqlalchemy.py
+++ b/instana/instrumentation/sqlalchemy.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2018
 
-from __future__ import absolute_import
 
 import re
 from operator import attrgetter

--- a/instana/instrumentation/tornado/client.py
+++ b/instana/instrumentation/tornado/client.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2019
 
-from __future__ import absolute_import
 
 import opentracing
 import wrapt

--- a/instana/instrumentation/tornado/server.py
+++ b/instana/instrumentation/tornado/server.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2019
 
-from __future__ import absolute_import
 
 import opentracing
 import wrapt

--- a/instana/instrumentation/urllib3.py
+++ b/instana/instrumentation/urllib3.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2017
 
-from __future__ import absolute_import
 
 import opentracing
 import opentracing.ext.tags as ext

--- a/instana/middleware.py
+++ b/instana/middleware.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2017
 
-from __future__ import absolute_import
 
 from .instrumentation.wsgi import InstanaWSGIMiddleware
 from .instrumentation.asgi import InstanaASGIMiddleware

--- a/instana/propagators/base_propagator.py
+++ b/instana/propagators/base_propagator.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2020
 
-from __future__ import absolute_import
 
 import sys
 

--- a/instana/propagators/binary_propagator.py
+++ b/instana/propagators/binary_propagator.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2020
 
-from __future__ import absolute_import
 
 from instana.log import logger
 from instana.propagators.base_propagator import BasePropagator

--- a/instana/propagators/http_propagator.py
+++ b/instana/propagators/http_propagator.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2020
 
-from __future__ import absolute_import
 
 from instana.log import logger
 from instana.propagators.base_propagator import BasePropagator

--- a/instana/propagators/text_propagator.py
+++ b/instana/propagators/text_propagator.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2020
 
-from __future__ import absolute_import
 
 from instana.log import logger
 from instana.propagators.base_propagator import BasePropagator

--- a/instana/recorder.py
+++ b/instana/recorder.py
@@ -2,7 +2,6 @@
 # (c) Copyright Instana Inc. 2016
 
 # Accept, process and queue spans for eventual reporting.
-from __future__ import absolute_import
 
 import os
 import queue

--- a/instana/tracer.py
+++ b/instana/tracer.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2016
 
-from __future__ import absolute_import
 
 import os
 import re

--- a/instana/wsgi.py
+++ b/instana/wsgi.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2017
 
-from __future__ import absolute_import
 
 from .instrumentation.wsgi import InstanaWSGIMiddleware
 


### PR DESCRIPTION
This import was only relevant for Python 2.5 & 2.6. Beginning with 2.7 this was the default behaviour anyway, and now that the codebase only supports 3.7 and above, it is about time to get rid of this.