### PR TITLE
[OTel] Guarantee propagators tests after OTel migration.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,6 @@ from instana.tracer import InstanaTracerProvider
 # Ignoring tests during OpenTelemetry migration.
 collect_ignore_glob = [
     "*platforms*",
-    "*propagators*",
     "*w3c_trace_context*",
 ]
 

--- a/tests/propagators/test_binary_propagator.py
+++ b/tests/propagators/test_binary_propagator.py
@@ -1,73 +1,180 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2021
 
+from typing import Generator
+
+import pytest
+from opentelemetry.trace import (
+    format_span_id,
+    format_trace_id,
+)
+
 from instana.propagators.binary_propagator import BinaryPropagator
 from instana.span_context import SpanContext
-import unittest
 
 
-class TestBinaryPropagator(unittest.TestCase):
-    def setUp(self):
+class TestBinaryPropagator:
+    @pytest.fixture(autouse=True)
+    def _resources(self) -> Generator[None, None, None]:
+        """SetUp and TearDown"""
+        # setup
         self.bp = BinaryPropagator()
+        yield
 
-    def test_inject_carrier_dict(self):
+    def test_inject_carrier_dict(self, trace_id: int, span_id: int) -> None:
         carrier = {}
-        ctx = SpanContext(span_id="1234567890abcdef", trace_id="1234d0e0e4736234",
-                                  level=1, baggage={}, sampled=True,
-                                  synthetic=False)
+        ctx = SpanContext(
+            span_id=span_id,
+            trace_id=trace_id,
+            is_remote=False,
+            level=1,
+            baggage={},
+            sampled=True,
+            synthetic=False,
+        )
         carrier = self.bp.inject(ctx, carrier)
-        self.assertEqual(carrier[b'x-instana-t'], b"1234d0e0e4736234")
 
-    def test_inject_carrier_dict_w3c_True(self):
+        assert carrier[b"x-instana-t"] == str(trace_id).encode("utf-8")
+        assert carrier[b"x-instana-s"] == str(span_id).encode("utf-8")
+        assert carrier[b"x-instana-l"] == b"1"
+        assert carrier[b"server-timing"] == f"intid;desc={trace_id}".encode("utf-8")
+
+    def test_inject_carrier_dict_w3c_True(self, trace_id: int, span_id: int) -> None:
         carrier = {}
-        ctx = SpanContext(span_id="1234567890abcdef", trace_id="1234d0e0e4736234",
-                                  level=1, baggage={}, sampled=True,
-                                  synthetic=False)
+        ctx = SpanContext(
+            span_id=span_id,
+            trace_id=trace_id,
+            is_remote=False,
+            level=1,
+            baggage={},
+            sampled=True,
+            synthetic=False,
+        )
         carrier = self.bp.inject(ctx, carrier, disable_w3c_trace_context=False)
-        self.assertEqual(carrier[b'x-instana-t'], b"1234d0e0e4736234")
-        self.assertEqual(carrier[b'traceparent'], b'00-00000000000000001234d0e0e4736234-1234567890abcdef-01')
-        self.assertEqual(carrier[b'tracestate'], b'in=1234d0e0e4736234;1234567890abcdef')
 
-    def test_inject_carrier_list(self):
+        assert carrier[b"x-instana-t"] == str(trace_id).encode("utf-8")
+        assert carrier[b"x-instana-s"] == str(span_id).encode("utf-8")
+        assert carrier[b"x-instana-l"] == b"1"
+        assert carrier[b"server-timing"] == f"intid;desc={trace_id}".encode("utf-8")
+        assert carrier[
+            b"traceparent"
+        ] == f"00-{format_trace_id(trace_id)}-{format_span_id(span_id)}-01".encode(
+            "utf-8"
+        )
+        assert carrier[b"tracestate"] == f"in={trace_id};{span_id}".encode("utf-8")
+
+    def test_inject_carrier_list(self, trace_id: int, span_id: int) -> None:
         carrier = []
-        ctx = SpanContext(span_id="1234567890abcdef", trace_id="1234d0e0e4736234",
-                                  level=1, baggage={}, sampled=True,
-                                  synthetic=False)
+        ctx = SpanContext(
+            span_id=span_id,
+            trace_id=trace_id,
+            is_remote=False,
+            level=1,
+            baggage={},
+            sampled=True,
+            synthetic=False,
+        )
         carrier = self.bp.inject(ctx, carrier)
-        self.assertEqual(carrier[0], (b'x-instana-t', b'1234d0e0e4736234'))
 
-    def test_inject_carrier_list_w3c_True(self):
+        assert isinstance(carrier, list)
+        assert carrier[0] == (b"x-instana-t", str(trace_id).encode("utf-8"))
+        assert carrier[1] == (b"x-instana-s", str(span_id).encode("utf-8"))
+        assert carrier[2] == (b"x-instana-l", b"1")
+        assert carrier[3] == (
+            b"server-timing",
+            f"intid;desc={trace_id}".encode("utf-8"),
+        )
+
+    def test_inject_carrier_list_w3c_True(self, trace_id: int, span_id: int) -> None:
         carrier = []
