### PR TITLE
fix: Capture the correct log caller

### DIFF
--- a/src/instana/instrumentation/logging.py
+++ b/src/instana/instrumentation/logging.py
@@ -16,12 +16,16 @@ def log_with_instana(wrapped, instance, argv, kwargs):
     # argv[0] = level
     # argv[1] = message
     # argv[2] = args for message
+    if sys.version_info >= (3, 13):
+        stacklevel = 3
+    else:
+        stacklevel = 2
     try:
         tracer, parent_span, _ = get_tracer_tuple()
 
         # Only needed if we're tracing and serious log
         if tracing_is_off() or argv[0] < logging.WARN:
-            return wrapped(*argv, **kwargs)
+            return wrapped(*argv, **kwargs, stacklevel=stacklevel)
 
         msg = str(argv[1])
         args = argv[2]
@@ -48,7 +52,7 @@ def log_with_instana(wrapped, instance, argv, kwargs):
     except Exception:
         logger.debug('log_with_instana:', exc_info=True)
 
-    return wrapped(*argv, **kwargs)
+    return wrapped(*argv, **kwargs, stacklevel=stacklevel)
 
 
 logger.debug('Instrumenting logging')


### PR DESCRIPTION
## What
#### Python version >= 3.13
log_with_instana -> \_\_call__ -> custom_func
`stacklevel1 -> stacklevel2 -> stacklevel3`

#### Python version < 3.13
log_with_instana -> custom_func
`stacklevel1 -> stacklevel2`

## Why
Bug reported by a customer: https://github.com/instana/python-sensor/issues/563

## Before the changes

```
BEFORE instana import
funcName:custom_func message:Hello, world

AFTER instana import
funcName:log_with_instana message:Hello, world
```

## After the changes

```
BEFORE instana import
funcName:custom_func message:Hello, world

AFTER instana import
funcName:custom_func message:Hello, world
```