### PR TITLE
fix: Report data to agent

### DIFF
--- a/src/instana/collector/aws_eks_fargate.py
+++ b/src/instana/collector/aws_eks_fargate.py
@@ -9,7 +9,7 @@ from time import time
 from instana.collector.base import BaseCollector
 from instana.collector.helpers.eks.process import EKSFargateProcessHelper
 from instana.collector.helpers.runtime import RuntimeHelper
-from instana.collector.utils import format_trace_and_span_ids
+from instana.collector.utils import format_span
 from instana.log import logger
 from instana.util import DictionaryOfStan
 
@@ -37,7 +37,7 @@ class EKSFargateCollector(BaseCollector):
 
         try:
             if not self.span_queue.empty():
-                payload["spans"] = format_trace_and_span_ids(self.queued_spans())
+                payload["spans"] = format_span(self.queued_spans())
 
             with_snapshot = self.should_send_snapshot_data()
 

--- a/src/instana/collector/aws_fargate.py
+++ b/src/instana/collector/aws_fargate.py
@@ -17,7 +17,7 @@ from instana.collector.helpers.fargate.docker import DockerHelper
 from instana.collector.helpers.fargate.process import FargateProcessHelper
 from instana.collector.helpers.fargate.task import TaskHelper
 from instana.collector.helpers.runtime import RuntimeHelper
-from instana.collector.utils import format_trace_and_span_ids
+from instana.collector.utils import format_span
 from instana.log import logger
 from instana.singletons import env_is_test
 from instana.util import DictionaryOfStan, validate_url
@@ -145,7 +145,7 @@ class AWSFargateCollector(BaseCollector):
 
         try:
             if not self.span_queue.empty():
-                payload["spans"] = format_trace_and_span_ids(self.queued_spans())
+                payload["spans"] = format_span(self.queued_spans())
 
             with_snapshot = self.should_send_snapshot_data()
 

--- a/src/instana/collector/aws_lambda.py
+++ b/src/instana/collector/aws_lambda.py
@@ -6,7 +6,7 @@ AWS Lambda Collector: Manages the periodic collection of metrics & snapshot data
 """
 
 from instana.collector.base import BaseCollector
-from instana.collector.utils import format_trace_and_span_ids
+from instana.collector.utils import format_span
 from instana.log import logger
 from instana.util import DictionaryOfStan
 from instana.util.aws import normalize_aws_lambda_arn
@@ -50,7 +50,7 @@ class AWSLambdaCollector(BaseCollector):
         payload["metrics"] = None
 
         if not self.span_queue.empty():
-            payload["spans"] = format_trace_and_span_ids(self.queued_spans())
+            payload["spans"] = format_span(self.queued_spans())
 
         if self.should_send_snapshot_data():
             payload["metrics"] = self.snapshot_data

--- a/src/instana/collector/google_cloud_run.py
+++ b/src/instana/collector/google_cloud_run.py
@@ -15,7 +15,7 @@ from instana.collector.helpers.google_cloud_run.instance_entity import (
     InstanceEntityHelper,
 )
 from instana.collector.helpers.google_cloud_run.process import GCRProcessHelper
-from instana.collector.utils import format_trace_and_span_ids
+from instana.collector.utils import format_span
 from instana.log import logger
 from instana.util import DictionaryOfStan, validate_url
 
@@ -120,7 +120,7 @@ class GCRCollector(BaseCollector):
 
         try:
             if not self.span_queue.empty():
-                payload["spans"] = format_trace_and_span_ids(self.queued_spans())
+                payload["spans"] = format_span(self.queued_spans())
 
             self.fetching_start_time = int(time())
             delta = self.fetching_start_time - self.__last_gcr_md_full_fetch

--- a/src/instana/collector/host.py
+++ b/src/instana/collector/host.py
@@ -10,7 +10,7 @@ from typing import DefaultDict, Any
 
 from instana.collector.base import BaseCollector
 from instana.collector.helpers.runtime import RuntimeHelper
-from instana.collector.utils import format_trace_and_span_ids
+from instana.collector.utils import format_span
 from instana.log import logger
 from instana.util import DictionaryOfStan
 
@@ -81,7 +81,7 @@ class HostCollector(BaseCollector):
 
         try:
             if not self.span_queue.empty():
-                payload["spans"] = format_trace_and_span_ids(self.queued_spans())
+                payload["spans"] = format_span(self.queued_spans())
 
             if not self.profile_queue.empty():
                 payload["profiles"] = self.queued_profiles()

--- a/src/instana/collector/utils.py
+++ b/src/instana/collector/utils.py
@@ -3,16 +3,17 @@
 from typing import TYPE_CHECKING, List
 
 from opentelemetry.trace.span import format_span_id
+from opentelemetry.trace import SpanKind
 
 if TYPE_CHECKING:
     from instana.span.span import InstanaSpan
 
 
-def format_trace_and_span_ids(
+def format_span(
     queued_spans: List["InstanaSpan"],
 ) -> List["InstanaSpan"]:
     """
