### PR TITLE
Fix OTel logging tests

### DIFF
--- a/tests/clients/test_logging.py
+++ b/tests/clients/test_logging.py
@@ -120,8 +120,9 @@ class TestLogging(unittest.TestCase):
         def log_custom_warning():
             self.logger.warning("foo %s", "bar")
 
-        with tracer.start_active_span("test"):
+        with tracer.start_as_current_span("test"):
             log_custom_warning()
-        self.assertEqual(self.caplog.records[0].funcName, "log_custom_warning")
+
+        assert self.caplog.records[-1].funcName == "log_custom_warning"
 
         self.logger.removeHandler(handler)

--- a/tests/clients/test_logging.py
+++ b/tests/clients/test_logging.py
@@ -2,28 +2,27 @@
 # (c) Copyright Instana Inc. 2020
 
 import logging
-import unittest
+from typing import Generator
 from unittest.mock import patch
 
+import pytest
 from opentelemetry.trace import SpanKind
 
-import pytest
 from instana.singletons import agent, tracer
 
-class TestLogging(unittest.TestCase):
 
-    @pytest.fixture
-    def capture_log(self, caplog):
-        self.caplog = caplog
-
-    def setUp(self) -> None:
-        """Clear all spans before a test run"""
+class TestLogging:
+    @pytest.fixture(autouse=True)
+    def _resource(self) -> Generator[None, None, None]:
+        """SetUp and TearDown"""
+        # setup
+        # Clear all spans before a test run
         self.recorder = tracer.span_processor
         self.recorder.clear_spans()
         self.logger = logging.getLogger("unit test")
-
-    def tearDown(self) -> None:
-        """Ensure that allow_exit_as_root has the default value"""
+        yield
+        # tearDown
+        # Ensure that allow_exit_as_root has the default value
         agent.options.allow_exit_as_root = False
 
     def test_no_span(self) -> None:
@@ -32,6 +31,7 @@ class TestLogging(unittest.TestCase):
             self.logger.info("info message")
 
         spans = self.recorder.queued_spans()
+
         assert len(spans) == 1
 
     def test_extra_span(self) -> None:
@@ -39,9 +39,9 @@ class TestLogging(unittest.TestCase):
             self.logger.warning("foo %s", "bar")
 
         spans = self.recorder.queued_spans()
+
         assert len(spans) == 2
         assert spans[0].k is SpanKind.CLIENT
-
         assert spans[0].data["log"].get("message") == "foo bar"
 
     def test_log_with_tuple(self) -> None:
@@ -49,9 +49,9 @@ class TestLogging(unittest.TestCase):
             self.logger.warning("foo %s", ("bar",))
 
         spans = self.recorder.queued_spans()
+
         assert len(spans) == 2
         assert spans[0].k is SpanKind.CLIENT
-
         assert spans[0].data["log"].get("message") == "foo ('bar',)"
 
     def test_log_with_dict(self) -> None:
@@ -59,9 +59,9 @@ class TestLogging(unittest.TestCase):
             self.logger.warning("foo %s", {"bar": 18})
 
         spans = self.recorder.queued_spans()
+
         assert len(spans) == 2
         assert spans[0].k is SpanKind.CLIENT
-
         assert spans[0].data["log"].get("message") == "foo {'bar': 18}"
 
     def test_parameters(self) -> None:
@@ -74,8 +74,8 @@ class TestLogging(unittest.TestCase):
                 self.logger.exception("Exception: %s", str(e))
 
         spans = self.recorder.queued_spans()
-        assert len(spans) == 2
 
+        assert len(spans) == 2
         assert spans[0].data["log"].get("parameters") is not None
 
     def test_no_root_exit_span(self) -> None:
@@ -83,6 +83,7 @@ class TestLogging(unittest.TestCase):
         self.logger.info("info message")
 
         spans = self.recorder.queued_spans()
+
         assert len(spans) == 0
 
     def test_root_exit_span(self) -> None:
@@ -90,9 +91,9 @@ class TestLogging(unittest.TestCase):
         self.logger.warning("foo %s", "bar")
 
         spans = self.recorder.queued_spans()
+
         assert len(spans) == 1
         assert spans[0].k is SpanKind.CLIENT
-
         assert spans[0].data["log"].get("message") == "foo bar"
 
     def test_exception(self) -> None:
@@ -104,13 +105,12 @@ class TestLogging(unittest.TestCase):
                 self.logger.warning("foo %s", "bar")
 
         spans = self.recorder.queued_spans()
+
         assert len(spans) == 2
         assert spans[0].k is SpanKind.CLIENT
-
         assert spans[0].data["log"] == {}
 
-    @pytest.mark.usefixtures("capture_log")
-    def test_log_caller(self):
+    def test_log_caller(self, caplog: pytest.LogCaptureFixture) -> None:
         handler = logging.StreamHandler()
         handler.setFormatter(
             logging.Formatter("source: %(funcName)s, message: %(message)s")
@@ -123,6 +123,6 @@ class TestLogging(unittest.TestCase):
         with tracer.start_as_current_span("test"):
             log_custom_warning()
 
-        assert self.caplog.records[-1].funcName == "log_custom_warning"
+        assert caplog.records[-1].funcName == "log_custom_warning"
 
         self.logger.removeHandler(handler)


### PR DESCRIPTION
- fix: Adapt logging tests to OTel after rebase.
- tests(logging): Refactor to pure pytest UT.