-        ctx = SpanContext(span_id="1234567890abcdef", trace_id="1234d0e0e4736234",
-                                  level=1, baggage={}, sampled=True,
-                                  synthetic=False)
+        ctx = SpanContext(
+            span_id=span_id,
+            trace_id=trace_id,
+            is_remote=False,
+            level=1,
+            baggage={},
+            sampled=True,
+            synthetic=False,
+        )
         carrier = self.bp.inject(ctx, carrier, disable_w3c_trace_context=False)
-        self.assertEqual(carrier[2], (b'x-instana-t', b'1234d0e0e4736234'))
-        self.assertEqual(carrier[0], (b'traceparent', b'00-00000000000000001234d0e0e4736234-1234567890abcdef-01'))
-        self.assertEqual(carrier[1], (b'tracestate', b'in=1234d0e0e4736234;1234567890abcdef'))
 
-    def test_inject_carrier_tupple(self):
+        assert isinstance(carrier, list)
+        assert carrier[0] == (
+            b"traceparent",
+            f"00-{format_trace_id(trace_id)}-{format_span_id(span_id)}-01".encode(
+                "utf-8"
+            ),
+        )
+        assert carrier[1] == (b"tracestate", f"in={trace_id};{span_id}".encode("utf-8"))
+        assert carrier[2] == (b"x-instana-t", str(trace_id).encode("utf-8"))
+        assert carrier[3] == (b"x-instana-s", str(span_id).encode("utf-8"))
+        assert carrier[4] == (b"x-instana-l", b"1")
+        assert carrier[5] == (
+            b"server-timing",
+            f"intid;desc={trace_id}".encode("utf-8"),
+        )
+
+    def test_inject_carrier_tuple(self, trace_id: int, span_id: int) -> None:
         carrier = ()
-        ctx = SpanContext(span_id="1234567890abcdef", trace_id="1234d0e0e4736234",
-                                  level=1, baggage={}, sampled=True,
-                                  synthetic=False)
+        ctx = SpanContext(
+            span_id=span_id,
+            trace_id=trace_id,
+            is_remote=False,
+            level=1,
+            baggage={},
+            sampled=True,
+            synthetic=False,
+        )
         carrier = self.bp.inject(ctx, carrier)
-        self.assertEqual(carrier[0], (b'x-instana-t', b'1234d0e0e4736234'))
 
-    def test_inject_carrier_tupple_w3c_True(self):
+        assert isinstance(carrier, tuple)
+        assert carrier[0] == (b"x-instana-t", str(trace_id).encode("utf-8"))
+        assert carrier[1] == (b"x-instana-s", str(span_id).encode("utf-8"))
+        assert carrier[2] == (b"x-instana-l", b"1")
+        assert carrier[3] == (
+            b"server-timing",
+            f"intid;desc={trace_id}".encode("utf-8"),
+        )
+
+    def test_inject_carrier_tuple_w3c_True(self, trace_id: int, span_id: int) -> None:
         carrier = ()
-        ctx = SpanContext(span_id="1234567890abcdef", trace_id="1234d0e0e4736234",
-                                  level=1, baggage={}, sampled=True,
-                                  synthetic=False)
+        ctx = SpanContext(
+            span_id=span_id,
+            trace_id=trace_id,
+            is_remote=False,
+            level=1,
+            baggage={},
+            sampled=True,
+            synthetic=False,
+        )
         carrier = self.bp.inject(ctx, carrier, disable_w3c_trace_context=False)
-        self.assertEqual(carrier[2], (b'x-instana-t', b'1234d0e0e4736234'))
-        self.assertEqual(carrier[0], (b'traceparent', b'00-00000000000000001234d0e0e4736234-1234567890abcdef-01'))
-        self.assertEqual(carrier[1], (b'tracestate', b'in=1234d0e0e4736234;1234567890abcdef'))
 
-    def test_inject_carrier_set_exception(self):
+        assert isinstance(carrier, tuple)
+        assert carrier[0] == (
+            b"traceparent",
+            f"00-{format_trace_id(trace_id)}-{format_span_id(span_id)}-01".encode(
+                "utf-8"
+            ),
+        )
+        assert carrier[1] == (b"tracestate", f"in={trace_id};{span_id}".encode("utf-8"))
+        assert carrier[2] == (b"x-instana-t", str(trace_id).encode("utf-8"))
+        assert carrier[3] == (b"x-instana-s", str(span_id).encode("utf-8"))
+        assert carrier[4] == (b"x-instana-l", b"1")
+        assert carrier[5] == (
+            b"server-timing",
+            f"intid;desc={trace_id}".encode("utf-8"),
+        )
+
+    def test_inject_carrier_set_exception(self, trace_id: int, span_id: int) -> None:
         carrier = set()
-        ctx = SpanContext(span_id="1234567890abcdef", trace_id="1234d0e0e4736234",
-                                  level=1, baggage={}, sampled=True,
-                                  synthetic=False)
+        ctx = SpanContext(
+            span_id=span_id,
+            trace_id=trace_id,
+            is_remote=False,
+            level=1,
+            baggage={},
+            sampled=True,
+            synthetic=False,
+        )
         carrier = self.bp.inject(ctx, carrier)
