### PR TITLE
currency: Fix currency report overwrite

### DIFF
--- a/.tekton/.currency/currency-scheduled-eventlistener.yaml
+++ b/.tekton/.currency/currency-scheduled-eventlistener.yaml
@@ -41,7 +41,7 @@ kind: CronJob
 metadata:
   name: python-currency-cronjob
 spec:
-  schedule: "5 2 * * Mon-Fri"
+  schedule: "35 0 * * Mon-Fri"
   jobTemplate:
     spec:
       template:

--- a/.tekton/.currency/currency-tasks.yaml
+++ b/.tekton/.currency/currency-tasks.yaml
@@ -42,6 +42,10 @@ spec:
         pip install -r resources/requirements.txt
 
         python scripts/generate_report.py
+        if [ $? -ne 0 ]; then
+            echo "Error occured while generating the python tracer currency report." >&2
+            exit 1
+        fi
         cat docs/report.md
 ---
 apiVersion: tekton.dev/v1beta1


### PR DESCRIPTION
- [skip push and exit pipeline when report generation fails](https://github.com/instana/python-sensor/commit/c4c4afce1426c3555208b640eedf788b4b18a121)
- [schedule the currency pipeline to run 15 mins after the CI pipeline](https://github.com/instana/python-sensor/commit/65a5c053925e2a2289697691ffac3336ea44f69e)