### PR TITLE
report(currency): updated starlette version

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,8 @@ import os
 import sys
 import pytest
 
-if importlib.util.find_spec('celery'):
-    pytest_plugins = ("celery.contrib.pytest", )
+if importlib.util.find_spec("celery"):
+    pytest_plugins = ("celery.contrib.pytest",)
 
 # Set our testing flags
 os.environ["INSTANA_TEST"] = "true"
@@ -20,7 +20,7 @@ collect_ignore_glob = []
 
 # Cassandra and gevent tests are run in dedicated jobs on CircleCI and will
 # be run explicitly.  (So always exclude them here)
-if not os.environ.get("CASSANDRA_TEST" ):
+if not os.environ.get("CASSANDRA_TEST"):
     collect_ignore_glob.append("*test_cassandra*")
 
 if not os.environ.get("COUCHBASE_TEST"):
@@ -64,22 +64,25 @@ if sys.version_info >= (3, 13):
     collect_ignore_glob.append("*test_grpcio*")
     collect_ignore_glob.append("*test_sanic*")
 
-@pytest.fixture(scope='session')
+    # Currently latest version of starlette depends on the `greenlet` module
+    # which is still not supporting Python 3.13
+    collect_ignore_glob.append("*test_starlette*")
+
+
+@pytest.fixture(scope="session")
 def celery_config():
     return {
-        'broker_connection_retry_on_startup': True,
-        'broker_url': 'redis://localhost:6379',
-        'result_backend': 'redis://localhost:6379'
+        "broker_connection_retry_on_startup": True,
+        "broker_url": "redis://localhost:6379",
+        "result_backend": "redis://localhost:6379",
     }
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def celery_enable_logging():
     return True
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def celery_includes():
-    return {
-        'tests.frameworks.test_celery'
-    }
+    return {"tests.frameworks.test_celery"}

--- a/tests/requirements-gevent-starlette.txt
+++ b/tests/requirements-gevent-starlette.txt
@@ -4,6 +4,6 @@ gevent>=1.4.0
 mock>=2.0.0
 pyramid>=2.0.1
 pytest>=4.6
-starlette>=0.12.13
+starlette>=0.38.2
 urllib3>=1.26.5
 uvicorn>=0.13.4

--- a/tests/requirements-gevent-starlette.txt
+++ b/tests/requirements-gevent-starlette.txt
@@ -4,6 +4,6 @@ gevent>=1.4.0
 mock>=2.0.0
 pyramid>=2.0.1
 pytest>=4.6
-starlette>=0.38.2
+starlette>=0.12.13
 urllib3>=1.26.5
 uvicorn>=0.13.4


### PR DESCRIPTION
- Added Starlette version 0.38.2 for Python 3.8, 3.9, 3.10, 3.11 and 3.12 has been updated. Python 3.13 has no support for `greenlet` yet which is required for Starlette.
- Added dependency to tests/conftest.py

https://github.com/python-greenlet/greenlet/issues/392