-        self.assertIsNone(carrier)
+        assert not carrier

--- a/tests/propagators/test_http_propagator.py
+++ b/tests/propagators/test_http_propagator.py
@@ -1,364 +1,341 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2021
 
-from instana.propagators.http_propagator import HTTPPropagator
-from instana.w3c_trace_context.traceparent import Traceparent
-from instana.span_context import SpanContext
-from mock import patch
 import os
-import unittest
+from typing import Any, Dict, Generator
+
+import pytest
+from opentelemetry.trace import (
+    INVALID_SPAN_ID,
+    INVALID_TRACE_ID,
+    format_span_id,
+    format_trace_id,
+)
+
+from instana.propagators.http_propagator import HTTPPropagator
+from instana.span_context import SpanContext
+from instana.util.ids import header_to_id
 
 
-class TestHTTPPropagatorTC(unittest.TestCase):
-    def setUp(self):
+class TestHTTPPropagator:
+    @pytest.fixture(autouse=True)
+    def _resources(self) -> Generator[None, None, None]:
+        """SetUp and TearDown"""
+        # setup
         self.hptc = HTTPPropagator()
-
-    def tearDown(self):
-        """ Clear the INSTANA_DISABLE_W3C_TRACE_CORRELATION environment variable """
+        yield
+        # teardown
+        # Clear the INSTANA_DISABLE_W3C_TRACE_CORRELATION environment variable
         os.environ["INSTANA_DISABLE_W3C_TRACE_CORRELATION"] = ""
 
-    @patch.object(Traceparent, "get_traceparent_fields")
-    @patch.object(Traceparent, "validate")
-    def test_extract_carrier_dict(self, mock_validate, mock_get_traceparent_fields):
+    @pytest.fixture(scope="function")
+    def _instana_long_tracer_id(self) -> str:
+        return "4bf92f3577b34da6a3ce929d0e0e4736"
+
+    @pytest.fixture(scope="function")
+    def _instana_span_id(self) -> str:
+        return "00f067aa0ba902b7"
+
+    @pytest.fixture(scope="function")
+    def _trace_id(self, _instana_long_tracer_id: str) -> int:
+        return int(_instana_long_tracer_id[-16:], 16)
+
+    @pytest.fixture(scope="function")
+    def _span_id(self, _instana_span_id: str) -> int:
+        return int(_instana_span_id, 16)
+
+    @pytest.fixture(scope="function")
+    def _long_tracer_id(self, _instana_long_tracer_id: str) -> int:
+        return int(_instana_long_tracer_id, 16)
+
+    @pytest.fixture(scope="function")
+    def _traceparent(self, _instana_long_tracer_id: str, _instana_span_id: str) -> str:
+        return f"00-{_instana_long_tracer_id}-{_instana_span_id}-01"
+
+    @pytest.fixture(scope="function")
+    def _tracestate(self) -> str:
+        return "congo=t61rcWkgMzE"
+
+    def test_extract_carrier_dict(
+        self,
+        trace_id: int,
+        span_id: int,
+        _instana_long_tracer_id: str,
+        _instana_span_id: str,
+        _long_tracer_id: int,
+        _trace_id: int,
+        _span_id: int,
+        _traceparent: str,
+        _tracestate: str,
+    ) -> None:
         carrier = {
-            'traceparent': '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
-            'tracestate': 'congo=t61rcWkgMzE',
-            'X-INSTANA-T': '1234d0e0e4736234',
-            'X-INSTANA-S': '1234567890abcdef',
-            'X-INSTANA-L': '1, correlationType=web; correlationId=1234567890abcdef'
+            "traceparent": _traceparent,
+            "tracestate": _tracestate,
+            "X-INSTANA-T": f"{trace_id}",
+            "X-INSTANA-S": f"{span_id}",
+            "X-INSTANA-L": f"1, correlationType=web; correlationId={span_id}",
         }
-        mock_validate.return_value = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
-        mock_get_traceparent_fields.return_value = ["00", "4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7", True]
+
         ctx = self.hptc.extract(carrier)
-        self.assertEqual(ctx.correlation_id, '1234567890abcdef')
-        self.assertEqual(ctx.correlation_type, "web")
-        self.assertIsNone(ctx.instana_ancestor)
-        self.assertEqual(ctx.level, 1)
-        self.assertEqual(ctx.long_trace_id, "4bf92f3577b34da6a3ce929d0e0e4736")
-        self.assertEqual(ctx.span_id, "00f067aa0ba902b7")
-        self.assertFalse(ctx.synthetic)
-        self.assertEqual(ctx.trace_id, "a3ce929d0e0e4736")  # 16 last chars from traceparent trace_id
-        self.assertTrue(ctx.trace_parent)
-        self.assertEqual(ctx.traceparent, '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01')
-        self.assertEqual(ctx.tracestate, 'congo=t61rcWkgMzE')
 
