### PR TITLE
fix: Remove an unsupported Span data field.

### DIFF
--- a/src/instana/span.py
+++ b/src/instana/span.py
@@ -106,7 +106,6 @@ class BaseSpan(object):
         self.t = span.context.trace_id
         self.p = span.parent_id
         self.s = span.context.span_id
-        self.l = span.context.level
         self.ts = int(round(span.start_time * 1000))
         self.d = int(round(span.duration * 1000))
         self.f = source


### PR DESCRIPTION
Removed the data field "l" (which stores the span level) from the Span data since the Instana Backend does not support it.