### PR TITLE
(new) Adapt common utilities to OTel specifications.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,9 +330,9 @@ workflows:
       - python311
       - python312
       - python313
-      - py39cassandra
-      - py39couchbase
-      - py39gevent_starlette
+      # - py39cassandra
+      # - py39couchbase
+      # - py39gevent_starlette
       - final_job:
           requires:
             - python38
@@ -341,9 +341,9 @@ workflows:
             - python311
             - python312
             - python313
-            - py39cassandra
-            - py39couchbase
-            - py39gevent_starlette
+            # - py39cassandra
+            # - py39couchbase
+            # - py39gevent_starlette
           filters:
             branches:
               only: master

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ log_cli = 1
 log_cli_level = WARN
 log_cli_format = %(asctime)s %(levelname)s %(message)s
 log_cli_date_format = %H:%M:%S
+pythonpath = src

--- a/src/instana/collector/helpers/runtime.py
+++ b/src/instana/collector/helpers/runtime.py
@@ -2,6 +2,7 @@
 # (c) Copyright Instana Inc. 2020
 
 """ Collection helper for the Python runtime """
+import gc
 import importlib.metadata
 import os
 import platform

--- a/src/instana/collector/host.py
+++ b/src/instana/collector/host.py
@@ -6,6 +6,7 @@ Host Collector: Manages the periodic collection of metrics & snapshot data
 """
 
 from time import time
+from typing import DefaultDict, Any
 
 from instana.collector.base import BaseCollector
 from instana.collector.helpers.runtime import RuntimeHelper
@@ -72,7 +73,7 @@ class HostCollector(BaseCollector):
             return True
         return False
 
-    def prepare_payload(self) -> DictionaryOfStan:
+    def prepare_payload(self) -> DefaultDict[Any, Any]:
         payload = DictionaryOfStan()
         payload["spans"] = []
         payload["profiles"] = []

--- a/src/instana/propagators/base_propagator.py
+++ b/src/instana/propagators/base_propagator.py
@@ -2,8 +2,8 @@
 # (c) Copyright Instana Inc. 2020
 
 
-import sys
 import os
+import typing
 
 from instana.log import logger
 from instana.util.ids import header_to_id, header_to_long_id
@@ -19,7 +19,7 @@ from opentelemetry.trace import (
 )
 from opentelemetry.context.context import Context
 
-# The carrier can be a dict or a list.
+# The carrier, typed here as CarrierT, can be a dict, a list, or a tuple.
 # Using the trace header as an example, it can be in the following forms
 # for extraction:
 #   X-Instana-T
@@ -30,6 +30,7 @@ from opentelemetry.context.context import Context
 #
 # For injection, we only support the standard format:
 #   X-Instana-T
+CarrierT = typing.TypeVar("CarrierT", typing.Dict, typing.List, typing.Tuple)
 
 
 class BasePropagator(object):

--- a/src/instana/w3c_trace_context/tracestate.py
+++ b/src/instana/w3c_trace_context/tracestate.py
@@ -42,8 +42,10 @@ class Tracestate:
         :return: tracestate updated
         """
         try:
-            span_id = in_span_id.zfill(16)  # if span_id is shorter than 16 characters we prepend zeros
-            instana_tracestate = "in={};{}".format(in_trace_id, span_id)
+            span_id = (
+                in_span_id.zfill(16) if not isinstance(in_span_id, int) else in_span_id
+            )
+            instana_tracestate = f"in={in_trace_id};{span_id}"
             if tracestate is None or tracestate == "":
                 tracestate = instana_tracestate
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,8 @@ os.environ["INSTANA_DISABLE_AUTO_INSTR"] = "true"
 from instana.span import BaseSpan, InstanaSpan  # noqa: E402
 from instana.span_context import SpanContext  # noqa: E402
 