-    @patch.object(Traceparent, "get_traceparent_fields")
-    @patch.object(Traceparent, "validate")
-    def test_extract_carrier_list(self, mock_validate, mock_get_traceparent_fields):
-        carrier = [('user-agent', 'python-requests/2.23.0'), ('accept-encoding', 'gzip, deflate'),
-                   ('accept', '*/*'), ('connection', 'keep-alive'),
-                   ('traceparent', '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'),
-                   ('tracestate', 'congo=t61rcWkgMzE'),
-                   ('X-INSTANA-T', '1234d0e0e4736234'),
-                   ('X-INSTANA-S', '1234567890abcdef'),
-                   ('X-INSTANA-L', '1')]
+        assert ctx.correlation_id == str(span_id)
+        assert ctx.correlation_type == "web"
+        assert not ctx.instana_ancestor
+        assert ctx.level == 1
+        assert ctx.long_trace_id == header_to_id(_instana_long_tracer_id)
+        assert ctx.span_id == _span_id
+        assert not ctx.synthetic
+        assert ctx.trace_id == _trace_id
+        assert ctx.trace_parent
+        assert ctx.traceparent == f"00-{_instana_long_tracer_id}-{_instana_span_id}-01"
+        assert ctx.tracestate == _tracestate
 
-        mock_validate.return_value = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
-        mock_get_traceparent_fields.return_value = ["00", "4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7", True]
+    def test_extract_carrier_list(
+        self,
+        trace_id: int,
+        span_id: int,
+        _instana_long_tracer_id: str,
+        _instana_span_id: str,
+        _traceparent: str,
+        _tracestate: str,
+    ) -> None:
+        carrier = [
+            ("user-agent", "python-requests/2.23.0"),
+            ("accept-encoding", "gzip, deflate"),
+            ("accept", "*/*"),
+            ("connection", "keep-alive"),
+            ("traceparent", _traceparent),
+            ("tracestate", _tracestate),
+            ("X-INSTANA-T", f"{trace_id}"),
+            ("X-INSTANA-S", f"{span_id}"),
+            ("X-INSTANA-L", "1"),
+        ]
+
         ctx = self.hptc.extract(carrier)
-        self.assertIsNone(ctx.correlation_id)
-        self.assertIsNone(ctx.correlation_type)
-        self.assertIsNone(ctx.instana_ancestor)
-        self.assertEqual(ctx.level, 1)
-        self.assertIsNone(ctx.long_trace_id)
-        self.assertEqual(ctx.span_id, "1234567890abcdef")
-        self.assertFalse(ctx.synthetic)
-        self.assertEqual(ctx.trace_id, "1234d0e0e4736234")  # 16 last chars from traceparent trace_id
-        self.assertIsNone(ctx.trace_parent)
-        self.assertEqual(ctx.traceparent, '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01')
-        self.assertEqual(ctx.tracestate, 'congo=t61rcWkgMzE')
 
-    @patch.object(Traceparent, "validate")
-    def test_extract_carrier_dict_validate_Exception_None_returned(self, mock_validate):
-        """
-        In this test case the traceparent header fails the validation, so traceparent and tracestate are not gonna used
-        Additionally because in the instana L header the correlation flags are present we need to start a new ctx and
-        the present values of 'X-INSTANA-T', 'X-INSTANA-S' headers should no be used. This means the ctx should be None
-        :param mock_validate:
-        :return:
-        """
+        assert not ctx.correlation_id
+        assert not ctx.correlation_type
+        assert not ctx.instana_ancestor
+        assert ctx.level == 1
+        assert not ctx.long_trace_id
+        assert ctx.span_id == span_id
+        assert not ctx.synthetic
+        assert ctx.trace_id == trace_id
+        assert not ctx.trace_parent
+        assert ctx.traceparent == f"00-{_instana_long_tracer_id}-{_instana_span_id}-01"
+        assert ctx.tracestate == _tracestate
+
+    def test_extract_carrier_dict_validate_Exception_None_returned(
+        self,
+        trace_id: int,
+        span_id: int,
+        _tracestate: str,
+    ) -> None:
+        # In this test case, the traceparent header fails the validation, so
+        # traceparent and tracestate are not used.
+        # Additionally, because the correlation flags are present in the
+        # 'X-INSTANA-L' header, we need to start a new SpanContext, and the
+        # present values of 'X-INSTANA-T' and 'X-INSTANA-S' headers should not
+        # be used.
+
         carrier = {
-            'traceparent': '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
-            'tracestate': 'congo=t61rcWkgMzE',
-            'X-INSTANA-T': '1234d0e0e4736234',
-            'X-INSTANA-S': '1234567890abcdef',
-            'X-INSTANA-L': '1, correlationType=web; correlationId=1234567890abcdef'
+            "traceparent": "00-4gf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'",  # the long-trace-id is malformed to be invalid.
+            "tracestate": _tracestate,
+            "X-INSTANA-T": f"{trace_id}",
+            "X-INSTANA-S": f"{span_id}",
+            "X-INSTANA-L": f"1, correlationType=web; correlationId={span_id}",
         }
-        mock_validate.return_value = None
-        ctx = self.hptc.extract(carrier)
-        self.assertTrue(isinstance(ctx, SpanContext))
-        assert ctx.trace_id is None
-        assert ctx.span_id is None
-        assert ctx.synthetic is False
-        self.assertEqual(ctx.correlation_id, "1234567890abcdef")
-        self.assertEqual(ctx.correlation_type, "web")
 
