### PR TITLE
ci: Include testing with latest starlette version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ commands:
             INSTANA_TEST: "true"
             CASSANDRA_TEST: "<<parameters.cassandra>>"
             COUCHBASE_TEST: "<<parameters.couchbase>>"
-            GEVENT_TEST: "<<parameters.gevent>>"
+            GEVENT_STARLETTE_TEST: "<<parameters.gevent>>"
           command: |
             . venv/bin/activate
             coverage run --source=instana -m pytest -v --junitxml=test-results <<parameters.tests>>
@@ -329,17 +329,17 @@ jobs:
       - store-pytest-results
       - run_sonarqube
 
-  py39gevent:
+  py39gevent_starlette:
     docker:
       - image: cimg/python:3.9.17
     working_directory: ~/repo
     steps:
       - checkout
       - pip-install-deps:
-          requirements: "tests/requirements-gevent.txt"
+          requirements: "tests/requirements-gevent-starlette.txt"
       - run-tests-with-coverage-report:
           gevent: "true"
-          tests: "tests/frameworks/test_gevent.py"
+          tests: "tests/frameworks/test_gevent.py tests/frameworks/test_starlette.py"
       - store-pytest-results
       - store-coverage-report
 
@@ -355,7 +355,7 @@ workflows:
       - python312
       - py39cassandra
       - py39couchbase
-      - py39gevent
+      - py39gevent_starlette
       - final_job:
           requires:
             - python37
@@ -366,4 +366,4 @@ workflows:
             - python312
             - py39cassandra
             - py39couchbase
-            - py39gevent
+            - py39gevent_starlette

--- a/.tekton/github-pr-pipeline.yaml.part
+++ b/.tekton/github-pr-pipeline.yaml.part
@@ -26,7 +26,7 @@ spec:
       - unittest-default
       - unittest-cassandra
       - unittest-couchbase
-      - unittest-gevent
+      - unittest-gevent-starlette
       taskRef:
         kind: Task
         name: github-set-status

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -70,7 +70,7 @@ spec:
       workspaces:
         - name: task-pvc
           workspace: python-tracer-ci-pipeline-pvc
-    - name: unittest-gevent
+    - name: unittest-gevent-starlette
       runAfter:
         - clone
       matrix:
@@ -80,7 +80,7 @@ spec:
               # 3.9.18-bookworm
               - "sha256:530d4ba717be787c0e2d011aa107edac6d721f8c06fe6d44708d4aa5e9bc5ec9"
       taskRef:
-        name: python-tracer-unittest-gevent-task
+        name: python-tracer-unittest-gevent-starlette-task
       workspaces:
         - name: task-pvc
           workspace: python-tracer-ci-pipeline-pvc

--- a/.tekton/run_unittests.sh
+++ b/.tekton/run_unittests.sh
@@ -36,13 +36,13 @@ couchbase)
   export REQUIREMENTS='requirements-couchbase.txt'
   export TESTS='tests/clients/test_couchbase.py'
   export COUCHBASE_TEST='true' ;;
-gevent)
-  export REQUIREMENTS='requirements-gevent.txt'
-  export TESTS='tests/frameworks/test_gevent.py'
-  export GEVENT_TEST='true' ;;
+gevent_starlette)
+  export REQUIREMENTS='requirements-gevent-starlette.txt'
+  export TESTS='tests/frameworks/test_gevent.py tests/frameworks/test_starlette.py'
+  export GEVENT_STARLETTE_TEST='true' ;;
 *)
   echo "ERROR \$TEST_CONFIGURATION='${TEST_CONFIGURATION}' is unsupported " \
-       "not in (default|cassandra|couchbase|gevent)" >&2
+       "not in (default|cassandra|couchbase|gevent_starlette)" >&2
   exit 3 ;;
 esac
 

--- a/.tekton/run_unittests.sh
+++ b/.tekton/run_unittests.sh
@@ -27,18 +27,18 @@ default)
     *)
       export REQUIREMENTS='requirements.txt' ;;
   esac
-  export TESTS='tests' ;;
+  export TESTS=('tests') ;;
 cassandra)
   export REQUIREMENTS='requirements-cassandra.txt'
-  export TESTS='tests/clients/test_cassandra-driver.py'
+  export TESTS=('tests/clients/test_cassandra-driver.py')
   export CASSANDRA_TEST='true' ;;
 couchbase)
   export REQUIREMENTS='requirements-couchbase.txt'
-  export TESTS='tests/clients/test_couchbase.py'
+  export TESTS=('tests/clients/test_couchbase.py')
   export COUCHBASE_TEST='true' ;;
 gevent_starlette)
   export REQUIREMENTS='requirements-gevent-starlette.txt'
-  export TESTS='tests/frameworks/test_gevent.py tests/frameworks/test_starlette.py'
+  export TESTS=('tests/frameworks/test_gevent.py' 'tests/frameworks/test_starlette.py')
   export GEVENT_STARLETTE_TEST='true' ;;
 *)
   echo "ERROR \$TEST_CONFIGURATION='${TEST_CONFIGURATION}' is unsupported " \
