### PR TITLE
fix: TracerProvider.get_tracer() after API update.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "requests>=2.6.0",
     "six>=1.12.0",
     "urllib3>=1.26.5",
-    "opentelemetry-api>=1.23.0",
+    "opentelemetry-api>=1.26.0",
 ]
 
 [project.optional-dependencies]

--- a/src/instana/tracer.py
+++ b/src/instana/tracer.py
@@ -59,6 +59,7 @@ class InstanaTracerProvider(TracerProvider):
         instrumenting_module_name: str,
         instrumenting_library_version: Optional[str] = None,
         schema_url: Optional[str] = None,
+        attributes: Optional[types.Attributes] = None,
     ) -> Tracer:
         if not instrumenting_module_name:  # Reject empty strings too.
             instrumenting_module_name = ""


### PR DESCRIPTION
The new OTel API version 1.26.0 introduces changes to the `TracerProvider.get_tracer()`, which must be reflected in our code.