### PR TITLE
Refectoring and improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   redis:
-    image: redis
+    image: docker.io/library/redis
     volumes:
       - ./tests/conf/redis.conf:/usr/local/etc/redis/redis.conf:Z
     command: redis-server /usr/local/etc/redis/redis.conf
@@ -9,19 +9,19 @@ services:
       - "0.0.0.0:6379:6379"
 
   cassandra:
-    image: cassandra
+    image: docker.io/library/cassandra
     ports:
       - 9042:9042
 
 
   couchbase:
-    image: couchbase
+    image: docker.io/library/couchbase
     ports:
       - 8091-8094:8091-8094
       - 11210:11210
 
   mariadb:
-    image: mariadb
+    image: docker.io/library/mariadb
     ports:
       - 3306:3306
     environment:
@@ -35,12 +35,12 @@ services:
       - ./tests/config/database/mysql/conf.d/mysql.cnf:/etc/mysql/conf.d/mysql.cnf:Z
 
   mongodb:
-    image: mongo
+    image: docker.io/library/mongo
     ports:
       - '27017:27017'
 
   postgres:
-    image: postgres
+    image: docker.io/library/postgres
     ports:
       - 5432:5432
     environment:
@@ -49,7 +49,7 @@ services:
       POSTGRES_DB: circle_test
 
   rabbitmq:
-    image: rabbitmq
+    image: docker.io/library/rabbitmq
     environment:
       - RABBITMQ_NODENAME=rabbit@localhost
     ports:
@@ -57,7 +57,7 @@ services:
       - 5672:5672
 
   pubsub:
-    image: egymgmbh/pubsub-emulator
+    image: docker.io/egymgmbh/pubsub-emulator
     environment:
       - PUBSUB_EMULATOR_HOST=0.0.0.0:8085
     command:

--- a/tests/requirements-310-with-tornado.txt
+++ b/tests/requirements-310-with-tornado.txt
@@ -5,35 +5,4 @@
 # An alternative would be to disable this in testconf:
 # collect_ignore_glob.append("*test_tornado*")
 tornado>=6.1
-aiofiles>=0.5.0
-aiohttp>=3.8.3
-boto3>=1.17.74
-celery>=5.2.7
-coverage>=5.5
-Django>=5.0
-fastapi>=0.92.0
-flask>=2.3.2
-markupsafe>=2.1.0
-grpcio>=1.37.1
-google-cloud-pubsub<=2.1.0
-google-cloud-storage>=1.24.0
-lxml>=4.9.2
-mock>=4.0.3
-moto>=4.1.2
-mysqlclient>=2.0.3
-PyMySQL[rsa]>=1.0.2
-psycopg2-binary>=2.8.6
-pika>=1.2.0
-pymongo>=3.11.4
-pyramid>=2.0.1
-pytest>=6.2.4
-pytest-celery
-redis>=3.5.3
-requests-mock
-responses<=0.17.0
-sanic==21.6.2
-sqlalchemy>=2.0.0
-spyne>=2.14.0
-
-uvicorn>=0.13.4
-urllib3>=1.26.5
+-r requirements-310.txt


### PR DESCRIPTION
This PR contains two commits to refector and improve our code:

1. The first guarantee container images always come from the Docker registry. That prevents that podman, for example, running in RHEL systems, from downloading images from other registries.
2. To reduce the maintenance of the requirements used in our tests, this fix refers to other requirement files that have the same list of packages.

Signed-off-by: Paulo Vital <paulo.vital@ibm.com>