### PR TITLE
fix: Re-enable activation without codechange (`AUTOWRAPT_BOOTSTRAP=instana`)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ dependencies = [
     "urllib3>=1.26.5",
 ]
 
+[project.entry-points."instana"]
+string = "instana:load"
+
 [project.optional-dependencies]
 dev = [
   "pytest",

--- a/src/instana/version.py
+++ b/src/instana/version.py
@@ -3,4 +3,4 @@
 
 # Module version file.  Used by setup.py and snapshot reporting.
 
-VERSION = "2.5.1"
+VERSION = "2.5.2"


### PR DESCRIPTION
Before commit `c222d96`, the `setup.py` contained the following entry point specification:
````
     entry_points={
             'instana':  ['string = instana:load'],
````
And **entrypoints** are a must have when using `autowrapt`. 
Quote from the [autowrapt documentation](
https://github.com/GrahamDumpleton/autowrapt/blob/d4770e4f511c19012055deaab68ef0ec8aa54ba4/README.rst?plain=1#L11 ):
> list the names of the setuptools **entrypoints** you wish to activate

This can also be observed in the calls made by `autowrapt`:
````
  <frozen importlib._bootstrap>(991)_find_and_load()
  <frozen importlib._bootstrap>(975)_find_and_load_unlocked()
  <frozen importlib._bootstrap>(671)_load_unlocked()
  <frozen importlib._bootstrap_external>(843)exec_module()
  <frozen importlib._bootstrap>(219)_call_with_frames_removed()
  /usr/local/lib/python3.8/site.py(580)<module>()
-> main()
  /usr/local/lib/python3.8/site.py(575)main()
-> execusercustomize()
  /usr/local/lib/python3.8/site-packages/autowrapt/bootstrap.py(46)_execusercustomize()
-> _register_bootstrap_functions()
  /usr/local/lib/python3.8/site-packages/autowrapt/bootstrap.py(27)_register_bootstrap_functions()
-> discover_post_import_hooks(name)
  /usr/local/lib/python3.8/site-packages/wrapt/importer.py(97)discover_post_import_hooks()
-> for entrypoint in pkg_resources.iter_entry_points(group=group):
  /usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py(642)<genexpr>()
-> for entry in dist.get_entry_map(group).values()
> /usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py(2853)get_entry_map()
````

Which fails to fill up the `ep_map`, since the `entry_points.txt` metadata is empty:
````
   2853             ep_map = self._ep_map = EntryPoint.parse_map(
   2854                 self._get_metadata('entry_points.txt'), self
   2855             )
````