### PR TITLE
fix: The trace is malformed and contains multiple root calls

### DIFF
--- a/src/instana/tracer.py
+++ b/src/instana/tracer.py
@@ -94,15 +94,10 @@ class InstanaTracer(Tracer):
         exporter: Type["BaseAgent"],
         propagators: Mapping[str, Type["BasePropagator"]],
     ) -> None:
-        self._tracer_id = generate_id()
         self._sampler = sampler
         self._span_processor = span_processor
         self._exporter = exporter
         self._propagators = propagators
-
-    @property
-    def tracer_id(self) -> str:
-        return self._tracer_id
 
     @property
     def span_processor(self) -> Optional[StanRecorder]:
@@ -218,14 +213,17 @@ class InstanaTracer(Tracer):
     def _create_span_context(self, parent_context: SpanContext) -> SpanContext:
         """Creates a new SpanContext based on the given parent context."""
 
+        generated_id = generate_id()
+
         if parent_context is not None and parent_context.trace_id is not None:
             trace_id = parent_context.trace_id
-            span_id = generate_id()
+            span_id = generated_id
             trace_flags = parent_context.trace_flags
             is_remote = parent_context.is_remote
         else:
-            trace_id = self.tracer_id
-            span_id = self.tracer_id
+            # root span
+            trace_id = generated_id
+            span_id = generated_id
             trace_flags = TraceFlags(self._sampler.sampled())
             is_remote = False
 

--- a/src/instana/tracer.py
+++ b/src/instana/tracer.py
@@ -124,7 +124,7 @@ class InstanaTracer(Tracer):
             raise TypeError("parent_context must be an Instana SpanContext or None.")
 
         if parent_context is not None and not parent_context.is_valid:
-            # We probably have a INVALID_SPAN_CONTEXT.
+            # We probably have an INVALID_SPAN_CONTEXT.
             parent_context = None
 
         span_context = self._create_span_context(parent_context)
@@ -213,17 +213,13 @@ class InstanaTracer(Tracer):
     def _create_span_context(self, parent_context: SpanContext) -> SpanContext:
         """Creates a new SpanContext based on the given parent context."""
 
-        generated_id = generate_id()
-
         if parent_context is not None and parent_context.trace_id is not None:
             trace_id = parent_context.trace_id
-            span_id = generated_id
+            span_id = generate_id()
             trace_flags = parent_context.trace_flags
             is_remote = parent_context.is_remote
         else:
-            # root span
-            trace_id = generated_id
-            span_id = generated_id
+            trace_id = span_id = generate_id()
             trace_flags = TraceFlags(self._sampler.sampled())
             is_remote = False
 

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -18,8 +18,6 @@ def test_tracer_defaults(tracer_provider: InstanaTracerProvider) -> None:
         tracer_provider._propagators,
     )
 