-    @patch.object(Traceparent, "validate")
-    def test_extract_fake_exception(self, mock_validate):
+        ctx = self.hptc.extract(carrier)
+
+        assert isinstance(ctx, SpanContext)
+        assert ctx.trace_id == INVALID_TRACE_ID
+        assert ctx.span_id == INVALID_SPAN_ID
+        assert not ctx.synthetic
+        assert ctx.correlation_id == str(span_id)
+        assert ctx.correlation_type == "web"
+
+    def test_extract_fake_exception(
+        self,
+        trace_id: int,
+        span_id: int,
+        _tracestate: str,
+        mocker,
+    ) -> None:
         carrier = {
-            'traceparent': '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
-            'tracestate': 'congo=t61rcWkgMzE',
-            'X-INSTANA-T': '1234d0e0e4736234',
-            'X-INSTANA-S': '1234567890abcdef',
-            'X-INSTANA-L': '1, correlationType=web; correlationId=1234567890abcdef'
+            "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e-00f067aa0ba902b7-01",
+            "tracestate": _tracestate,
+            "X-INSTANA-T": f"{trace_id}",
+            "X-INSTANA-S": f"{span_id}",
+            "X-INSTANA-L": f"1, correlationType=web; correlationId={span_id}",
         }
-        mock_validate.side_effect = Exception
-        ctx = self.hptc.extract(carrier)
-        self.assertIsNone(ctx)
+        with pytest.raises(Exception):
+            ctx = self.hptc.extract(carrier)
+            assert not ctx
 
-    @patch.object(Traceparent, "get_traceparent_fields")
-    @patch.object(Traceparent, "validate")
-    def test_extract_carrier_dict_corrupted_level_header(self, mock_validate, mock_get_traceparent_fields):
-        """
-        In this test case the traceparent header fails the validation, so traceparent and tracestate are not gonna used
-        Additionally because in the instana L header the correlation flags are present we need to start a new ctx and
-        the present values of 'X-INSTANA-T', 'X-INSTANA-S' headers should no be used. This means the ctx should be None
-        :param mock_validate:
-        :return:
-        """
+    def test_extract_carrier_dict_corrupted_level_header(
+        self,
+        trace_id: int,
+        span_id: int,
+        _instana_long_tracer_id: str,
+        _trace_id: int,
+        _span_id: int,
+        _traceparent: str,
+        _tracestate: str,
+    ) -> None:
+        # In this test case, the 'X-INSTANA-L' header is corrupted
+
         carrier = {
-            'traceparent': '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
-            'tracestate': 'congo=t61rcWkgMzE',
-            'X-INSTANA-T': '1234d0e0e4736234',
-            'X-INSTANA-S': '1234567890abcdef',
-            'X-INSTANA-L': '1, correlationTypeweb; correlationId1234567890abcdef'
+            "traceparent": _traceparent,
+            "tracestate": _tracestate,
+            "X-INSTANA-T": f"{trace_id}",
+            "X-INSTANA-S": f"{span_id}",
+            "X-INSTANA-L": f"1, correlationType=web; correlationId{span_id}",
         }
-        mock_validate.return_value = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
-        mock_get_traceparent_fields.return_value = ["00", "4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7", True]
-        ctx = self.hptc.extract(carrier)
-        self.assertIsNone(ctx.correlation_id)
-        self.assertIsNone(ctx.correlation_type)
-        self.assertIsNone(ctx.instana_ancestor)
-        self.assertEqual(ctx.level, 1)
-        self.assertEqual(ctx.long_trace_id, '4bf92f3577b34da6a3ce929d0e0e4736')
-        self.assertEqual(ctx.span_id, "00f067aa0ba902b7")
-        self.assertFalse(ctx.synthetic)
-        self.assertEqual(ctx.trace_id, "a3ce929d0e0e4736")  # 16 last chars from traceparent trace_id
-        self.assertTrue(ctx.trace_parent)
-        self.assertEqual(ctx.traceparent, '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01')
-        self.assertEqual(ctx.tracestate, 'congo=t61rcWkgMzE')
 
