### PR TITLE
OTel small fixes.

### DIFF
--- a/src/instana/span/base_span.py
+++ b/src/instana/span/base_span.py
@@ -27,7 +27,7 @@ class BaseSpan(object):
         self.s = span.context.span_id
         self.l = span.context.level
         self.ts = round(span.start_time / 10**6)
-        self.d = round(span.duration / 10**6) if span.duration is not None else None
+        self.d = round(span.duration / 10**6) if span.duration else None
         self.f = source
         self.ec = span.attributes.pop("ec", None)
         self.data = DictionaryOfStan()

--- a/src/instana/span/readable_span.py
+++ b/src/instana/span/readable_span.py
@@ -92,7 +92,7 @@ class ReadableSpan:
         return self._end_time
 
     @property
-    def duration(self) -> int:
+    def duration(self) -> Optional[int]:
         return self._duration
 
     @property

--- a/src/instana/span/span.py
+++ b/src/instana/span/span.py
@@ -192,7 +192,8 @@ class InstanaSpan(Span, ReadableSpan):
 
     def end(self, end_time: Optional[int] = None) -> None:
         with self._lock:
-            self._end_time = end_time if end_time is not None else time_ns()
+            self._end_time = end_time if end_time else time_ns()
+            self._duration = self._end_time - self._start_time
 
         self._span_processor.record_span(self._readable_span())
 

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -770,3 +770,38 @@ def test_get_current_span_INVALID_SPAN() -> None:
 
     assert span
     assert span == INVALID_SPAN
+
+
+def test_span_duration_default(
+    span_context: SpanContext, span_processor: StanRecorder
+) -> None:
+    span_name = "test-span"
+    span = InstanaSpan(span_name, span_context, span_processor)
+
+    assert not span.end_time
+    assert not span.duration
+
+    span.end()
+
+    assert span.end_time
+    assert span.duration
+    assert isinstance(span.duration, int)
+    assert span.duration > 0
+
+
+def test_span_duration(span_context: SpanContext, span_processor: StanRecorder) -> None:
+    span_name = "test-span"
+    span = InstanaSpan(span_name, span_context, span_processor)
+
+    assert not span.end_time
+    assert not span.duration
+
+    timestamp_end = time.time_ns()
+    span.end(timestamp_end)
+
+    assert span.end_time
+    assert span.end_time == timestamp_end
+    assert span.duration
+    assert isinstance(span.duration, int)
+    assert span.duration > 0
+    assert span.duration == (timestamp_end - span.start_time)


### PR DESCRIPTION
- style: Update type hints.
  - Use Type["BaseAgent"] instead of a long Union list with all its inherited classes.
  - Update the return type hint for the Span duration property.
- fix(tests): Add Span duration unit tests.
  - Add new tests to cover the changes on the (readable)span duration property.
  - Fix the Span duration update when ending a Span.