### PR TITLE
chore(version): Bump version to 2.4.0

### DIFF
--- a/src/instana/version.py
+++ b/src/instana/version.py
@@ -3,4 +3,4 @@
 
 # Module version file.  Used by setup.py and snapshot reporting.
 
-VERSION = "2.3.0"
+VERSION = "2.4.0"


### PR DESCRIPTION
New feature going into `2.4.0`: Add opt-in root exit spans