-    @patch.object(Traceparent, "get_traceparent_fields")
-    @patch.object(Traceparent, "validate")
-    def test_extract_carrier_dict_level_header_not_splitable(self, mock_validate, mock_get_traceparent_fields):
-        """
-        In this test case the traceparent header fails the validation, so traceparent and tracestate are not gonna used
-        Additionally because in the instana L header the correlation flags are present we need to start a new ctx and
-        the present values of 'X-INSTANA-T', 'X-INSTANA-S' headers should no be used. This means the ctx should be None
-        :param mock_validate:
-        :return:
-        """
+        ctx = self.hptc.extract(carrier)
+
+        assert not ctx.correlation_id
+        assert ctx.correlation_type == "web"
+        assert not ctx.instana_ancestor
+        assert ctx.level == 1
+        assert ctx.long_trace_id == header_to_id(_instana_long_tracer_id)
+        assert ctx.span_id == _span_id
+        assert not ctx.synthetic
+        assert ctx.trace_id == _trace_id
+        assert ctx.trace_parent
+        assert ctx.traceparent == _traceparent
+        assert ctx.tracestate == _tracestate
+
+    def test_extract_carrier_dict_level_header_not_splitable(
+        self,
+        trace_id: int,
+        span_id: int,
+        _traceparent: str,
+        _tracestate: str,
+    ) -> None:
         carrier = {
-            'traceparent': '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
-            'tracestate': 'congo=t61rcWkgMzE',
-            'X-INSTANA-T': '1234d0e0e4736234',
-            'X-INSTANA-S': '1234567890abcdef',
-            'X-INSTANA-L': ['1']
+            "traceparent": _traceparent,
+            "tracestate": _tracestate,
+            "X-INSTANA-T": f"{trace_id}",
+            "X-INSTANA-S": f"{span_id}",
+            "X-INSTANA-L": ["1"],
         }
-        mock_validate.return_value = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
-        mock_get_traceparent_fields.return_value = ["00", "4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7", True]
-        ctx = self.hptc.extract(carrier)
-        self.assertIsNone(ctx.correlation_id)
-        self.assertIsNone(ctx.correlation_type)
-        self.assertIsNone(ctx.instana_ancestor)
-        self.assertEqual(ctx.level, 1)
-        self.assertIsNone(ctx.long_trace_id)
-        self.assertEqual(ctx.span_id, "1234567890abcdef")
-        self.assertFalse(ctx.synthetic)
-        self.assertEqual(ctx.trace_id, "1234d0e0e4736234")
-        self.assertIsNone(ctx.trace_parent)
-        self.assertEqual(ctx.traceparent, '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01')
-        self.assertEqual(ctx.tracestate, 'congo=t61rcWkgMzE')
 
-
-    # 28 in the tracer_compliance_test_cases.json
-    # "Scenario/incoming headers": "w3c off, only X-INSTANA-L=0",
-    def test_w3c_off_only_x_instana_l_0(self):
-        carrier = {
-            'X-INSTANA-L': '0'
-        }
-        os.environ['INSTANA_DISABLE_W3C_TRACE_CORRELATION'] = 'yes_please'
         ctx = self.hptc.extract(carrier)
 
-        # Assert that the level is (zero) int, not str
-        self.assertEqual(ctx.level, 0)
-        # Assert that the suppression is on
-        self.assertTrue(ctx.suppression)
+        assert not ctx.correlation_id
+        assert not ctx.correlation_type
+        assert not ctx.instana_ancestor
+        assert ctx.level == 1
+        assert not ctx.long_trace_id
+        assert ctx.span_id == span_id
+        assert not ctx.synthetic
+        assert ctx.trace_id == trace_id
+        assert not ctx.trace_parent
+        assert ctx.traceparent == _traceparent
+        assert ctx.tracestate == _tracestate
 
-        # Assert that the rest of the attributes are on their default value
-        self.assertTrue(ctx.sampled)
-        self.assertFalse(ctx.synthetic)
-        self.assertEqual(ctx._baggage, {})
+    # The following tests are based on the test cases defined in the
+    # tracer_compliance_test_cases.json file.
+    #
+    # Each line of the parametrize tuple correlates to a test case scenario:
+    # - scenario 28: "Scenario/incoming headers": "w3c off, only X-INSTANA-L=0"
+    # - scenario 29: "Scenario/incoming headers": "w3c off, X-INSTANA-L=0 plus -T and -S"
+    # - scenario 30: "Scenario/incoming headers": "w3c off, X-INSTANA-L=0 plus traceparent"
+    # - scenario 31: "Scenario/incoming headers": "w3c off, X-INSTANA-L=0 plus traceparent and tracestate",
+    @pytest.mark.parametrize(
+        "disable_w3c, carrier_header",
+        [
+            ("yes_please", {"X-INSTANA-L": "0"}),
+            (
+                "w3c_trace_correlation_stinks",
+                {
+                    "X-INSTANA-T": "11803532876627986230",
+                    "X-INSTANA-S": "67667974448284343",
+                    "X-INSTANA-L": "0",
+                },
+            ),
+            (
+                "w3c_trace_correlation_stinks",
+                {
+                    "traceparent": "00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01",
+                    "X-INSTANA-L": "0",
+                },
+            ),
+            (
+                "w3c_trace_correlation_stinks",
+                {
+                    "traceparent": "00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01",
+                    "tracestate": "congo=ucfJifl5GOE,rojo=00f067aa0ba902b7",
+                    "X-INSTANA-L": "0",
+                },
+            ),
+        ],
+    )
+    def test_w3c_off_x_instana_l_0(
+        self,
+        disable_w3c: str,
+        carrier_header: Dict[str, Any],
+        trace_id: int,
+    ) -> None:
+        os.environ["INSTANA_DISABLE_W3C_TRACE_CORRELATION"] = disable_w3c
 
