### PR TITLE
fix: prevent tracing internal requests.

### DIFF
--- a/src/instana/agent/aws_eks_fargate.py
+++ b/src/instana/agent/aws_eks_fargate.py
@@ -66,6 +66,7 @@ class EKSFargateAgent(BaseAgent):
                 self.report_headers["Content-Type"] = "application/json"
                 self.report_headers["X-Instana-Host"] = self.podname
                 self.report_headers["X-Instana-Key"] = self.options.agent_key
+                self.report_headers["X-Instana-L"] = "0"
 
             response = self.client.post(self.__data_bundle_url(),
                                         data=to_json(payload),

--- a/src/instana/agent/aws_fargate.py
+++ b/src/instana/agent/aws_fargate.py
@@ -63,6 +63,7 @@ class AWSFargateAgent(BaseAgent):
                 self.report_headers["Content-Type"] = "application/json"
                 self.report_headers["X-Instana-Host"] = self.collector.get_fq_arn()
                 self.report_headers["X-Instana-Key"] = self.options.agent_key
+                self.report_headers["X-Instana-L"] = "0"
 
             response = self.client.post(self.__data_bundle_url(),
                                         data=to_json(payload),

--- a/src/instana/agent/aws_lambda.py
+++ b/src/instana/agent/aws_lambda.py
@@ -63,6 +63,7 @@ class AWSLambdaAgent(BaseAgent):
                 self.report_headers["Content-Type"] = "application/json"
                 self.report_headers["X-Instana-Host"] = self.collector.get_fq_arn()
                 self.report_headers["X-Instana-Key"] = self.options.agent_key
+                self.report_headers["X-Instana-L"] = "0"
 
             response = self.client.post(self.__data_bundle_url(),
                                         data=to_json(payload),

--- a/src/instana/agent/google_cloud_run.py
+++ b/src/instana/agent/google_cloud_run.py
@@ -64,7 +64,8 @@ class GCRAgent(BaseAgent):
                     "Content-Type": "application/json",
                     "X-Instana-Host": "gcp:cloud-run:revision:{revision}".format(
                         revision=self.collector.revision),
-                    "X-Instana-Key": self.options.agent_key
+                    "X-Instana-Key": self.options.agent_key,
+                    "X-Instana-L": "0",
                 }
 
             response = self.client.post(self.__data_bundle_url(),


### PR DESCRIPTION
The urllib3 library, which we instrument, is used by the requests package, and this last one is used by Instana Python Tracer to connect with an Instana Agent.

When the INSTANA_ALLOW_EXIT_AS_ROOT environment variable is set, the internal requests are traced as EXIT_ROOT spans.

This commit prevents the internal requests from being traced by our lib.