+from opentelemetry.trace import set_span_in_context
+from opentelemetry.context.context import Context
 
 collect_ignore_glob = [
     "*autoprofile*",
@@ -123,3 +125,8 @@ def span(span_context: SpanContext) -> InstanaSpan:
 @pytest.fixture
 def base_span(span: InstanaSpan) -> BaseSpan:
     return BaseSpan(span, None, "test")
+
+
+@pytest.fixture
+def context(span: InstanaSpan) -> Context:
+    return set_span_in_context(span)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ import os
 import sys
 
 import pytest
+from opentelemetry.context.context import Context
+from opentelemetry.trace import set_span_in_context
 
 if importlib.util.find_spec('celery'):
     pytest_plugins = ("celery.contrib.pytest", )
@@ -19,9 +21,6 @@ os.environ["INSTANA_DISABLE_AUTO_INSTR"] = "true"
 # migration of instrumentation codes.
 from instana.span import BaseSpan, InstanaSpan  # noqa: E402
 from instana.span_context import SpanContext  # noqa: E402
-
-from opentelemetry.trace import set_span_in_context
-from opentelemetry.context.context import Context
 
 collect_ignore_glob = [
     "*autoprofile*",

--- a/tests/requirements-310.txt
+++ b/tests/requirements-310.txt
@@ -29,6 +29,7 @@ protobuf<4.0.0
 pymongo>=3.11.4
 pyramid>=2.0.1
 pytest>=6.2.4
+pytest-mock>=3.12.0
 redis>=3.5.3
 requests-mock
 responses<=0.17.0

--- a/tests/requirements-312.txt
+++ b/tests/requirements-312.txt
@@ -29,6 +29,7 @@ protobuf<4.0.0
 pymongo>=3.11.4
 pyramid>=2.0.1
 pytest>=6.2.4
+pytest-mock>=3.12.0
 redis>=3.5.3
 requests-mock
 responses<=0.17.0

--- a/tests/requirements-313.txt
+++ b/tests/requirements-313.txt
@@ -34,6 +34,7 @@ protobuf<4.0.0
 pymongo>=3.11.4
 pyramid>=2.0.1
 pytest>=6.2.4
+pytest-mock>=3.12.0
 redis>=3.5.3
 requests-mock
 responses<=0.17.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -28,6 +28,7 @@ protobuf<4.0.0
 pymongo>=3.11.4
 pyramid>=2.0.1
 pytest>=6.2.4
+pytest-mock>=3.12.0
 redis>=3.5.3
 requests-mock
 responses<=0.17.0

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -44,6 +44,7 @@ def test_span_get_span_context(
     trace_id: int,
     span_id: int,
 ) -> None:
+
     span_name = "test-span"
     span = InstanaSpan(span_name, span_context)
 
@@ -714,10 +715,9 @@ def test_span_assure_errored_exception(span_context: SpanContext) -> None:
         assert not span.attributes
 
 
-def test_get_current_span(span_context) -> None:
-    # span = get_current_span(span_context)
-    # assert span
-    pass
+def test_get_current_span(context) -> None:
+    span = get_current_span(context)
+    assert isinstance(span, InstanaSpan)
 
 
 def test_get_current_span_INVALID_SPAN() -> None:

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -1,6 +1,5 @@
 # (c) Copyright IBM Corp. 2024
 
-from unittest.mock import patch
 from opentelemetry.trace import set_span_in_context
 from opentelemetry.trace.span import _SPAN_ID_MAX_VALUE, INVALID_SPAN_ID
 import pytest


### PR DESCRIPTION
Based on changes made on #550. 

Adapt the following to OTel specifications, and fix some rebasing issues:

- inject()
- extract()
- traceparent
- tracestate
- get_current_span()
- get_active_tracer()
- get_tracer_tuple()

Signed-off-by: Varsha GS [varsha.gs@ibm.com](mailto:varsha.gs@ibm.com)
Co-authored-by: Paulo Vital [paulo.vital@ibm.com](mailto:paulo.vital@ibm.com)