-        self.assertTrue(
-                all(map(lambda x: x is None,
-                    (ctx.correlation_id, ctx.trace_id, ctx.span_id,
-                     ctx.trace_parent, ctx.instana_ancestor,
-                     ctx.long_trace_id, ctx.correlation_type,
-                     ctx.correlation_id, ctx.traceparent, ctx.tracestate)
-            )))
+        ctx = self.hptc.extract(carrier_header)
 
-        # Simulate the sideffect of starting a span,
-        # getting a trace_id and span_id:
-        ctx.trace_id = ctx.span_id = '4dfe94d65496a02c'
+        # Assert the level is (zero) int, not str
+        assert isinstance(ctx.level, int)
+        assert ctx.level == 0
+
+        # Assert the suppression is on
+        assert ctx.suppression
+
+        # Assert the rest of the attributes are on their default value
+        assert ctx.trace_id == INVALID_TRACE_ID
+        assert ctx.span_id == INVALID_SPAN_ID
+        assert not ctx.synthetic
+        assert not ctx.correlation_id
+        assert not ctx.trace_parent
+        assert not ctx.instana_ancestor
+        assert not ctx.long_trace_id
+        assert not ctx.correlation_type
+        assert not ctx.correlation_id
+
+        # Assert that the traceparent is propagated when it is enabled
+        if "traceparent" in carrier_header.keys():
+            assert ctx.traceparent
+            tp_trace_id = header_to_id(carrier_header["traceparent"].split("-")[1])
+        else:
+            assert not ctx.traceparent
+            tp_trace_id = ctx.trace_id
+
+        # Assert that the tracestate is propagated when it is enabled
+        if "tracestate" in carrier_header.keys():
+            assert ctx.tracestate
+        else:
+            assert not ctx.tracestate
+
+        # Simulate the side-effect of starting a span, getting a trace_id and span_id.
+        # Actually, with OTel API using a Tuple to store the SpanContext info,
+        # this will not change the values.
+        ctx.trace_id = ctx.span_id = trace_id
 
         # Test propagation
         downstream_carrier = {}
 
         self.hptc.inject(ctx, downstream_carrier)
 
-        # Assert that 'X-INSTANA-L' has been injected with the correct 0 value
-        self.assertIn('X-INSTANA-L', downstream_carrier)
-        self.assertEqual(downstream_carrier.get('X-INSTANA-L'), '0')
+        # Assert the 'X-INSTANA-L' has been injected with the correct 0 value
+        assert "X-INSTANA-L" in downstream_carrier
+        assert downstream_carrier.get("X-INSTANA-L") == "0"
 
-        self.assertIn('traceparent', downstream_carrier)
-        self.assertEqual('00-0000000000000000' + ctx.trace_id + '-' + ctx.span_id + '-00',
-                         downstream_carrier.get('traceparent'))
+        assert "traceparent" in downstream_carrier
+        assert (
+            downstream_carrier.get("traceparent")
+            == f"00-{format_trace_id(tp_trace_id)}-{format_span_id(ctx.span_id)}-00"
+        )
 
