### PR TITLE
[FastAPI] Add TC for non-async methods

### DIFF
--- a/tests/apps/fastapi_app/app.py
+++ b/tests/apps/fastapi_app/app.py
@@ -1,10 +1,13 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2020
 
+from ...helpers import testenv
+
 from fastapi import FastAPI, HTTPException, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import PlainTextResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
+import requests
 
 fastapi_server = FastAPI()
 
@@ -47,3 +50,12 @@ async def five_hundred():
 @fastapi_server.get("/starlette_exception")
 async def starlette_exception():
     raise StarletteHTTPException(status_code=500, detail="500 response")
+
+def trigger_outgoing_call():
+    response = requests.get(testenv["fastapi_server"]+"/users/1")
+    return response.json()
+
+@fastapi_server.get("/non_async")
+def non_async_complex_call():
+    response = trigger_outgoing_call()
+    return response

--- a/tests/apps/fastapi_app/app.py
+++ b/tests/apps/fastapi_app/app.py
@@ -6,6 +6,7 @@ from ...helpers import testenv
 from fastapi import FastAPI, HTTPException, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import PlainTextResponse
+from fastapi.concurrency import run_in_threadpool
 from starlette.exceptions import HTTPException as StarletteHTTPException
 import requests
 
@@ -55,7 +56,12 @@ def trigger_outgoing_call():
     response = requests.get(testenv["fastapi_server"]+"/users/1")
     return response.json()
 
-@fastapi_server.get("/non_async")
+@fastapi_server.get("/non_async_simple")
 def non_async_complex_call():
     response = trigger_outgoing_call()
     return response
+
+@fastapi_server.get("/non_async_threadpool")
+def non_async_threadpool():
+    run_in_threadpool(trigger_outgoing_call)
+    return {"message": "non async functions executed on a thread pool can't be followed through thread boundaries"}


### PR DESCRIPTION
Add a non-async path operation function that makes a complex non-asynchronous request to check if all the outgoing calls made by the request are properly traced.