### PR TITLE
chore: Drop 3.7 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,31 +112,6 @@ commands:
           path: htmlcov
 
 jobs:
-  python37:
-    docker:
-      - image: cimg/python:3.7.17
-      - image: cimg/postgres:9.6.24
-        environment:
-          POSTGRES_USER: root
-          POSTGRES_PASSWORD: passw0rd
-          POSTGRES_DB: instana_test_db
-      - image: cimg/mariadb:10.11.2
-        environment:
-          MYSQL_ROOT_PASSWORD: passw0rd
-          MYSQL_DATABASE: instana_test_db
-      - image: cimg/redis:5.0.14
-      - image: rabbitmq:3.9.13
-      - image: mongo:4.2.3
-      - image: vanmoof/pubsub-emulator
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - pip-install-deps:
-          requirements: "tests/requirements-307.txt"
-      - run-tests-with-coverage-report
-      - store-pytest-results
-      - store-coverage-report
-
   python38:
     docker:
       - image: cimg/python:3.8.17
@@ -323,7 +298,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - python37
       - python38
       - python39
       - python310

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -25,8 +25,6 @@ spec:
         params:
           - name: imageDigest
             value:
-              # 3.7.17-bookworm
-              - "sha256:2011a37d2a08fe83dd9ff923e0f83bfd7290152e2e6afe359bde1453170d9bdc"
               # 3.8.18-bookworm
               - "sha256:625008535504ab68868ca06d1bdd868dee92a9878d5b55fc240af7ceb38b7183"
               # 3.9.18-bookworm

--- a/.tekton/python-tracer-prepuller.yaml
+++ b/.tekton/python-tracer-prepuller.yaml
@@ -65,10 +65,6 @@ spec:
           # 3.3.1-bookworm
           image: ruby@sha256:5cf0004738f54bd67e4c4316394208ca38a6726eda7a1b0586d95601aad86e5d
           command: ["sh", "-c", "'true'"]
-        - name: prepuller-37
-          # 3.7.17-bookworm
-          image: "python@sha256:2011a37d2a08fe83dd9ff923e0f83bfd7290152e2e6afe359bde1453170d9bdc"
-          command: ["sh", "-c", "'true'"]
         - name: prepuller-38
           # 3.8.18-bookworm
           image: "python@sha256:625008535504ab68868ca06d1bdd868dee92a9878d5b55fc240af7ceb38b7183"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = [
 ]
 description = "Python Distributed Tracing & Metrics Sensor for Instana."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = "MIT"
 keywords = [
     "performance",
@@ -31,7 +31,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
This is needed for multiple reasons,
most pressing is that the `importlib.metadata` is only available in 3.8, and that would be needed to fix deprecation warnings about `pkg_resources`.