@@ -73,4 +73,4 @@ coverage run \
   --data-file=".coverage-${PYTHON_VERSION}-${TEST_CONFIGURATION}" \
   --module \
   pytest \
-    --verbose --junitxml=test-results "${TESTS}" # pytest options (not coverage options anymore)
+    --verbose --junitxml=test-results "${TESTS[@]}" # pytest options (not coverage options anymore)

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -94,7 +94,7 @@ spec:
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: python-tracer-unittest-gevent-task
+  name: python-tracer-unittest-gevent-starlette-task
 spec:
   params:
   - name: imageDigest
@@ -107,7 +107,7 @@ spec:
       image: python@$(params.imageDigest)
       env:
         - name: TEST_CONFIGURATION
-          value: gevent
+          value: gevent_starlette
       workingDir: /workspace/python-sensor/
       command:
       - /workspace/python-sensor/.tekton/run_unittests.sh

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@ import os
 
 os.environ["INSTANA_TEST"] = "true"
 
-if os.environ.get('GEVENT_TEST'):
+if os.environ.get('GEVENT_STARLETTE_TEST'):
     from gevent import monkey
     monkey.patch_all()
 

--- a/tests/apps/aiohttp_app/__init__.py
+++ b/tests/apps/aiohttp_app/__init__.py
@@ -8,7 +8,7 @@ from ..utils import launch_background_thread
 
 APP_THREAD = None
 
-if not any((os.environ.get('GEVENT_TEST'),
+if not any((os.environ.get('GEVENT_STARLETTE_TEST'),
             os.environ.get('CASSANDRA_TEST'),
             sys.version_info < (3, 5, 3))):
     APP_THREAD = launch_background_thread(server, "AIOHTTP")

--- a/tests/apps/grpc_server/__init__.py
+++ b/tests/apps/grpc_server/__init__.py
@@ -6,7 +6,7 @@ import sys
 import time
 import threading
 
-if not any((os.environ.get('GEVENT_TEST'),
+if not any((os.environ.get('GEVENT_STARLETTE_TEST'),
             os.environ.get('CASSANDRA_TEST'),
             sys.version_info < (3, 5, 3))):
     # Background RPC application

--- a/tests/apps/tornado_server/__init__.py
+++ b/tests/apps/tornado_server/__init__.py
@@ -8,7 +8,7 @@ from ..utils import launch_background_thread
 
 app_thread = None
 
-if not any((app_thread, os.environ.get('GEVENT_TEST'), os.environ.get('CASSANDRA_TEST'))):
+if not any((app_thread, os.environ.get('GEVENT_STARLETTE_TEST'), os.environ.get('CASSANDRA_TEST'))):
     testenv["tornado_port"] = 10813
     testenv["tornado_server"] = ("http://127.0.0.1:" + str(testenv["tornado_port"]))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,8 +22,9 @@ if not os.environ.get("CASSANDRA_TEST" ):
 if not os.environ.get("COUCHBASE_TEST"):
     collect_ignore_glob.append("*test_couchbase*")
 
-if not os.environ.get("GEVENT_TEST"):
+if not os.environ.get("GEVENT_STARLETTE_TEST"):
     collect_ignore_glob.append("*test_gevent*")
+    collect_ignore_glob.append("*test_starlette*")
 
 # Python 3.10 support is incomplete yet
 # TODO: Remove this once we start supporting Tornado >= 6.0

--- a/tests/frameworks/test_gevent.py
+++ b/tests/frameworks/test_gevent.py
@@ -15,7 +15,7 @@ from instana.singletons import tracer
 from ..helpers import testenv, get_spans_by_filter
 
 
-@unittest.skipIf(not os.environ.get("GEVENT_TEST"), reason="")
+@unittest.skipIf(not os.environ.get("GEVENT_STARLETTE_TEST"), reason="")
 class TestGEvent(unittest.TestCase):
     def setUp(self):
         self.http = urllib3.HTTPConnectionPool('127.0.0.1', port=testenv["wsgi_port"], maxsize=20)

--- a/tests/requirements-gevent-starlette.txt
+++ b/tests/requirements-gevent-starlette.txt
@@ -4,4 +4,6 @@ gevent>=1.4.0
 mock>=2.0.0
 pyramid>=2.0.1
 pytest>=4.6
+starlette>=0.12.13
 urllib3>=1.26.5
+uvicorn>=0.13.4


### PR DESCRIPTION
### What
Run both starlette and gevent tests together in a single job

### Why
[PR](https://github.com/tiangolo/fastapi/pull/11146/files) from FastAPI to include the latest starlette version is still not merged

### Reference
slack thread: https://instana.slack.com/archives/C05M4RNDPLZ/p1709204882315999