-
-    # 29 in the tracer_compliance_test_cases.json
-    # "Scenario/incoming headers": "w3c off, X-INSTANA-L=0 plus -T and -S",
-    def test_w3c_off_x_instana_l_0_plus_t_and_s(self):
-        os.environ['INSTANA_DISABLE_W3C_TRACE_CORRELATION'] = 'w3c_trace_correlation_stinks'
-        carrier = {
-            'X-INSTANA-T': 'fa2375d711a4ca0f',
-            'X-INSTANA-S': '37cb2d6e9b1c078a',
-            'X-INSTANA-L': '0'
-        }
-
-        ctx = self.hptc.extract(carrier)
-
-        # Assert that the level is (zero) int, not str
-        self.assertEqual(ctx.level, 0)
-        # Assert that the suppression is on
-        self.assertTrue(ctx.suppression)
-
-        # Assert that the rest of the attributes are on their default value
-        # And even T and S are None
-        self.assertTrue(ctx.sampled)
-        self.assertFalse(ctx.synthetic)
-        self.assertEqual(ctx._baggage, {})
-
-        self.assertTrue(
-                all(map(lambda x: x is None,
-                    (ctx.correlation_id, ctx.trace_id, ctx.span_id,
-                     ctx.trace_parent, ctx.instana_ancestor,
-                     ctx.long_trace_id, ctx.correlation_type,
-                     ctx.correlation_id, ctx.traceparent, ctx.tracestate)
-            )))
-
-        # Simulate the sideffect of starting a span,
-        # getting a trace_id and span_id:
-        ctx.trace_id = ctx.span_id = '4dfe94d65496a02c'
-
-        # Test propagation
-        downstream_carrier = {}
-
-        self.hptc.inject(ctx, downstream_carrier)
-
-        # Assert that 'X-INSTANA-L' has been injected with the correct 0 value
-        self.assertIn('X-INSTANA-L', downstream_carrier)
-        self.assertEqual(downstream_carrier.get('X-INSTANA-L'), '0')
-
-        self.assertIn('traceparent', downstream_carrier)
-        self.assertEqual('00-0000000000000000' + ctx.trace_id + '-' + ctx.span_id + '-00',
-                         downstream_carrier.get('traceparent'))
-
-
-
-    # 30 in the tracer_compliance_test_cases.json
-    # "Scenario/incoming headers": "w3c off, X-INSTANA-L=0 plus traceparent",
-    def test_w3c_off_x_instana_l_0_plus_traceparent(self):
-        os.environ['INSTANA_DISABLE_W3C_TRACE_CORRELATION'] = 'w3c_trace_correlation_stinks'
-        carrier = {
-            'traceparent': '00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01',
-            'X-INSTANA-L': '0'
-        }
-
-        ctx = self.hptc.extract(carrier)
-
-        # Assert that the level is (zero) int, not str
-        self.assertEqual(ctx.level, 0)
-        # Assert that the suppression is on
-        self.assertTrue(ctx.suppression)
-        # Assert that the traceparent is not None
-        self.assertIsNotNone(ctx.traceparent)
-
-        # Assert that the rest of the attributes are on their default value
-        self.assertTrue(ctx.sampled)
-        self.assertFalse(ctx.synthetic)
-        self.assertEqual(ctx._baggage, {})
-
-        self.assertTrue(
-                all(map(lambda x: x is None,
-                    (ctx.correlation_id, ctx.trace_id, ctx.span_id,
-                     ctx.instana_ancestor, ctx.long_trace_id, ctx.correlation_type,
-                     ctx.correlation_id, ctx.tracestate)
-            )))
-
-        # Simulate the sideffect of starting a span,
-        # getting a trace_id and span_id:
-        ctx.trace_id = ctx.span_id = '4dfe94d65496a02c'
-
-        # Test propagation
-        downstream_carrier = {}
-        self.hptc.inject(ctx, downstream_carrier)
-
-        # Assert that 'X-INSTANA-L' has been injected with the correct 0 value
-        self.assertIn('X-INSTANA-L', downstream_carrier)
-        self.assertEqual(downstream_carrier.get('X-INSTANA-L'), '0')
-        # Assert that the traceparent is propagated
-        self.assertIn('traceparent', downstream_carrier)
-        self.assertEqual('00-0af7651916cd43dd8448eb211c80319c-' + ctx.trace_id + '-00',
-                         downstream_carrier.get('traceparent'))
-
-
-    # 31 in the tracer_compliance_test_cases.json
-    # "Scenario/incoming headers": "w3c off, X-INSTANA-L=0 plus traceparent and tracestate",
-    def test_w3c_off_x_instana_l_0_plus_traceparent_and_tracestate(self):
-        os.environ['INSTANA_DISABLE_W3C_TRACE_CORRELATION'] = 'w3c_trace_correlation_stinks'
-        carrier = {
-            'traceparent': '00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01',
-            'tracestate': 'congo=ucfJifl5GOE,rojo=00f067aa0ba902b7',
-            'X-INSTANA-L': '0'
-        }
-
-        ctx = self.hptc.extract(carrier)
-
-        # Assert that the level is (zero) int, not str
-        self.assertEqual(ctx.level, 0)
-        # Assert that the suppression is on
-        self.assertTrue(ctx.suppression)
-        # Assert that the traceparent is not None
-        self.assertIsNotNone(ctx.traceparent)
-
-        # Assert that the rest of the attributes are on their default value
-        self.assertTrue(ctx.sampled)
-        self.assertFalse(ctx.synthetic)
-        self.assertEqual(ctx._baggage, {})
-
-        self.assertTrue(
-                all(map(lambda x: x is None,
-                    (ctx.correlation_id, ctx.trace_id, ctx.span_id,
-                     ctx.instana_ancestor, ctx.long_trace_id, ctx.correlation_type,
-                     ctx.correlation_id)
-            )))
-
-        # Simulate the sideffect of starting a span,
-        # getting a trace_id and span_id:
-        ctx.trace_id = ctx.span_id = '4dfe94d65496a02c'
-
-        # Test propagation
-        downstream_carrier = {}
-        self.hptc.inject(ctx, downstream_carrier)
-
-        # Assert that 'X-INSTANA-L' has been injected with the correct 0 value
-        self.assertIn('X-INSTANA-L', downstream_carrier)
-        self.assertEqual(downstream_carrier.get('X-INSTANA-L'), '0')
-        # Assert that the traceparent is propagated
-        self.assertIn('traceparent', downstream_carrier)
-        self.assertEqual('00-0af7651916cd43dd8448eb211c80319c-' + ctx.trace_id + '-00',
-                         downstream_carrier.get('traceparent'))
-        # Assert that the tracestate is propagated
-        self.assertIn('tracestate', downstream_carrier)
-        self.assertEqual(carrier['tracestate'], downstream_carrier['tracestate'])
+        # Assert that the tracestate is propagated when it is enabled
+        if "tracestate" in carrier_header.keys():
+            assert "tracestate" in downstream_carrier
+            assert carrier_header["tracestate"] == downstream_carrier["tracestate"]


### PR DESCRIPTION
- Fixed propagators and traceparent files to work after OTel migration, following the OTel and W3C specifications.
- TODO later:
  - Adapted propagators and w3c files to follow new style guidelines.
  - Coverage will be handled later.