### PR TITLE
fix: log message >WARN not showing up in the UI

### DIFF
--- a/src/instana/span/registered_span.py
+++ b/src/instana/span/registered_span.py
@@ -139,8 +139,8 @@ class RegisteredSpan(BaseSpan):
         if span.name == "render":
             self.data["render"]["name"] = span.attributes.pop("name", None)
             self.data["render"]["type"] = span.attributes.pop("type", None)
-            self.data["event"]["message"] = span.attributes.pop("message", None)
-            self.data["event"]["parameters"] = span.attributes.pop("parameters", None)
+            self.data["log"]["message"] = span.attributes.pop("message", None)
+            self.data["log"]["parameters"] = span.attributes.pop("parameters", None)
         else:
             logger.debug("SpanRecorder: Unknown local span: %s" % span.name)
 
@@ -309,11 +309,9 @@ class RegisteredSpan(BaseSpan):
             # use last special key values
             for event in span.events:
                 if "message" in event.attributes:
-                    self.data["event"]["message"] = event.attributes.pop(
-                        "message", None
-                    )
+                    self.data["log"]["message"] = event.attributes.pop("message", None)
                 if "parameters" in event.attributes:
-                    self.data["event"]["parameters"] = event.attributes.pop(
+                    self.data["log"]["parameters"] = event.attributes.pop(
                         "parameters", None
                     )
         else:

--- a/tests/clients/test_logging.py
+++ b/tests/clients/test_logging.py
@@ -37,7 +37,7 @@ class TestLogging(unittest.TestCase):
         assert len(spans) == 2
         assert spans[0].k is SpanKind.CLIENT
 
-        assert spans[0].data["event"].get("message") == "foo bar"
+        assert spans[0].data["log"].get("message") == "foo bar"
 
     def test_log_with_tuple(self) -> None:
         with tracer.start_as_current_span("test"):
@@ -47,7 +47,7 @@ class TestLogging(unittest.TestCase):
         assert len(spans) == 2
         assert spans[0].k is SpanKind.CLIENT
 
-        assert spans[0].data["event"].get("message") == "foo ('bar',)"
+        assert spans[0].data["log"].get("message") == "foo ('bar',)"
 
     def test_log_with_dict(self) -> None:
         with tracer.start_as_current_span("test"):
@@ -57,7 +57,7 @@ class TestLogging(unittest.TestCase):
         assert len(spans) == 2
         assert spans[0].k is SpanKind.CLIENT
 
-        assert spans[0].data["event"].get("message") == "foo {'bar': 18}"
+        assert spans[0].data["log"].get("message") == "foo {'bar': 18}"
 
     def test_parameters(self) -> None:
         with tracer.start_as_current_span("test"):
@@ -71,7 +71,7 @@ class TestLogging(unittest.TestCase):
         spans = self.recorder.queued_spans()
         assert len(spans) == 2
 
-        assert spans[0].data["event"].get("parameters") is not None
+        assert spans[0].data["log"].get("parameters") is not None
 
     def test_no_root_exit_span(self) -> None:
         agent.options.allow_exit_as_root = True
@@ -88,7 +88,7 @@ class TestLogging(unittest.TestCase):
         assert len(spans) == 1
         assert spans[0].k is SpanKind.CLIENT
 
-        assert spans[0].data["event"].get("message") == "foo bar"
+        assert spans[0].data["log"].get("message") == "foo bar"
 
     def test_exception(self) -> None:
         with tracer.start_as_current_span("test"):
@@ -102,4 +102,4 @@ class TestLogging(unittest.TestCase):
         assert len(spans) == 2
         assert spans[0].k is SpanKind.CLIENT
 
-        assert spans[0].data["event"] == {}
+        assert spans[0].data["log"] == {}

--- a/tests/test_span_registered.py
+++ b/tests/test_span_registered.py
@@ -426,5 +426,5 @@ def test_populate_exit_span_data_log(
 
     reg_span._populate_exit_span_data(span)
 
-    assert excepted_text == reg_span.data["event"]["message"]
-    assert excepted_text == reg_span.data["event"]["parameters"]
+    assert excepted_text == reg_span.data["log"]["message"]
+    assert excepted_text == reg_span.data["log"]["parameters"]


### PR DESCRIPTION
#### Issue:
Log message >WARN not showing up in the UI

<img width="600" height="200" alt="Screenshot 2024-07-29 at 8 18 24 PM" src="https://github.com/user-attachments/assets/ffc3d0c5-a705-4bce-ac87-7442f11e336c">

#### Fix:
Revert `span.data["event"]` to `span.data["log"]`

<img width="1385" alt="Screenshot 2024-07-29 at 4 30 33 PM" src="https://github.com/user-attachments/assets/2104a8c8-268f-4cc1-a399-3f6d34945982">