-    Format the Trace, Parent Span, and Span IDs of Spans to be a 64-bit
+    Format Span Kind and the Trace, Parent Span and Span IDs of the Spans to be a 64-bit
     Hexadecimal String instead of Integer before being pushed to a
     Collector (or Instana Agent).
     """
@@ -21,5 +22,7 @@ def format_trace_and_span_ids(
         span.t = format_span_id(span.t)
         span.s = format_span_id(span.s)
         span.p = format_span_id(span.p) if span.p else None
+        if isinstance(span.k, SpanKind):
+            span.k = span.k.value if not span.k is SpanKind.INTERNAL else 3
         spans.append(span)
     return spans

--- a/src/instana/collector/utils.py
+++ b/src/instana/collector/utils.py
@@ -1,17 +1,17 @@
 # (c) Copyright IBM Corp. 2024
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Type, List
 
 from opentelemetry.trace.span import format_span_id
 from opentelemetry.trace import SpanKind
 
 if TYPE_CHECKING:
-    from instana.span.span import InstanaSpan
+    from instana.span.base_span import BaseSpan
 
 
 def format_span(
-    queued_spans: List["InstanaSpan"],
-) -> List["InstanaSpan"]:
+    queued_spans: List[Type["BaseSpan"]],
+) -> List[Type["BaseSpan"]]:
     """
     Format Span Kind and the Trace, Parent Span and Span IDs of the Spans to be a 64-bit
     Hexadecimal String instead of Integer before being pushed to a

--- a/src/instana/span/registered_span.py
+++ b/src/instana/span/registered_span.py
@@ -23,7 +23,7 @@ class RegisteredSpan(BaseSpan):
             self.k = SpanKind.CLIENT  # exit
             self._populate_exit_span_data(span)
         elif span.name in LOCAL_SPANS:
-            self.k = 3  # intermediate span
+            self.k = SpanKind.INTERNAL  # intermediate span
             self._populate_local_span_data(span)
 
         if "rabbitmq" in self.data and self.data["rabbitmq"]["sort"] == "publish":

--- a/src/instana/span/registered_span.py
+++ b/src/instana/span/registered_span.py
@@ -12,7 +12,9 @@ class RegisteredSpan(BaseSpan):
         # pylint: disable=invalid-name
         super(RegisteredSpan, self).__init__(span, source, **kwargs)
         self.n = span.name
-        self.k = SpanKind.SERVER    # entry
+        self.k = (
+            SpanKind.SERVER
+        )  # entry -> Server span represents a synchronous incoming remote call such as an incoming HTTP request
 
         self.data["service"] = service_name
         if span.name in ENTRY_SPANS:
@@ -20,10 +22,14 @@ class RegisteredSpan(BaseSpan):
             self._populate_entry_span_data(span)
             self._populate_extra_span_attributes(span)
         elif span.name in EXIT_SPANS:
-            self.k = SpanKind.CLIENT  # exit
+            self.k = (
+                SpanKind.CLIENT
+            )  # exit -> Client span represents a synchronous outgoing remote call such as an outgoing HTTP request or database call
             self._populate_exit_span_data(span)
         elif span.name in LOCAL_SPANS:
-            self.k = SpanKind.INTERNAL  # intermediate span
+            self.k = (
+                SpanKind.INTERNAL
+            )  # intermediate -> Internal span represents an internal operation within an application
             self._populate_local_span_data(span)
 
         if "rabbitmq" in self.data and self.data["rabbitmq"]["sort"] == "publish":

--- a/tests/test_span_registered.py
+++ b/tests/test_span_registered.py
@@ -20,7 +20,7 @@ from instana.span_context import SpanContext
         ("gcps-producer", ("gcps", SpanKind.CLIENT, "gcps"), {}),
         ("urllib3", ("urllib3", SpanKind.CLIENT, "http"), {}),
         ("rabbitmq", ("rabbitmq", SpanKind.CLIENT, "rabbitmq"), {"sort": "publish"}),
-        ("render", ("render", 3, "render"), {"arguments": "--quiet"}),
+        ("render", ("render", SpanKind.INTERNAL, "render"), {"arguments": "--quiet"}),
     ],
 )
 def test_registered_span(


### PR DESCRIPTION
Fix the below error that hinders reporting tracer data to the agent.
```
2024-07-15 12:41:31,430: 51725 DEBUG instana: to_json non-fatal encoding issue: 
Traceback (most recent call last):
  File "/Users/varsha/Documents/GitHub/instana-repos/tracer-repos/python-sensor/src/instana/util/__init__.py", line 36, in to_json
    return json.dumps(obj, default=extractor, sort_keys=False, separators=(',', ':')).encode()
  File "/Users/varsha/.pyenv/versions/3.9.7/lib/python3.9/json/__init__.py", line 234, in dumps
    return cls(
  File "/Users/varsha/.pyenv/versions/3.9.7/lib/python3.9/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/Users/varsha/.pyenv/versions/3.9.7/lib/python3.9/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
```
`span.k` was of type ENUM class attribute. Change it to Literal[Spankind.\<attribute\>] which is basically the integer value of the ENUM class attribute before sending the spans to the agent.