-    assert tracer.tracer_id > INVALID_SPAN_ID
-    assert tracer.tracer_id <= _SPAN_ID_MAX_VALUE
     assert isinstance(tracer._sampler, InstanaSampler)
     assert isinstance(tracer.span_processor, StanRecorder)
     assert isinstance(tracer.exporter, TestAgent)

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -112,6 +112,29 @@ def test_tracer_create_span_context(
     assert span_context.span_id != new_span_context.span_id
     assert span_context.long_trace_id == new_span_context.long_trace_id
 
+    assert span_context.trace_id > INVALID_SPAN_ID
+    assert span_context.trace_id <= _SPAN_ID_MAX_VALUE
+
+    assert span_context.span_id > INVALID_SPAN_ID
+    assert span_context.span_id <= _SPAN_ID_MAX_VALUE
+
+
+def test_tracer_create_span_context_root(
+    tracer_provider: InstanaTracerProvider,
+) -> None:
+    tracer = InstanaTracer(
+        tracer_provider.sampler,
+        tracer_provider._span_processor,
+        tracer_provider._exporter,
+        tracer_provider._propagators,
+    )
+    new_span_context = tracer._create_span_context(parent_context=None)
+
+    assert new_span_context.trace_id > INVALID_SPAN_ID
+    assert new_span_context.trace_id <= _SPAN_ID_MAX_VALUE
+
+    assert new_span_context.trace_id == new_span_context.span_id
+
 
 def test_tracer_add_stack_high_limit(
     span: InstanaSpan, tracer_provider: InstanaTracerProvider

--- a/tests/test_tracer_provider.py
+++ b/tests/test_tracer_provider.py
@@ -29,8 +29,6 @@ def test_tracer_provider_get_tracer() -> None:
     tracer = provider.get_tracer("instana.test.tracer")
 
     assert isinstance(tracer, InstanaTracer)
-    assert tracer.tracer_id > INVALID_SPAN_ID
-    assert tracer.tracer_id <= _SPAN_ID_MAX_VALUE
 
 
 def test_tracer_provider_get_tracer_empty_instrumenting_module_name(
@@ -41,8 +39,6 @@ def test_tracer_provider_get_tracer_empty_instrumenting_module_name(
 
     assert "get_tracer called with missing module name." == caplog.record_tuples[0][2]
     assert isinstance(tracer, InstanaTracer)
-    assert tracer.tracer_id > INVALID_SPAN_ID
-    assert tracer.tracer_id <= _SPAN_ID_MAX_VALUE
 
 
 def test_tracer_provider_add_span_processor(span_processor: StanRecorder) -> None:


### PR DESCRIPTION
#### Issue:

The trace is malformed and contains multiple root calls: [link](https://instana.rocks/s/b5H7hsYFSwavGPBy59rcIQ)

```
127.0.0.1 - - [30/Jul/2024 13:23:34] "GET /users/5 HTTP/1.1" 200 -
2024-07-30 13:23:34,444: 64371 DEBUG instana: Reporting 2 spans
1 - Trace ID: 04c06e2c65ecc0eb  Span ID: 0bf364bca4dfac96       Span Name: urllib3
2 - Trace ID: 04c06e2c65ecc0eb  Span ID: 04c06e2c65ecc0eb       Span Name: wsgi
foo bar
127.0.0.1 - - [30/Jul/2024 13:23:38] "GET /users/ HTTP/1.1" 200 -
2024-07-30 13:23:38,441: 64371 DEBUG instana: Reporting 3 spans
1 - Trace ID: 04c06e2c65ecc0eb  Span ID: 997a95ffb37bf2ff       Span Name: log
2 - Trace ID: 04c06e2c65ecc0eb  Span ID: c29c6688592d996f       Span Name: urllib3
3 - Trace ID: 04c06e2c65ecc0eb  Span ID: 04c06e2c65ecc0eb       Span Name: wsgi
127.0.0.1 - - [30/Jul/2024 13:25:12] "GET /users/2 HTTP/1.1" 200 -
2024-07-30 13:25:12,444: 64371 DEBUG instana: Reporting 2 spans
1 - Trace ID: 04c06e2c65ecc0eb  Span ID: c466dbaf3f6429bf       Span Name: urllib3
2 - Trace ID: 04c06e2c65ecc0eb  Span ID: 04c06e2c65ecc0eb       Span Name: wsgi
```

#### Fix:

Determine both trace and span ids only when `start_span()` is called.

```
127.0.0.1 - - [29/Jul/2024 16:44:29] "GET /users/4 HTTP/1.1" 200 -
2024-07-29 16:44:30,677: 45782 DEBUG instana: Reporting 2 spans
1 - Trace ID: 3a6d3762c9e451e6  Span ID: 1799ad61e6a76361    Span Name: urllib3
2 - Trace ID: 3a6d3762c9e451e6  Span ID: 3a6d3762c9e451e6    Span Name: wsgi
foo bar
127.0.0.1 - - [29/Jul/2024 16:46:29] "GET /users/ HTTP/1.1" 200 -
2024-07-29 16:46:29,675: 45782 DEBUG instana: Reporting 3 spans
1 - Trace ID: 9d0cc0e13a617890  Span ID: 1651c02974e7a1f8    Span Name: log
2 - Trace ID: 9d0cc0e13a617890  Span ID: 2cbea1438576e8a7    Span Name: urllib3
3 - Trace ID: 9d0cc0e13a617890  Span ID: 9d0cc0e13a617890    Span Name: wsgi
```