### PR TITLE
Added constraint for setuptools Python module

### DIFF
--- a/tests/requirements-310.txt
+++ b/tests/requirements-310.txt
@@ -29,12 +29,12 @@ protobuf<4.0.0
 pymongo>=3.11.4
 pyramid>=2.0.1
 pytest>=6.2.4
+pytz>=2024.1
 redis>=3.5.3
 requests-mock
 responses<=0.17.0
 sanic==21.6.2
 sqlalchemy>=2.0.0
-spyne>=2.14.0
 
 uvicorn>=0.13.4
 urllib3>=1.26.5

--- a/tests/requirements-312.txt
+++ b/tests/requirements-312.txt
@@ -29,12 +29,12 @@ protobuf<4.0.0
 pymongo>=3.11.4
 pyramid>=2.0.1
 pytest>=6.2.4
+pytz>=2024.1
 redis>=3.5.3
 requests-mock
 responses<=0.17.0
 sanic==21.6.2
 sqlalchemy>=2.0.0
-spyne>=2.14.0
 
 uvicorn>=0.13.4
 urllib3>=1.26.5

--- a/tests/requirements-313.txt
+++ b/tests/requirements-313.txt
@@ -34,6 +34,7 @@ protobuf<4.0.0
 pymongo>=3.11.4
 pyramid>=2.0.1
 pytest>=6.2.4
+pytz>=2024.1
 redis>=3.5.3
 requests-mock
 responses<=0.17.0
@@ -42,7 +43,6 @@ responses<=0.17.0
 # `too few arguments to function ‘_PyLong_AsByteArray’`
 #sanic==21.6.2
 sqlalchemy>=2.0.0
-spyne>=2.14.0
 
 uvicorn>=0.13.4
 urllib3>=1.26.5

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -28,12 +28,12 @@ protobuf<4.0.0
 pymongo>=3.11.4
 pyramid>=2.0.1
 pytest>=6.2.4
+pytz>=2024.1
 redis>=3.5.3
 requests-mock
 responses<=0.17.0
 sanic==21.6.2
 sqlalchemy>=2.0.0
-spyne>=2.14.0
 tornado>=4.5.3,<6.0
 uvicorn>=0.13.4
 urllib3>=1.26.5


### PR DESCRIPTION
There is a common issue with the last version of setuptools. It looks like they've removed the test attribute from setuptools.command module. I found a solution from the Github issue below and implemented it to our pipeline.

It's because of a package named spyne: https://github.com/arskom/spyne
It's not being updated for a long time (7 months), has some conflicts with setuptools

https://github.com/pypa/setuptools/issues/4519