### PR TITLE
[OTel] Fix `sanic` headers capture, `couchbase` imports, `sdk.custom.tags`

### DIFF
--- a/src/instana/instrumentation/couchbase_inst.py
+++ b/src/instana/instrumentation/couchbase_inst.py
@@ -6,25 +6,26 @@ couchbase instrumentation - This instrumentation supports the Python CouchBase 2
 https://docs.couchbase.com/python-sdk/2.5/start-using-sdk.html
 """
 
-from typing import Any, Callable, Dict, Tuple, Union
-
-import wrapt
-
-from instana.log import logger
-from instana.span.span import InstanaSpan
-from instana.util.traceutils import get_tracer_tuple, tracing_is_off
-
 try:
     import couchbase
-    from couchbase.bucket import Bucket
+    from instana.log import logger
 
-    if not hasattr(couchbase, "__version__") and (
-        couchbase.__version__ < "2.3.4" or couchbase.__version__ >= "3.0.0"
+    if not (
+        hasattr(couchbase, "__version__")
+        and (couchbase.__version__ >= "2.3.4" and couchbase.__version__ < "3.0.0")
     ):
         logger.debug("Instana supports 2.3.4 <= couchbase_versions < 3.0.0. Skipping.")
         raise ImportError
 
+    from couchbase.bucket import Bucket
     from couchbase.n1ql import N1QLQuery
+
+    from typing import Any, Callable, Dict, Tuple, Union
+
+    import wrapt
+
+    from instana.span.span import InstanaSpan
+    from instana.util.traceutils import get_tracer_tuple, tracing_is_off
 
     # List of operations to instrument
     # incr, incr_multi, decr, decr_multi, retrieve_in are wrappers around operations above

--- a/src/instana/span/sdk_span.py
+++ b/src/instana/span/sdk_span.py
@@ -22,7 +22,7 @@ class SDKSpan(BaseSpan):
 
         self.data["sdk"]["name"] = span.name
         self.data["sdk"]["type"] = span_kind[0]
-        self.data["sdk"]["custom"]["attributes"] = self._validate_attributes(
+        self.data["sdk"]["custom"]["tags"] = self._validate_attributes(
             span.attributes
         )
 

--- a/tests/span/test_span_sdk.py
+++ b/tests/span/test_span_sdk.py
@@ -45,8 +45,8 @@ def test_sdkspan(span_context: SpanContext, span_processor: StanRecorder) -> Non
     assert len(expected_result["data"]["sdk"]) == len(sdk_span.data["sdk"])
     assert expected_result["data"]["sdk"]["name"] == sdk_span.data["sdk"]["name"]
     assert expected_result["data"]["sdk"]["type"] == sdk_span.data["sdk"]["type"]
-    assert len(attributes) == len(sdk_span.data["sdk"]["custom"]["attributes"])
-    assert attributes == sdk_span.data["sdk"]["custom"]["attributes"]
+    assert len(attributes) == len(sdk_span.data["sdk"]["custom"]["tags"])
+    assert attributes == sdk_span.data["sdk"]["custom"]["tags"]
     assert attributes["arguments"] == sdk_span.data["sdk"]["arguments"]
     assert attributes["return"] == sdk_span.data["sdk"]["return"]
 


### PR DESCRIPTION
- fix(sanic): capture headers only if `agent.options.extra_http_headers` is `True`
- fix(sanic): skip instrumentation for unsupported versions
- fix(couchbase): fix skipping instrumentation for unsupported versions. Earlier, it would fail even if `couchbase` does not have `__version__` attribute.
- minor fix(couchbase): skip importing other modules if the package to be instrumented is not present
- fix: capture custom tags on SDK spans: https://github.ibm.com/instana/technical-documentation/tree/master/tracing/specification#span-data