### PR TITLE
Fix OTel header inject values.

### DIFF
--- a/src/instana/instrumentation/aiohttp/server.py
+++ b/src/instana/instrumentation/aiohttp/server.py
@@ -70,9 +70,6 @@ try:
 
                 span.set_attribute(SpanAttributes.HTTP_STATUS_CODE, response.status)
                 tracer.inject(span.context, Format.HTTP_HEADERS, response.headers)
-                response.headers["Server-Timing"] = (
-                    f"intid;desc={span.context.trace_id}"
-                )
 
             return response
         except Exception as exc:

--- a/src/instana/instrumentation/aws/lambda_inst.py
+++ b/src/instana/instrumentation/aws/lambda_inst.py
@@ -16,6 +16,7 @@ from instana import get_aws_lambda_handler
 from instana.instrumentation.aws.triggers import enrich_lambda_span, get_context
 from instana.log import logger
 from instana.singletons import env_is_aws_lambda, get_agent, get_tracer
+from instana.util.ids import define_server_timing
 
 if TYPE_CHECKING:
     from instana.agent.aws_lambda import AWSLambdaAgent
@@ -43,7 +44,7 @@ def lambda_handler_with_instana(
             result = wrapped(*args, **kwargs)
 
             if isinstance(result, dict):
-                server_timing_value = f"intid;desc={span.context.trace_id}"
+                server_timing_value = define_server_timing(span.context.trace_id)
                 if "headers" in result:
                     result["headers"]["Server-Timing"] = server_timing_value
                 elif "multiValueHeaders" in result:

--- a/src/instana/instrumentation/django/middleware.py
+++ b/src/instana/instrumentation/django/middleware.py
@@ -122,9 +122,6 @@ class InstanaMiddleware(MiddlewareMixin):
                     request.span, response.headers, format=False
                 )
                 tracer.inject(request.span.context, Format.HTTP_HEADERS, response)
-                response["Server-Timing"] = (
-                    "intid;desc=%s" % request.span.context.trace_id
-                )
         except Exception:
             logger.debug("Instana middleware @ process_response", exc_info=True)
         finally:

--- a/src/instana/instrumentation/flask/common.py
+++ b/src/instana/instrumentation/flask/common.py
@@ -90,11 +90,6 @@ def handle_user_exception_with_instana(
 
                 if hasattr(response, 'headers'):
                     tracer.inject(span.context, Format.HTTP_HEADERS, response.headers)
-                    value = "intid;desc=%s" % span.context.trace_id
-                    if hasattr(response.headers, 'add'):
-                        response.headers.add('Server-Timing', value)
-                    elif type(response.headers) is dict or hasattr(response.headers, "__dict__"):
-                        response.headers['Server-Timing'] = value
             if span and span.is_recording():
                 span.end()
             flask.g.span = None

--- a/src/instana/instrumentation/flask/vanilla.py
+++ b/src/instana/instrumentation/flask/vanilla.py
@@ -79,9 +79,6 @@ def after_request_with_instana(
             extract_custom_headers(span, response.headers, format=False)
 
             tracer.inject(span.context, Format.HTTP_HEADERS, response.headers)
-            response.headers.add(
-                "Server-Timing", "intid;desc=%s" % span.context.trace_id
-            )
     except:
         logger.debug("Flask after_request", exc_info=True)
     finally:

--- a/src/instana/instrumentation/flask/with_blinker.py
+++ b/src/instana/instrumentation/flask/with_blinker.py
@@ -78,9 +78,6 @@ def request_finished_with_instana(
             extract_custom_headers(span, response.headers, format=False)
 
             tracer.inject(span.context, Format.HTTP_HEADERS, response.headers)
-            response.headers.add(
-                "Server-Timing", "intid;desc=%s" % span.context.trace_id
-            )
     except:
         logger.debug("Flask request_finished_with_instana", exc_info=True)
     finally:

--- a/src/instana/instrumentation/pyramid.py
+++ b/src/instana/instrumentation/pyramid.py
@@ -77,9 +77,6 @@ try:
                     self._extract_custom_headers(span, response.headers)
 
                     tracer.inject(span.context, Format.HTTP_HEADERS, response.headers)
-                    response.headers["Server-Timing"] = (
-                        f"intid;desc={span.context.trace_id}"
-                    )
                 except HTTPException as e:
                     response = e
                     logger.debug(

--- a/src/instana/instrumentation/sanic_inst.py
+++ b/src/instana/instrumentation/sanic_inst.py
@@ -116,9 +116,6 @@ try:
                     if agent.options.extra_http_headers:
                         extract_custom_headers(span, response.headers)
                     tracer.inject(span.context, Format.HTTP_HEADERS, response.headers)
-                    response.headers["Server-Timing"] = (
-                        f"intid;desc={span.context.trace_id}"
-                    )
 
                 if span.is_recording():
                     span.end()

--- a/src/instana/instrumentation/tornado/server.py
+++ b/src/instana/instrumentation/tornado/server.py
@@ -56,7 +56,6 @@ try:
             # Set the context response headers now because tornado doesn't give us a better option to do so
             # later for this request.
             tracer.inject(span.context, Format.HTTP_HEADERS, instance._headers)
-            instance.set_header(name='Server-Timing', value=f"intid;desc={span.context.trace_id}")
 
             return wrapped(*argv, **kwargs)
         except Exception:
@@ -70,7 +69,6 @@ try:
 
         span = instance.request._instana
         tracer.inject(span.context, Format.HTTP_HEADERS, instance._headers)
-        instance.set_header(name='Server-Timing', value=f"intid;desc={span.context.trace_id}")
 
 
     @wrapt.patch_function_wrapper('tornado.web', 'RequestHandler.on_finish')

--- a/src/instana/instrumentation/wsgi.py
+++ b/src/instana/instrumentation/wsgi.py
@@ -26,9 +26,6 @@ class InstanaWSGIMiddleware(object):
         def new_start_response(status: str, headers: List[Tuple[object, ...]], exc_info: Optional[Exception] = None) -> object:
             """Modified start response with additional headers."""
             tracer.inject(self.span.context, Format.HTTP_HEADERS, headers)
-            headers.append(
-                ("Server-Timing", "intid;desc=%s" % self.span.context.trace_id)
-            )
 
             headers_str = [(header[0], str(header[1])) if not isinstance(header[1], str) else header for header in headers]
             res = start_response(status, headers_str, exc_info)

--- a/src/instana/propagators/base_propagator.py
+++ b/src/instana/propagators/base_propagator.py
@@ -38,11 +38,13 @@ class BasePropagator(object):
     HEADER_KEY_SYNTHETIC = 'X-INSTANA-SYNTHETIC'
     HEADER_KEY_TRACEPARENT = "traceparent"
     HEADER_KEY_TRACESTATE = "tracestate"
+    HEADER_KEY_SERVER_TIMING = "Server-Timing"
 
     LC_HEADER_KEY_T = 'x-instana-t'
     LC_HEADER_KEY_S = 'x-instana-s'
     LC_HEADER_KEY_L = 'x-instana-l'
     LC_HEADER_KEY_SYNTHETIC = 'x-instana-synthetic'
+    LC_HEADER_KEY_SERVER_TIMING = "server-timing"
 
     ALT_LC_HEADER_KEY_T = 'http_x_instana_t'
     ALT_LC_HEADER_KEY_S = 'http_x_instana_s'
@@ -50,15 +52,16 @@ class BasePropagator(object):
     ALT_LC_HEADER_KEY_SYNTHETIC = 'http_x_instana_synthetic'
     ALT_HEADER_KEY_TRACEPARENT = "http_traceparent"
     ALT_HEADER_KEY_TRACESTATE = "http_tracestate"
+    ALT_LC_HEADER_KEY_SERVER_TIMING = "http_server_timing"
 
     # ByteArray variations
     B_HEADER_KEY_T = b'x-instana-t'
     B_HEADER_KEY_S = b'x-instana-s'
     B_HEADER_KEY_L = b'x-instana-l'
     B_HEADER_KEY_SYNTHETIC = b'x-instana-synthetic'
-    B_HEADER_SERVER_TIMING = b'server-timing'
     B_HEADER_KEY_TRACEPARENT = b'traceparent'
     B_HEADER_KEY_TRACESTATE = b'tracestate'
+    B_HEADER_KEY_SERVER_TIMING = b"server-timing"
 
     B_ALT_LC_HEADER_KEY_T = b'http_x_instana_t'
     B_ALT_LC_HEADER_KEY_S = b'http_x_instana_s'
@@ -66,6 +69,7 @@ class BasePropagator(object):
     B_ALT_LC_HEADER_KEY_SYNTHETIC = b'http_x_instana_synthetic'
     B_ALT_HEADER_KEY_TRACEPARENT = b'http_traceparent'
     B_ALT_HEADER_KEY_TRACESTATE = b'http_tracestate'
+    B_ALT_LC_HEADER_KEY_SERVER_TIMING = b"http_server_timing"
 
     def __init__(self):
         self._tp = Traceparent()

--- a/src/instana/propagators/binary_propagator.py
+++ b/src/instana/propagators/binary_propagator.py
@@ -7,6 +7,8 @@ from instana.propagators.base_propagator import BasePropagator
 
 from opentelemetry.trace.span import format_span_id
 
+from instana.util.ids import define_server_timing
+
 
 class BinaryPropagator(BasePropagator):
     """
@@ -30,7 +32,7 @@ class BinaryPropagator(BasePropagator):
             trace_id = format_span_id(span_context.trace_id).encode()
             span_id = format_span_id(span_context.span_id).encode()
             level = str(span_context.level).encode()
-            server_timing = f"intid;desc={span_context.trace_id}".encode()
+            server_timing = define_server_timing(span_context.trace_id).encode()
 
             if disable_w3c_trace_context:
                 traceparent, tracestate = [None] * 2

--- a/src/instana/propagators/binary_propagator.py
+++ b/src/instana/propagators/binary_propagator.py
@@ -5,6 +5,8 @@
 from instana.log import logger
 from instana.propagators.base_propagator import BasePropagator
 
+from opentelemetry.trace.span import format_span_id
+
 
 class BinaryPropagator(BasePropagator):
     """
@@ -25,8 +27,8 @@ class BinaryPropagator(BasePropagator):
 
     def inject(self, span_context, carrier, disable_w3c_trace_context=True):
         try:
-            trace_id = str(span_context.trace_id).encode()
-            span_id = str(span_context.span_id).encode()
+            trace_id = format_span_id(span_context.trace_id).encode()
+            span_id = format_span_id(span_context.span_id).encode()
             level = str(span_context.level).encode()
             server_timing = f"intid;desc={span_context.trace_id}".encode()
 

--- a/src/instana/propagators/http_propagator.py
+++ b/src/instana/propagators/http_propagator.py
@@ -4,6 +4,7 @@
 
 from instana.log import logger
 from instana.propagators.base_propagator import BasePropagator
+from instana.util.ids import define_server_timing
 
 from opentelemetry.trace.span import format_span_id
 
@@ -56,6 +57,9 @@ class HTTPPropagator(BasePropagator):
 
             inject_key_value(carrier, self.HEADER_KEY_T, format_span_id(trace_id))
             inject_key_value(carrier, self.HEADER_KEY_S, format_span_id(span_id))
+            inject_key_value(
+                carrier, self.HEADER_KEY_SERVER_TIMING, define_server_timing(trace_id)
+            )
 
         except Exception:
             logger.debug("inject error:", exc_info=True)

--- a/src/instana/propagators/http_propagator.py
+++ b/src/instana/propagators/http_propagator.py
@@ -5,6 +5,7 @@
 from instana.log import logger
 from instana.propagators.base_propagator import BasePropagator
 
+from opentelemetry.trace.span import format_span_id
 
 class HTTPPropagator(BasePropagator):
     """
@@ -53,8 +54,8 @@ class HTTPPropagator(BasePropagator):
             if span_context.suppression:
                 return
 
-            inject_key_value(carrier, self.HEADER_KEY_T, str(trace_id))
-            inject_key_value(carrier, self.HEADER_KEY_S, str(span_id))
+            inject_key_value(carrier, self.HEADER_KEY_T, format_span_id(trace_id))
+            inject_key_value(carrier, self.HEADER_KEY_S, format_span_id(span_id))
 
         except Exception:
             logger.debug("inject error:", exc_info=True)

--- a/src/instana/propagators/text_propagator.py
+++ b/src/instana/propagators/text_propagator.py
@@ -5,6 +5,8 @@
 from instana.log import logger
 from instana.propagators.base_propagator import BasePropagator
 
+from opentelemetry.trace.span import format_span_id
+
 
 class TextPropagator(BasePropagator):
     """
@@ -16,8 +18,8 @@ class TextPropagator(BasePropagator):
 
     def inject(self, span_context, carrier, disable_w3c_trace_context=True):
         try:
-            trace_id = span_context.trace_id
-            span_id = span_context.span_id
+            trace_id = format_span_id(span_context.trace_id)
+            span_id = format_span_id(span_context.span_id)
 
             if isinstance(carrier, dict) or hasattr(carrier, "__dict__"):
                 carrier[self.LC_HEADER_KEY_T] = trace_id

--- a/src/instana/util/ids.py
+++ b/src/instana/util/ids.py
@@ -44,6 +44,9 @@ def header_to_long_id(header: Union[bytes, str]) -> int:
     if not isinstance(header, str):
         return INVALID_SPAN_ID
 
+    if header.isdecimal():
+        return header
+
     try:
         if len(header) < 16:
             # Left pad ID with zeros
@@ -69,6 +72,9 @@ def header_to_id(header: Union[bytes, str]) -> int:
     if not isinstance(header, str):
         return INVALID_SPAN_ID
 
+    if header.isdecimal():
+        return header
+
     try:
         length = len(header)
         if length < 16:
@@ -81,3 +87,14 @@ def header_to_id(header: Union[bytes, str]) -> int:
         return int(header, 16)
     except ValueError:
         return INVALID_SPAN_ID
+
+
+def hex_id(id: Union[int, str]) -> str:
+    """
+    Returns the hexadecimal representation of the given ID.
+    """
+
+    hex_id = hex(int(id))[2:]
+    if len(hex_id) < 16:
+        hex_id = hex_id.zfill(16)
+    return hex_id

--- a/src/instana/util/ids.py
+++ b/src/instana/util/ids.py
@@ -98,3 +98,8 @@ def hex_id(id: Union[int, str]) -> str:
     if len(hex_id) < 16:
         hex_id = hex_id.zfill(16)
     return hex_id
+
+
+def define_server_timing(trace_id: Union[int, str]) -> str:
+    # Note: The key `intid` is short for Instana Trace ID.
+    return f"intid;desc={hex_id(trace_id)}"

--- a/tests/clients/boto3/test_boto3_sqs.py
+++ b/tests/clients/boto3/test_boto3_sqs.py
@@ -9,9 +9,9 @@ from typing import Generator
 
 from moto import mock_aws
 
-import tests.apps.flask_app
+import tests.apps.flask_app  # noqa: F401
 from instana.singletons import tracer, agent
-from tests.helpers import get_first_span_by_filter, testenv
+from tests.helpers import get_first_span_by_filter, get_first_span_by_name, testenv
 
 pwd = os.path.dirname(os.path.abspath(__file__))
 
@@ -70,12 +70,10 @@ class TestSqs:
         spans = self.recorder.queued_spans()
         assert len(spans) == 2
 
-        filter = lambda span: span.n == "sdk"
-        test_span = get_first_span_by_filter(spans, filter)
+        test_span = get_first_span_by_name(spans, "sdk")
         assert test_span
 
-        filter = lambda span: span.n == "boto3"
-        boto_span = get_first_span_by_filter(spans, filter)
+        boto_span = get_first_span_by_name(spans, "boto3")
         assert boto_span
 
         assert boto_span.t == test_span.t
@@ -174,28 +172,31 @@ class TestSqs:
         spans = self.recorder.queued_spans()
         assert len(spans) == 5
 
-        filter = lambda span: span.n == "sdk"
-        test_span = get_first_span_by_filter(spans, filter)
+        test_span = get_first_span_by_name(spans, "sdk")
         assert test_span
 
-        filter = lambda span: span.n == "urllib3"
-        http_span = get_first_span_by_filter(spans, filter)
+        http_span = get_first_span_by_name(spans, "urllib3")
         assert http_span
 
-        filter = lambda span: span.n == "wsgi"
-        wsgi_span = get_first_span_by_filter(spans, filter)
+        wsgi_span = get_first_span_by_name(spans, "wsgi")
         assert wsgi_span
 
-        filter = (
-            lambda span: span.n == "boto3" and span.data["boto3"]["op"] == "CreateQueue"
+        bcq_span = get_first_span_by_filter(
+            spans,
+            (
+                lambda span: span.n == "boto3"
+                and span.data["boto3"]["op"] == "CreateQueue"
+            ),
         )
-        bcq_span = get_first_span_by_filter(spans, filter)
         assert bcq_span
 
-        filter = (
-            lambda span: span.n == "boto3" and span.data["boto3"]["op"] == "SendMessage"
+        bsm_span = get_first_span_by_filter(
+            spans,
+            (
+                lambda span: span.n == "boto3"
+                and span.data["boto3"]["op"] == "SendMessage"
+            ),
         )
-        bsm_span = get_first_span_by_filter(spans, filter)
         assert bsm_span
 
         assert http_span.t == test_span.t
@@ -258,12 +259,10 @@ class TestSqs:
         spans = self.recorder.queued_spans()
         assert len(spans) == 2
 
-        filter = lambda span: span.n == "sdk"
-        test_span = get_first_span_by_filter(spans, filter)
+        test_span = get_first_span_by_name(spans, "sdk")
         assert test_span
 
-        filter = lambda span: span.n == "boto3"
-        boto_span = get_first_span_by_filter(spans, filter)
+        boto_span = get_first_span_by_name(spans, "boto3")
         assert boto_span
 
         assert boto_span.t == test_span.t
@@ -351,12 +350,10 @@ class TestSqs:
         spans = self.recorder.queued_spans()
         assert len(spans) == 2
 
-        filter = lambda span: span.n == "sdk"
-        test_span = get_first_span_by_filter(spans, filter)
+        test_span = get_first_span_by_name(spans, "sdk")
         assert test_span
 
-        filter = lambda span: span.n == "boto3"
-        boto_span = get_first_span_by_filter(spans, filter)
+        boto_span = get_first_span_by_name(spans, "boto3")
         assert boto_span
 
         assert boto_span.t == test_span.t
@@ -444,12 +441,10 @@ class TestSqs:
         spans = self.recorder.queued_spans()
         assert len(spans) == 2
 
-        filter = lambda span: span.n == "sdk"
-        test_span = get_first_span_by_filter(spans, filter)
+        test_span = get_first_span_by_name(spans, "sdk")
         assert test_span
 
-        filter = lambda span: span.n == "boto3"
-        boto_span = get_first_span_by_filter(spans, filter)
+        boto_span = get_first_span_by_name(spans, "boto3")
         assert boto_span
 
         assert boto_span.t == test_span.t

--- a/tests/clients/test_pika.py
+++ b/tests/clients/test_pika.py
@@ -14,6 +14,7 @@ import pytest
 from opentelemetry.trace.span import format_span_id
 
 from instana.singletons import agent, tracer
+from instana.util.ids import hex_id
 
 
 class _TestPika:
@@ -377,6 +378,7 @@ class TestPikaChannel(_TestPika):
                         "X-INSTANA-T": format_span_id(rabbitmq_span.t),
                         "X-INSTANA-S": format_span_id(rabbitmq_span.s),
                         "X-INSTANA-L": "1",
+                        "Server-Timing": f"intid;desc={hex_id(rabbitmq_span.t)}",
                     }
                 ),
                 b"Hello!",
@@ -418,6 +420,7 @@ class TestPikaChannel(_TestPika):
                         "X-INSTANA-T": format_span_id(rabbitmq_span.t),
                         "X-INSTANA-S": format_span_id(rabbitmq_span.s),
                         "X-INSTANA-L": "1",
+                        "Server-Timing": f"intid;desc={hex_id(rabbitmq_span.t)}",
                     }
                 ),
                 b"Hello!",
@@ -451,6 +454,7 @@ class TestPikaChannel(_TestPika):
                         "X-INSTANA-T": format_span_id(rabbitmq_span.t),
                         "X-INSTANA-S": format_span_id(rabbitmq_span.s),
                         "X-INSTANA-L": "1",
+                        "Server-Timing": f"intid;desc={hex_id(rabbitmq_span.t)}",
                     }
                 ),
                 b"Hello!",

--- a/tests/clients/test_pika.py
+++ b/tests/clients/test_pika.py
@@ -11,6 +11,7 @@ import pika.adapters.blocking_connection
 import pika.channel
 import pika.spec
 import pytest
+from opentelemetry.trace.span import format_span_id
 
 from instana.singletons import agent, tracer
 
@@ -373,8 +374,8 @@ class TestPikaChannel(_TestPika):
             (
                 pika.spec.BasicProperties(
                     headers={
-                        "X-INSTANA-T": str(rabbitmq_span.t),
-                        "X-INSTANA-S": str(rabbitmq_span.s),
+                        "X-INSTANA-T": format_span_id(rabbitmq_span.t),
+                        "X-INSTANA-S": format_span_id(rabbitmq_span.s),
                         "X-INSTANA-L": "1",
                     }
                 ),
@@ -414,8 +415,8 @@ class TestPikaChannel(_TestPika):
             (
                 pika.spec.BasicProperties(
                     headers={
-                        "X-INSTANA-T": str(rabbitmq_span.t),
-                        "X-INSTANA-S": str(rabbitmq_span.s),
+                        "X-INSTANA-T": format_span_id(rabbitmq_span.t),
+                        "X-INSTANA-S": format_span_id(rabbitmq_span.s),
                         "X-INSTANA-L": "1",
                     }
                 ),
@@ -447,8 +448,8 @@ class TestPikaChannel(_TestPika):
                 pika.spec.BasicProperties(
                     headers={
                         "X-Custom-1": "test",
-                        "X-INSTANA-T": str(rabbitmq_span.t),
-                        "X-INSTANA-S": str(rabbitmq_span.s),
+                        "X-INSTANA-T": format_span_id(rabbitmq_span.t),
+                        "X-INSTANA-S": format_span_id(rabbitmq_span.s),
                         "X-INSTANA-L": "1",
                     }
                 ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 import pytest
 from opentelemetry.context.context import Context
 from opentelemetry.trace import set_span_in_context
+from opentelemetry.trace.span import format_span_id
 
 if importlib.util.find_spec("celery"):
     pytest_plugins = ("celery.contrib.pytest",)
@@ -97,6 +98,16 @@ def trace_id() -> int:
 def span_id() -> int:
     return 6895521157646639861
 
+@pytest.fixture
+def hex_trace_id(trace_id:int) -> str:
+    # Using format_span_id() to return a 16-byte hexadecimal string, instead of 
+    # the 32-byte hexadecimal string from format_trace_id().
+    return format_span_id(trace_id)
+
+
+@pytest.fixture
+def hex_span_id(span_id: int) -> str:
+    return format_span_id(span_id)
 
 @pytest.fixture
 def span_processor() -> StanRecorder:

--- a/tests/frameworks/test_aiohttp_client.py
+++ b/tests/frameworks/test_aiohttp_client.py
@@ -8,6 +8,7 @@ import asyncio
 import pytest
 
 from instana.singletons import tracer, agent
+from instana.util.ids import hex_id
 
 import tests.apps.flask_app  # noqa: F401
 import tests.apps.aiohttp_app  # noqa: F401
@@ -82,9 +83,9 @@ class TestAiohttpClient:
         assert len(aiohttp_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -125,9 +126,9 @@ class TestAiohttpClient:
         assert len(aiohttp_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(wsgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(wsgi_span.t)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -175,9 +176,9 @@ class TestAiohttpClient:
         assert len(aiohttp_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span2.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span2.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -221,9 +222,9 @@ class TestAiohttpClient:
         assert len(aiohttp_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -268,9 +269,9 @@ class TestAiohttpClient:
         assert len(aiohttp_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -315,9 +316,9 @@ class TestAiohttpClient:
         assert len(aiohttp_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -364,9 +365,9 @@ class TestAiohttpClient:
         assert len(aiohttp_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -418,9 +419,9 @@ class TestAiohttpClient:
         assert aiohttp_span.data["http"]["header"]["X-Capture-This"] == "Ok"
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers

--- a/tests/frameworks/test_aiohttp_client.py
+++ b/tests/frameworks/test_aiohttp_client.py
@@ -89,7 +89,7 @@ class TestAiohttpClient:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == f"intid;desc={traceId}"
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_client_get_as_root_exit_span(self) -> None:
         agent.options.allow_exit_as_root = True
@@ -132,7 +132,7 @@ class TestAiohttpClient:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == f"intid;desc={wsgi_span.t}"
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(wsgi_span.t)}"
 
     def test_client_get_301(self) -> None:
         async def test():
@@ -182,7 +182,7 @@ class TestAiohttpClient:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == f"intid;desc={traceId}"
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_client_get_405(self) -> None:
         async def test():
@@ -228,7 +228,7 @@ class TestAiohttpClient:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == f"intid;desc={traceId}"
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_client_get_500(self) -> None:
         async def test():
@@ -275,7 +275,7 @@ class TestAiohttpClient:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == f"intid;desc={traceId}"
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_client_get_504(self) -> None:
         async def test():
@@ -322,7 +322,7 @@ class TestAiohttpClient:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == f"intid;desc={traceId}"
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_client_get_with_params_to_scrub(self) -> None:
         async def test():
@@ -371,7 +371,7 @@ class TestAiohttpClient:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == f"intid;desc={traceId}"
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_client_response_header_capture(self) -> None:
         original_extra_http_headers = agent.options.extra_http_headers
@@ -425,7 +425,7 @@ class TestAiohttpClient:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == f"intid;desc={traceId}"
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
         agent.options.extra_http_headers = original_extra_http_headers
 

--- a/tests/frameworks/test_aiohttp_server.py
+++ b/tests/frameworks/test_aiohttp_server.py
@@ -83,7 +83,7 @@ class TestAiohttpServer:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == f"intid;desc={traceId}"
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_server_get_204(self):
         async def test():
@@ -132,7 +132,7 @@ class TestAiohttpServer:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == f"intid;desc={trace_id}"
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(trace_id)}"
 
     def test_server_synthetic_request(self):
         async def test():
@@ -205,7 +205,7 @@ class TestAiohttpServer:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == f"intid;desc={traceId}"
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_server_custom_header_capture(self):
         async def test():
@@ -265,7 +265,7 @@ class TestAiohttpServer:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == f"intid;desc={traceId}"
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
         assert "X-Capture-This" in aioserver_span.data["http"]["header"]
         assert aioserver_span.data["http"]["header"]["X-Capture-This"] == "this"
@@ -314,7 +314,7 @@ class TestAiohttpServer:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == f"intid;desc={traceId}"
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_server_get_500(self):
         async def test():
@@ -358,7 +358,7 @@ class TestAiohttpServer:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == f"intid;desc={traceId}"
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_server_get_exception(self):
         async def test():

--- a/tests/frameworks/test_aiohttp_server.py
+++ b/tests/frameworks/test_aiohttp_server.py
@@ -8,6 +8,7 @@ import aiohttp
 import pytest
 
 from instana.singletons import agent, tracer
+from instana.util.ids import hex_id
 from tests.helpers import testenv
 
 
@@ -76,9 +77,9 @@ class TestAiohttpServer:
         assert not aioserver_span.stack
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(aioserver_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(aioserver_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -125,9 +126,9 @@ class TestAiohttpServer:
         assert not aioserver_span.stack
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(trace_id)
+        assert response.headers["X-INSTANA-T"] == hex_id(trace_id)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(aioserver_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(aioserver_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -198,9 +199,9 @@ class TestAiohttpServer:
         assert not aioserver_span.stack
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(aioserver_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(aioserver_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -258,9 +259,9 @@ class TestAiohttpServer:
         assert not aioserver_span.stack
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(aioserver_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(aioserver_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -307,9 +308,9 @@ class TestAiohttpServer:
         assert not aioserver_span.stack
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(aioserver_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(aioserver_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -351,9 +352,9 @@ class TestAiohttpServer:
         assert not aioserver_span.stack
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(aioserver_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(aioserver_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers

--- a/tests/frameworks/test_django.py
+++ b/tests/frameworks/test_django.py
@@ -62,7 +62,7 @@ class TestDjango(StaticLiveServerTestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % django_span.t
+        server_timing_value = f"intid;desc={hex_id(django_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert "test" == test_span.data["sdk"]["name"]
@@ -151,7 +151,7 @@ class TestDjango(StaticLiveServerTestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % django_span.t
+        server_timing_value = f"intid;desc={hex_id(django_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert "test" == test_span.data["sdk"]["name"]
@@ -244,7 +244,7 @@ class TestDjango(StaticLiveServerTestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % django_span.t
+        server_timing_value = f"intid;desc={hex_id(django_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert "test" == test_span.data["sdk"]["name"]
@@ -410,7 +410,7 @@ class TestDjango(StaticLiveServerTestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % django_span.t
+        server_timing_value = f"intid;desc={hex_id(django_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert "traceparent" in response.headers
@@ -477,7 +477,7 @@ class TestDjango(StaticLiveServerTestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % django_span.t
+        server_timing_value = f"intid;desc={hex_id(django_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert "traceparent" in response.headers
@@ -537,7 +537,7 @@ class TestDjango(StaticLiveServerTestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % django_span.t
+        server_timing_value = f"intid;desc={hex_id(django_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert "traceparent" in response.headers
@@ -594,7 +594,7 @@ class TestDjango(StaticLiveServerTestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % django_span.t
+        server_timing_value = f"intid;desc={hex_id(django_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert "traceparent" in response.headers
@@ -645,7 +645,7 @@ class TestDjango(StaticLiveServerTestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % django_span.t
+        server_timing_value = f"intid;desc={hex_id(django_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
     def test_url_pattern_route(self) -> None:

--- a/tests/frameworks/test_django.py
+++ b/tests/frameworks/test_django.py
@@ -9,6 +9,7 @@ from typing import Generator
 from django.apps import apps
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 
+from instana.util.ids import hex_id
 from tests.apps.app_django import INSTALLED_APPS
 from instana.singletons import agent, tracer
 from tests.helpers import (
@@ -51,11 +52,11 @@ class TestDjango(StaticLiveServerTestCase):
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(django_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(django_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(django_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(django_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -140,11 +141,11 @@ class TestDjango(StaticLiveServerTestCase):
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(django_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(django_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(django_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(django_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -233,11 +234,11 @@ class TestDjango(StaticLiveServerTestCase):
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(django_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(django_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(django_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(django_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -399,11 +400,11 @@ class TestDjango(StaticLiveServerTestCase):
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(django_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(django_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(django_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(django_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -466,11 +467,11 @@ class TestDjango(StaticLiveServerTestCase):
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(django_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(django_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(django_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(django_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -526,11 +527,11 @@ class TestDjango(StaticLiveServerTestCase):
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(django_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(django_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(django_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(django_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -583,11 +584,11 @@ class TestDjango(StaticLiveServerTestCase):
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(django_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(django_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(django_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(django_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -634,11 +635,11 @@ class TestDjango(StaticLiveServerTestCase):
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(django_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(django_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(django_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(django_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"

--- a/tests/frameworks/test_fastapi.py
+++ b/tests/frameworks/test_fastapi.py
@@ -89,7 +89,7 @@ class TestFastAPI:
         
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "testserver"
@@ -140,7 +140,7 @@ class TestFastAPI:
         
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "testserver"
@@ -191,7 +191,7 @@ class TestFastAPI:
         
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert asgi_span.ec == 1
         assert asgi_span.data["http"]["host"] == "testserver"
@@ -241,7 +241,7 @@ class TestFastAPI:
         
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "testserver"
@@ -291,7 +291,7 @@ class TestFastAPI:
         
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "testserver"
@@ -342,7 +342,7 @@ class TestFastAPI:
         
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "testserver"
@@ -397,7 +397,7 @@ class TestFastAPI:
         
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)        
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "testserver"
@@ -455,7 +455,7 @@ class TestFastAPI:
         
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "testserver"
@@ -515,7 +515,7 @@ class TestFastAPI:
 
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span1.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span1.s)
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span1.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span1.t)}"
 
         assert not asgi_span1.ec
         assert asgi_span1.data["http"]["host"] == "testserver"
@@ -573,7 +573,7 @@ class TestFastAPI:
         
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "testserver"

--- a/tests/frameworks/test_fastapi.py
+++ b/tests/frameworks/test_fastapi.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 import pytest
 from instana.singletons import tracer, agent
 
+from instana.util.ids import hex_id
 from tests.apps.fastapi_app.app import fastapi_server
 from tests.helpers import get_first_span_by_filter
 
@@ -56,8 +57,8 @@ class TestFastAPI:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             result = self.client.get("/", headers=headers)
 
@@ -86,8 +87,8 @@ class TestFastAPI:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
         
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 
         assert not asgi_span.ec
@@ -107,8 +108,8 @@ class TestFastAPI:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             result = self.client.get("/400", headers=headers)
 
@@ -137,8 +138,8 @@ class TestFastAPI:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
         
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 
         assert not asgi_span.ec
@@ -158,8 +159,8 @@ class TestFastAPI:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             result = self.client.get("/500", headers=headers)
 
@@ -188,8 +189,8 @@ class TestFastAPI:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
         
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 
         assert asgi_span.ec == 1
@@ -208,8 +209,8 @@ class TestFastAPI:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             result = self.client.get("/users/1", headers=headers)
 
@@ -238,8 +239,8 @@ class TestFastAPI:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
         
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 
         assert not asgi_span.ec
@@ -258,8 +259,8 @@ class TestFastAPI:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             result = self.client.get("/?secret=shhh", headers=headers)
 
@@ -288,8 +289,8 @@ class TestFastAPI:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
         
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 
         assert not asgi_span.ec
@@ -308,8 +309,8 @@ class TestFastAPI:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
                 "X-INSTANA-SYNTHETIC": "1",
             }
             result = self.client.get("/", headers=headers)
@@ -339,8 +340,8 @@ class TestFastAPI:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
         
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 
         assert not asgi_span.ec
@@ -362,8 +363,8 @@ class TestFastAPI:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
                 "X-Capture-This": "this", 
                 "X-Capture-That": "that",
             }
@@ -394,8 +395,8 @@ class TestFastAPI:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
         
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)        
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)        
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 
         assert not asgi_span.ec
@@ -422,8 +423,8 @@ class TestFastAPI:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             result = self.client.get("/response_headers", headers=headers)
 
@@ -452,8 +453,8 @@ class TestFastAPI:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
         
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 
         assert not asgi_span.ec
@@ -477,8 +478,8 @@ class TestFastAPI:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             result = self.client.get("/non_async_simple", headers=headers)
 
@@ -512,8 +513,8 @@ class TestFastAPI:
         assert asgi_span1.t == traceId
         assert asgi_span2.t == traceId
 
-        assert result.headers["X-INSTANA-T"] == str(asgi_span1.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span1.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span1.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span1.s)
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span1.t}"
 
         assert not asgi_span1.ec
@@ -540,8 +541,8 @@ class TestFastAPI:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             result = self.client.get("/non_async_threadpool", headers=headers)
 
@@ -570,8 +571,8 @@ class TestFastAPI:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
         
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 
         assert not asgi_span.ec

--- a/tests/frameworks/test_fastapi_middleware.py
+++ b/tests/frameworks/test_fastapi_middleware.py
@@ -8,6 +8,7 @@ import pytest
 from instana.singletons import tracer
 from fastapi.testclient import TestClient
 
+from instana.util.ids import hex_id
 from tests.helpers import get_first_span_by_filter
 
 
@@ -53,8 +54,8 @@ class TestFastAPIMiddleware:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             result = self.client.get("/", headers=headers)
 
@@ -82,8 +83,8 @@ class TestFastAPIMiddleware:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
 
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 
         assert not asgi_span.ec

--- a/tests/frameworks/test_fastapi_middleware.py
+++ b/tests/frameworks/test_fastapi_middleware.py
@@ -85,7 +85,7 @@ class TestFastAPIMiddleware:
 
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["path"] == "/"

--- a/tests/frameworks/test_flask.py
+++ b/tests/frameworks/test_flask.py
@@ -6,6 +6,8 @@ import urllib3
 import flask
 from unittest.mock import patch
 
+from instana.util.ids import hex_id
+
 if hasattr(flask.signals, 'signals_available'):
     from flask.signals import signals_available
 else:
@@ -58,11 +60,11 @@ class TestFlask(unittest.TestCase):
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(wsgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(wsgi_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -133,11 +135,11 @@ class TestFlask(unittest.TestCase):
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(wsgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(wsgi_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -268,11 +270,11 @@ class TestFlask(unittest.TestCase):
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(wsgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(wsgi_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -348,11 +350,11 @@ class TestFlask(unittest.TestCase):
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(wsgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(wsgi_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -431,11 +433,11 @@ class TestFlask(unittest.TestCase):
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(wsgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(wsgi_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -642,11 +644,11 @@ class TestFlask(unittest.TestCase):
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(wsgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(wsgi_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -860,11 +862,11 @@ class TestFlask(unittest.TestCase):
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(wsgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(wsgi_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -940,11 +942,11 @@ class TestFlask(unittest.TestCase):
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(wsgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(wsgi_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -1015,11 +1017,11 @@ class TestFlask(unittest.TestCase):
         assert response.status == 200
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(wsgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(wsgi_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"

--- a/tests/frameworks/test_flask.py
+++ b/tests/frameworks/test_flask.py
@@ -70,7 +70,7 @@ class TestFlask(unittest.TestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert get_current_span().is_recording() is False
@@ -145,7 +145,7 @@ class TestFlask(unittest.TestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert get_current_span().is_recording() is False
@@ -280,7 +280,7 @@ class TestFlask(unittest.TestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert get_current_span().is_recording() is False
@@ -360,7 +360,7 @@ class TestFlask(unittest.TestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert get_current_span().is_recording() is False
@@ -443,7 +443,7 @@ class TestFlask(unittest.TestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert get_current_span().is_recording() is False
@@ -512,7 +512,7 @@ class TestFlask(unittest.TestCase):
         # assert response.headers['X-INSTANA-L'] == '1'
         #
         # assert 'Server-Timing' in response.headers
-        # server_timing_value = "intid;desc=%s" % wsgi_span.t
+        # server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         # assert response.headers['Server-Timing'] == server_timing_value
 
         assert get_current_span().is_recording() is False
@@ -583,7 +583,7 @@ class TestFlask(unittest.TestCase):
         # assert response.headers['X-INSTANA-L'] == '1'
         #
         # assert 'Server-Timing' in response.headers
-        # server_timing_value = "intid;desc=%s" % wsgi_span.t
+        # server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         # assert response.headers['Server-Timing'] == server_timing_value
 
         assert get_current_span().is_recording() is False
@@ -654,7 +654,7 @@ class TestFlask(unittest.TestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert get_current_span().is_recording() is False
@@ -727,7 +727,7 @@ class TestFlask(unittest.TestCase):
         # assert response.headers['X-INSTANA-L'] == '1'
         #
         # assert 'Server-Timing' in response.headers
-        # server_timing_value = "intid;desc=%s" % wsgi_span.t
+        # server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         # assert response.headers['Server-Timing'] == server_timing_value
 
         assert get_current_span().is_recording() is False
@@ -872,7 +872,7 @@ class TestFlask(unittest.TestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert get_current_span().is_recording() is False
@@ -952,7 +952,7 @@ class TestFlask(unittest.TestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert get_current_span().is_recording() is False
@@ -1027,7 +1027,7 @@ class TestFlask(unittest.TestCase):
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert get_current_span().is_recording() is False

--- a/tests/frameworks/test_pyramid.py
+++ b/tests/frameworks/test_pyramid.py
@@ -52,7 +52,7 @@ class TestPyramid:
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % pyramid_span.t
+        server_timing_value = f"intid;desc={hex_id(pyramid_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert not get_current_span().is_recording()
@@ -141,7 +141,7 @@ class TestPyramid:
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % pyramid_span.t
+        server_timing_value = f"intid;desc={hex_id(pyramid_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert not get_current_span().is_recording()
@@ -394,7 +394,7 @@ class TestPyramid:
         assert response.headers["X-INSTANA-L"] == "1"
 
         assert "Server-Timing" in response.headers
-        server_timing_value = "intid;desc=%s" % pyramid_span.t
+        server_timing_value = f"intid;desc={hex_id(pyramid_span.t)}"
         assert response.headers["Server-Timing"] == server_timing_value
 
         assert not get_current_span().is_recording()

--- a/tests/frameworks/test_pyramid.py
+++ b/tests/frameworks/test_pyramid.py
@@ -5,6 +5,7 @@ import pytest
 import urllib3
 from typing import Generator
 
+from instana.util.ids import hex_id
 import tests.apps.pyramid.pyramid_app
 from tests.helpers import testenv
 from instana.singletons import tracer, agent
@@ -41,11 +42,11 @@ class TestPyramid:
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(pyramid_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(pyramid_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(pyramid_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(pyramid_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -130,11 +131,11 @@ class TestPyramid:
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(pyramid_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(pyramid_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(pyramid_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(pyramid_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
@@ -383,11 +384,11 @@ class TestPyramid:
 
         assert "X-INSTANA-T" in response.headers
         assert int(response.headers["X-INSTANA-T"], 16)
-        assert response.headers["X-INSTANA-T"] == str(pyramid_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(pyramid_span.t)
 
         assert "X-INSTANA-S" in response.headers
         assert int(response.headers["X-INSTANA-S"], 16)
-        assert response.headers["X-INSTANA-S"] == str(pyramid_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(pyramid_span.s)
 
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"

--- a/tests/frameworks/test_sanic.py
+++ b/tests/frameworks/test_sanic.py
@@ -81,7 +81,7 @@ class TestSanic(_TraceContextMixin):
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == ("intid;desc=%s" % asgi_span.t)
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "127.0.0.1:1337"
@@ -127,7 +127,7 @@ class TestSanic(_TraceContextMixin):
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == ("intid;desc=%s" % asgi_span.t)
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "127.0.0.1:1337"
@@ -173,7 +173,7 @@ class TestSanic(_TraceContextMixin):
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == ("intid;desc=%s" % asgi_span.t)
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "127.0.0.1:1337"
@@ -219,7 +219,7 @@ class TestSanic(_TraceContextMixin):
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == ("intid;desc=%s" % asgi_span.t)
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert asgi_span.ec == 1
         assert asgi_span.data["http"]["host"] == "127.0.0.1:1337"
@@ -265,7 +265,7 @@ class TestSanic(_TraceContextMixin):
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == ("intid;desc=%s" % asgi_span.t)
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert asgi_span.ec == 1
         assert asgi_span.data["http"]["host"] == "127.0.0.1:1337"
@@ -311,7 +311,7 @@ class TestSanic(_TraceContextMixin):
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == ("intid;desc=%s" % asgi_span.t)
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "127.0.0.1:1337"
@@ -357,7 +357,7 @@ class TestSanic(_TraceContextMixin):
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == ("intid;desc=%s" % asgi_span.t)
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "127.0.0.1:1337"
@@ -404,7 +404,7 @@ class TestSanic(_TraceContextMixin):
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == ("intid;desc=%s" % asgi_span.t)
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "127.0.0.1:1337"
@@ -455,7 +455,7 @@ class TestSanic(_TraceContextMixin):
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == ("intid;desc=%s" % asgi_span.t)
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "127.0.0.1:1337"
@@ -506,7 +506,7 @@ class TestSanic(_TraceContextMixin):
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == ("intid;desc=%s" % asgi_span.t)
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "127.0.0.1:1337"

--- a/tests/frameworks/test_sanic.py
+++ b/tests/frameworks/test_sanic.py
@@ -6,6 +6,7 @@ from typing import Generator
 from sanic_testing.testing import SanicTestClient
 
 from instana.singletons import tracer, agent
+from instana.util.ids import hex_id
 from tests.helpers import get_first_span_by_filter
 from tests.test_utils import _TraceContextMixin
 from tests.apps.sanic_app.server import app
@@ -51,8 +52,8 @@ class TestSanic(_TraceContextMixin):
             # we must pass the SDK trace_id and span_id to the sanic server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             request, response = self.client.get("/", headers=headers)
 
@@ -74,9 +75,9 @@ class TestSanic(_TraceContextMixin):
         self.assertTraceContextPropagated(test_span, asgi_span)
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(asgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -97,8 +98,8 @@ class TestSanic(_TraceContextMixin):
             # we must pass the SDK trace_id and span_id to the sanic server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             request, response = self.client.get("/foo/not_an_int", headers=headers)
 
@@ -120,9 +121,9 @@ class TestSanic(_TraceContextMixin):
         self.assertTraceContextPropagated(test_span, asgi_span)
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(asgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -143,8 +144,8 @@ class TestSanic(_TraceContextMixin):
             # we must pass the SDK trace_id and span_id to the sanic server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             request, response = self.client.get("/wrong", headers=headers)
 
@@ -166,9 +167,9 @@ class TestSanic(_TraceContextMixin):
         self.assertTraceContextPropagated(test_span, asgi_span)
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(asgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -189,8 +190,8 @@ class TestSanic(_TraceContextMixin):
             # we must pass the SDK trace_id and span_id to the sanic server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             request, response = self.client.get("/instana_exception", headers=headers)
 
@@ -212,9 +213,9 @@ class TestSanic(_TraceContextMixin):
         self.assertTraceContextPropagated(test_span, asgi_span)
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(asgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -235,8 +236,8 @@ class TestSanic(_TraceContextMixin):
             # we must pass the SDK trace_id and span_id to the sanic server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             request, response = self.client.get("/test_request_args", headers=headers)
 
@@ -258,9 +259,9 @@ class TestSanic(_TraceContextMixin):
         self.assertTraceContextPropagated(test_span, asgi_span)
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(asgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -281,8 +282,8 @@ class TestSanic(_TraceContextMixin):
             # we must pass the SDK trace_id and span_id to the sanic server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             request, response = self.client.get("/foo/1", headers=headers)
 
@@ -304,9 +305,9 @@ class TestSanic(_TraceContextMixin):
         self.assertTraceContextPropagated(test_span, asgi_span)
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(asgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -327,8 +328,8 @@ class TestSanic(_TraceContextMixin):
             # we must pass the SDK trace_id and span_id to the sanic server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             request, response = self.client.get("/?secret=shhh", headers=headers)
 
@@ -350,9 +351,9 @@ class TestSanic(_TraceContextMixin):
         self.assertTraceContextPropagated(test_span, asgi_span)
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(asgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -373,8 +374,8 @@ class TestSanic(_TraceContextMixin):
             # we must pass the SDK trace_id and span_id to the sanic server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
                 "X-INSTANA-SYNTHETIC": "1",
             }
             request, response = self.client.get("/", headers=headers)
@@ -397,9 +398,9 @@ class TestSanic(_TraceContextMixin):
         self.assertTraceContextPropagated(test_span, asgi_span)
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(asgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -423,8 +424,8 @@ class TestSanic(_TraceContextMixin):
             # we must pass the SDK trace_id and span_id to the sanic server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
                 "X-Capture-This": "this",
                 "X-Capture-That": "that",
             }
@@ -448,9 +449,9 @@ class TestSanic(_TraceContextMixin):
         self.assertTraceContextPropagated(test_span, asgi_span)
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(asgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers
@@ -476,8 +477,8 @@ class TestSanic(_TraceContextMixin):
             # we must pass the SDK trace_id and span_id to the sanic server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             request, response = self.client.get("/response_headers", headers=headers)
 
@@ -499,9 +500,9 @@ class TestSanic(_TraceContextMixin):
         self.assertTraceContextPropagated(test_span, asgi_span)
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(asgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == "1"
         assert "Server-Timing" in response.headers

--- a/tests/frameworks/test_starlette.py
+++ b/tests/frameworks/test_starlette.py
@@ -7,6 +7,7 @@ import pytest
 from instana.singletons import agent, tracer
 from starlette.testclient import TestClient
 
+from instana.util.ids import hex_id
 from tests.apps.starlette_app.app import starlette_server
 from tests.helpers import get_first_span_by_filter
 
@@ -52,8 +53,8 @@ class TestStarlette:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             result = self.client.get("/", headers=headers)
 
@@ -81,8 +82,8 @@ class TestStarlette:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
 
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 
         assert not asgi_span.ec
@@ -101,8 +102,8 @@ class TestStarlette:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             result = self.client.get("/users/1", headers=headers)
 
@@ -129,8 +130,8 @@ class TestStarlette:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
 
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["X-INSTANA-L"] == "1"
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 
@@ -150,8 +151,8 @@ class TestStarlette:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             result = self.client.get("/?secret=shhh", headers=headers)
 
@@ -178,8 +179,8 @@ class TestStarlette:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
 
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["X-INSTANA-L"] == "1"
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 
@@ -198,8 +199,8 @@ class TestStarlette:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
                 "X-INSTANA-SYNTHETIC": "1",
             }
             result = self.client.get("/", headers=headers)
@@ -227,8 +228,8 @@ class TestStarlette:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
 
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["X-INSTANA-L"] == "1"
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 
@@ -250,8 +251,8 @@ class TestStarlette:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
                 "X-Capture-This": "this",
                 "X-Capture-That": "that",
             }
@@ -280,8 +281,8 @@ class TestStarlette:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
 
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["X-INSTANA-L"] == "1"
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 

--- a/tests/frameworks/test_starlette.py
+++ b/tests/frameworks/test_starlette.py
@@ -84,7 +84,7 @@ class TestStarlette:
 
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["path"] == "/"
@@ -133,7 +133,7 @@ class TestStarlette:
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["X-INSTANA-L"] == "1"
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["path"] == "/users/1"
@@ -182,7 +182,7 @@ class TestStarlette:
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["X-INSTANA-L"] == "1"
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "testserver"
@@ -231,7 +231,7 @@ class TestStarlette:
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["X-INSTANA-L"] == "1"
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "testserver"
@@ -284,7 +284,7 @@ class TestStarlette:
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["X-INSTANA-L"] == "1"
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["host"] == "testserver"

--- a/tests/frameworks/test_starlette_middleware.py
+++ b/tests/frameworks/test_starlette_middleware.py
@@ -7,6 +7,7 @@ import pytest
 from instana.singletons import agent, tracer
 from starlette.testclient import TestClient
 
+from instana.util.ids import hex_id
 from tests.apps.starlette_app.app2 import starlette_server
 from tests.helpers import get_first_span_by_filter
 
@@ -51,8 +52,8 @@ class TestStarletteMiddleware:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             result = self.client.get("/", headers=headers)
 
@@ -80,8 +81,8 @@ class TestStarletteMiddleware:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
 
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 
         assert not asgi_span.ec
@@ -100,8 +101,8 @@ class TestStarletteMiddleware:
             # we must pass the SDK trace_id and span_id to the ASGI server.
             span_context = span.get_span_context()
             headers = {
-                "X-INSTANA-T": str(span_context.trace_id),
-                "X-INSTANA-S": str(span_context.span_id),
+                "X-INSTANA-T": hex_id(span_context.trace_id),
+                "X-INSTANA-S": hex_id(span_context.span_id),
             }
             result = self.client.get("/five", headers=headers)
 
@@ -129,8 +130,8 @@ class TestStarletteMiddleware:
         assert test_span.t == asgi_span.t
         assert test_span.s == asgi_span.p
 
-        assert result.headers["X-INSTANA-T"] == str(asgi_span.t)
-        assert result.headers["X-INSTANA-S"] == str(asgi_span.s)
+        assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
+        assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
         assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
 
         assert asgi_span.ec == 1

--- a/tests/frameworks/test_starlette_middleware.py
+++ b/tests/frameworks/test_starlette_middleware.py
@@ -83,7 +83,7 @@ class TestStarletteMiddleware:
 
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert not asgi_span.ec
         assert asgi_span.data["http"]["path"] == "/"
@@ -132,7 +132,7 @@ class TestStarletteMiddleware:
 
         assert result.headers["X-INSTANA-T"] == hex_id(asgi_span.t)
         assert result.headers["X-INSTANA-S"] == hex_id(asgi_span.s)
-        assert result.headers["Server-Timing"] == f"intid;desc={asgi_span.t}"
+        assert result.headers["Server-Timing"] == f"intid;desc={hex_id(asgi_span.t)}"
 
         assert asgi_span.ec == 1
         assert asgi_span.data["http"]["path"] == "/five"

--- a/tests/frameworks/test_tornado_client.py
+++ b/tests/frameworks/test_tornado_client.py
@@ -11,6 +11,7 @@ from tornado.httpclient import AsyncHTTPClient
 from instana.singletons import tracer
 from instana.span.span import get_current_span
 
+from instana.util.ids import hex_id
 import tests.apps.tornado_server
 from tests.helpers import testenv, get_first_span_by_name, get_first_span_by_filter
 
@@ -82,9 +83,9 @@ class TestTornadoClient:
         assert len(client_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(server_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(server_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
@@ -137,9 +138,9 @@ class TestTornadoClient:
         assert len(client_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(server_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(server_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
@@ -222,9 +223,9 @@ class TestTornadoClient:
         assert len(client301_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(server_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(server_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
@@ -280,9 +281,9 @@ class TestTornadoClient:
         assert len(client_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(server_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(server_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
@@ -338,9 +339,9 @@ class TestTornadoClient:
         assert len(client_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(server_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(server_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
@@ -396,9 +397,9 @@ class TestTornadoClient:
         assert len(client_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(server_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(server_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
@@ -452,9 +453,9 @@ class TestTornadoClient:
         assert len(client_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(server_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(server_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers

--- a/tests/frameworks/test_tornado_client.py
+++ b/tests/frameworks/test_tornado_client.py
@@ -89,7 +89,7 @@ class TestTornadoClient:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == "intid;desc=%s" % traceId
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_post(self) -> None:
         async def test():
@@ -144,7 +144,7 @@ class TestTornadoClient:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == "intid;desc=%s" % traceId
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_get_301(self) -> None:
         async def test():
@@ -229,7 +229,7 @@ class TestTornadoClient:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == "intid;desc=%s" % traceId
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_get_405(self) -> None:
         async def test():
@@ -287,7 +287,7 @@ class TestTornadoClient:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == "intid;desc=%s" % traceId
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_get_500(self) -> None:
         async def test():
@@ -345,7 +345,7 @@ class TestTornadoClient:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == "intid;desc=%s" % traceId
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_get_504(self) -> None:
         async def test():
@@ -403,7 +403,7 @@ class TestTornadoClient:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == "intid;desc=%s" % traceId
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_get_with_params_to_scrub(self) -> None:
         async def test():
@@ -459,4 +459,4 @@ class TestTornadoClient:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == "intid;desc=%s" % traceId
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"

--- a/tests/frameworks/test_tornado_server.py
+++ b/tests/frameworks/test_tornado_server.py
@@ -107,7 +107,7 @@ class TestTornadoServer:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == "intid;desc=%s" % traceId
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_post(self) -> None:
         async def test():
@@ -168,7 +168,7 @@ class TestTornadoServer:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == "intid;desc=%s" % traceId
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_synthetic_request(self) -> None:
         async def test():
@@ -265,7 +265,7 @@ class TestTornadoServer:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == "intid;desc=%s" % traceId
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     @pytest.mark.skip("Non deterministic (flaky) testcase")
     def test_get_405(self) -> None:
@@ -327,7 +327,7 @@ class TestTornadoServer:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == "intid;desc=%s" % traceId
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     @pytest.mark.skip("Non deterministic (flaky) testcase")
     def test_get_500(self) -> None:
@@ -390,7 +390,7 @@ class TestTornadoServer:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == "intid;desc=%s" % traceId
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     @pytest.mark.skip("Non deterministic (flaky) testcase")
     def test_get_504(self) -> None:
@@ -453,7 +453,7 @@ class TestTornadoServer:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == "intid;desc=%s" % traceId
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_get_with_params_to_scrub(self) -> None:
         async def test():
@@ -515,7 +515,7 @@ class TestTornadoServer:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == "intid;desc=%s" % traceId
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_request_header_capture(self) -> None:
         async def test():
@@ -585,7 +585,7 @@ class TestTornadoServer:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == "intid;desc=%s" % traceId
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
         assert "X-Capture-This" in tornado_span.data["http"]["header"]
         assert tornado_span.data["http"]["header"]["X-Capture-This"] == "this"
@@ -655,7 +655,7 @@ class TestTornadoServer:
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
-        assert response.headers["Server-Timing"] == "intid;desc=%s" % traceId
+        assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
         assert "X-Capture-This-Too" in tornado_span.data["http"]["header"]
         assert tornado_span.data["http"]["header"]["X-Capture-This-Too"] == "this too"

--- a/tests/frameworks/test_tornado_server.py
+++ b/tests/frameworks/test_tornado_server.py
@@ -9,6 +9,7 @@ import aiohttp
 import tornado
 from tornado.httpclient import AsyncHTTPClient
 
+from instana.util.ids import hex_id
 import tests.apps.tornado_server
 
 from instana.singletons import tracer, agent
@@ -100,9 +101,9 @@ class TestTornadoServer:
         assert len(aiohttp_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(tornado_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(tornado_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
@@ -161,9 +162,9 @@ class TestTornadoServer:
         assert len(aiohttp_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(tornado_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(tornado_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
@@ -258,9 +259,9 @@ class TestTornadoServer:
         assert len(aiohttp_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(tornado_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(tornado_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
@@ -320,9 +321,9 @@ class TestTornadoServer:
         assert len(aiohttp_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(tornado_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(tornado_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
@@ -383,9 +384,9 @@ class TestTornadoServer:
         assert len(aiohttp_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(tornado_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(tornado_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
@@ -446,9 +447,9 @@ class TestTornadoServer:
         assert len(aiohttp_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(tornado_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(tornado_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
@@ -508,9 +509,9 @@ class TestTornadoServer:
         assert len(aiohttp_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(tornado_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(tornado_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
@@ -578,9 +579,9 @@ class TestTornadoServer:
         assert len(aiohttp_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(tornado_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(tornado_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers
@@ -648,9 +649,9 @@ class TestTornadoServer:
         assert len(aiohttp_span.stack) > 1
 
         assert "X-INSTANA-T" in response.headers
-        assert response.headers["X-INSTANA-T"] == str(traceId)
+        assert response.headers["X-INSTANA-T"] == hex_id(traceId)
         assert "X-INSTANA-S" in response.headers
-        assert response.headers["X-INSTANA-S"] == str(tornado_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(tornado_span.s)
         assert "X-INSTANA-L" in response.headers
         assert response.headers["X-INSTANA-L"] == '1'
         assert "Server-Timing" in response.headers

--- a/tests/frameworks/test_wsgi.py
+++ b/tests/frameworks/test_wsgi.py
@@ -6,6 +6,7 @@ import urllib3
 import pytest
 from typing import Generator
 
+from instana.util.ids import hex_id
 from tests.apps import bottle_app
 from tests.helpers import testenv
 from instana.singletons import agent, tracer
@@ -47,11 +48,11 @@ class TestWSGI:
 
         assert 'X-INSTANA-T' in response.headers
         assert int(response.headers['X-INSTANA-T'], 16)
-        assert response.headers["X-INSTANA-T"] == str(wsgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(wsgi_span.t)
 
         assert 'X-INSTANA-S' in response.headers
         assert int(response.headers['X-INSTANA-S'], 16)
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
 
         assert 'X-INSTANA-L' in response.headers
         assert response.headers['X-INSTANA-L'] == '1'
@@ -132,11 +133,11 @@ class TestWSGI:
 
         assert 'X-INSTANA-T' in response.headers
         assert int(response.headers['X-INSTANA-T'], 16)
-        assert response.headers["X-INSTANA-T"] == str(wsgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(wsgi_span.t)
 
         assert 'X-INSTANA-S' in response.headers
         assert int(response.headers['X-INSTANA-S'], 16)
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
 
         assert 'X-INSTANA-L' in response.headers
         assert response.headers['X-INSTANA-L'] == '1'
@@ -190,11 +191,11 @@ class TestWSGI:
 
         assert 'X-INSTANA-T' in response.headers
         assert int(response.headers['X-INSTANA-T'], 16)
-        assert response.headers["X-INSTANA-T"] == str(wsgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(wsgi_span.t)
 
         assert 'X-INSTANA-S' in response.headers
         assert int(response.headers['X-INSTANA-S'], 16)
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
 
         assert 'X-INSTANA-L' in response.headers
         assert response.headers['X-INSTANA-L'] == '1'
@@ -248,11 +249,11 @@ class TestWSGI:
 
         assert 'X-INSTANA-T' in response.headers
         assert int(response.headers['X-INSTANA-T'], 16)
-        assert response.headers["X-INSTANA-T"] == str(wsgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(wsgi_span.t)
 
         assert 'X-INSTANA-S' in response.headers
         assert int(response.headers['X-INSTANA-S'], 16)
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
 
         assert 'X-INSTANA-L' in response.headers
         assert response.headers['X-INSTANA-L'] == '1'
@@ -283,11 +284,11 @@ class TestWSGI:
 
         assert 'X-INSTANA-T' in response.headers
         assert int(response.headers['X-INSTANA-T'], 16)
-        assert response.headers["X-INSTANA-T"] == str(wsgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(wsgi_span.t)
 
         assert 'X-INSTANA-S' in response.headers
         assert int(response.headers['X-INSTANA-S'], 16)
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
 
         assert 'X-INSTANA-L' in response.headers
         assert response.headers['X-INSTANA-L'] == '1'
@@ -314,11 +315,11 @@ class TestWSGI:
 
         assert 'X-INSTANA-T' in response.headers
         assert int(response.headers['X-INSTANA-T'], 16)
-        assert response.headers["X-INSTANA-T"] == str(wsgi_span.t)
+        assert response.headers["X-INSTANA-T"] == hex_id(wsgi_span.t)
 
         assert 'X-INSTANA-S' in response.headers
         assert int(response.headers['X-INSTANA-S'], 16)
-        assert response.headers["X-INSTANA-S"] == str(wsgi_span.s)
+        assert response.headers["X-INSTANA-S"] == hex_id(wsgi_span.s)
 
         assert 'X-INSTANA-L' in response.headers
         assert response.headers['X-INSTANA-L'] == '1'

--- a/tests/frameworks/test_wsgi.py
+++ b/tests/frameworks/test_wsgi.py
@@ -58,7 +58,7 @@ class TestWSGI:
         assert response.headers['X-INSTANA-L'] == '1'
 
         assert 'Server-Timing' in response.headers
-        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         assert response.headers['Server-Timing'] == server_timing_value
 
         # Same traceId
@@ -143,7 +143,7 @@ class TestWSGI:
         assert response.headers['X-INSTANA-L'] == '1'
 
         assert 'Server-Timing' in response.headers
-        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         assert response.headers['Server-Timing'] == server_timing_value
 
         # Same traceId
@@ -201,7 +201,7 @@ class TestWSGI:
         assert response.headers['X-INSTANA-L'] == '1'
 
         assert 'Server-Timing' in response.headers
-        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         assert response.headers['Server-Timing'] == server_timing_value
 
         # Same traceId
@@ -259,7 +259,7 @@ class TestWSGI:
         assert response.headers['X-INSTANA-L'] == '1'
 
         assert 'Server-Timing' in response.headers
-        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         assert response.headers['Server-Timing'] == server_timing_value
 
     def test_with_incoming_mixed_case_context(self) -> None:
@@ -294,7 +294,7 @@ class TestWSGI:
         assert response.headers['X-INSTANA-L'] == '1'
 
         assert 'Server-Timing' in response.headers
-        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         assert response.headers['Server-Timing'] == server_timing_value
 
     def test_response_headers(self) -> None:
@@ -325,5 +325,5 @@ class TestWSGI:
         assert response.headers['X-INSTANA-L'] == '1'
 
         assert 'Server-Timing' in response.headers
-        server_timing_value = "intid;desc=%s" % wsgi_span.t
+        server_timing_value = f"intid;desc={hex_id(wsgi_span.t)}"
         assert response.headers['Server-Timing'] == server_timing_value

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -153,3 +153,6 @@ def launch_traced_request(url):
         response = requests.get(url)
 
     return response
+
+
+

--- a/tests/propagators/test_binary_propagator.py
+++ b/tests/propagators/test_binary_propagator.py
@@ -21,7 +21,7 @@ class TestBinaryPropagator:
         self.bp = BinaryPropagator()
         yield
 
-    def test_inject_carrier_dict(self, trace_id: int, span_id: int) -> None:
+    def test_inject_carrier_dict(self, trace_id: int, span_id: int, hex_trace_id: str, hex_span_id: str) -> None:
         carrier = {}
         ctx = SpanContext(
             span_id=span_id,
@@ -34,12 +34,12 @@ class TestBinaryPropagator:
         )
         carrier = self.bp.inject(ctx, carrier)
 
-        assert carrier[b"x-instana-t"] == str(trace_id).encode("utf-8")
-        assert carrier[b"x-instana-s"] == str(span_id).encode("utf-8")
+        assert carrier[b"x-instana-t"] == hex_trace_id.encode("utf-8")
+        assert carrier[b"x-instana-s"] == hex_span_id.encode("utf-8")
         assert carrier[b"x-instana-l"] == b"1"
         assert carrier[b"server-timing"] == f"intid;desc={trace_id}".encode("utf-8")
 
-    def test_inject_carrier_dict_w3c_True(self, trace_id: int, span_id: int) -> None:
+    def test_inject_carrier_dict_w3c_True(self, trace_id: int, span_id: int, hex_trace_id: str, hex_span_id: str) -> None:
         carrier = {}
         ctx = SpanContext(
             span_id=span_id,
@@ -52,8 +52,8 @@ class TestBinaryPropagator:
         )
         carrier = self.bp.inject(ctx, carrier, disable_w3c_trace_context=False)
 
-        assert carrier[b"x-instana-t"] == str(trace_id).encode("utf-8")
-        assert carrier[b"x-instana-s"] == str(span_id).encode("utf-8")
+        assert carrier[b"x-instana-t"] == hex_trace_id.encode("utf-8")
+        assert carrier[b"x-instana-s"] == hex_span_id.encode("utf-8")
         assert carrier[b"x-instana-l"] == b"1"
         assert carrier[b"server-timing"] == f"intid;desc={trace_id}".encode("utf-8")
         assert carrier[
@@ -61,9 +61,9 @@ class TestBinaryPropagator:
         ] == f"00-{format_trace_id(trace_id)}-{format_span_id(span_id)}-01".encode(
             "utf-8"
         )
-        assert carrier[b"tracestate"] == f"in={trace_id};{span_id}".encode("utf-8")
+        assert carrier[b"tracestate"] == f"in={hex_id(trace_id)};{hex_id(span_id)}".encode("utf-8")
 
-    def test_inject_carrier_list(self, trace_id: int, span_id: int) -> None:
+    def test_inject_carrier_list(self, trace_id: int, span_id: int, hex_trace_id: str, hex_span_id: str) -> None:
         carrier = []
         ctx = SpanContext(
             span_id=span_id,
@@ -77,15 +77,15 @@ class TestBinaryPropagator:
         carrier = self.bp.inject(ctx, carrier)
 
         assert isinstance(carrier, list)
-        assert carrier[0] == (b"x-instana-t", str(trace_id).encode("utf-8"))
-        assert carrier[1] == (b"x-instana-s", str(span_id).encode("utf-8"))
+        assert carrier[0] == (b"x-instana-t", hex_trace_id.encode("utf-8"))
+        assert carrier[1] == (b"x-instana-s", hex_span_id.encode("utf-8"))
         assert carrier[2] == (b"x-instana-l", b"1")
         assert carrier[3] == (
             b"server-timing",
             f"intid;desc={trace_id}".encode("utf-8"),
         )
 
-    def test_inject_carrier_list_w3c_True(self, trace_id: int, span_id: int) -> None:
+    def test_inject_carrier_list_w3c_True(self, trace_id: int, span_id: int, hex_trace_id: str, hex_span_id: str) -> None:
         carrier = []
         ctx = SpanContext(
             span_id=span_id,
@@ -105,16 +105,19 @@ class TestBinaryPropagator:
                 "utf-8"
             ),
         )
-        assert carrier[1] == (b"tracestate", f"in={trace_id};{span_id}".encode("utf-8"))
-        assert carrier[2] == (b"x-instana-t", str(trace_id).encode("utf-8"))
-        assert carrier[3] == (b"x-instana-s", str(span_id).encode("utf-8"))
+        assert carrier[1] == (
+            b"tracestate",
+            f"in={hex_id(trace_id)};{hex_id(span_id)}".encode("utf-8"),
+        )
+        assert carrier[2] == (b"x-instana-t", hex_trace_id.encode("utf-8"))
+        assert carrier[3] == (b"x-instana-s", hex_span_id.encode("utf-8"))
         assert carrier[4] == (b"x-instana-l", b"1")
         assert carrier[5] == (
             b"server-timing",
             f"intid;desc={trace_id}".encode("utf-8"),
         )
 
-    def test_inject_carrier_tuple(self, trace_id: int, span_id: int) -> None:
+    def test_inject_carrier_tuple(self, trace_id: int, span_id: int, hex_trace_id: str, hex_span_id: str) -> None:
         carrier = ()
         ctx = SpanContext(
             span_id=span_id,
@@ -128,15 +131,15 @@ class TestBinaryPropagator:
         carrier = self.bp.inject(ctx, carrier)
 
         assert isinstance(carrier, tuple)
-        assert carrier[0] == (b"x-instana-t", str(trace_id).encode("utf-8"))
-        assert carrier[1] == (b"x-instana-s", str(span_id).encode("utf-8"))
+        assert carrier[0] == (b"x-instana-t", hex_trace_id.encode("utf-8"))
+        assert carrier[1] == (b"x-instana-s", hex_span_id.encode("utf-8"))
         assert carrier[2] == (b"x-instana-l", b"1")
         assert carrier[3] == (
             b"server-timing",
             f"intid;desc={trace_id}".encode("utf-8"),
         )
 
-    def test_inject_carrier_tuple_w3c_True(self, trace_id: int, span_id: int) -> None:
+    def test_inject_carrier_tuple_w3c_True(self, trace_id: int, span_id: int, hex_trace_id: str, hex_span_id: str) -> None:
         carrier = ()
         ctx = SpanContext(
             span_id=span_id,
@@ -156,9 +159,12 @@ class TestBinaryPropagator:
                 "utf-8"
             ),
         )
-        assert carrier[1] == (b"tracestate", f"in={trace_id};{span_id}".encode("utf-8"))
-        assert carrier[2] == (b"x-instana-t", str(trace_id).encode("utf-8"))
-        assert carrier[3] == (b"x-instana-s", str(span_id).encode("utf-8"))
+        assert carrier[1] == (
+            b"tracestate",
+            f"in={hex_id(trace_id)};{hex_id(span_id)}".encode("utf-8"),
+        )
+        assert carrier[2] == (b"x-instana-t", hex_trace_id.encode("utf-8"))
+        assert carrier[3] == (b"x-instana-s", hex_span_id.encode("utf-8"))
         assert carrier[4] == (b"x-instana-l", b"1")
         assert carrier[5] == (
             b"server-timing",

--- a/tests/propagators/test_binary_propagator.py
+++ b/tests/propagators/test_binary_propagator.py
@@ -11,6 +11,7 @@ from opentelemetry.trace import (
 
 from instana.propagators.binary_propagator import BinaryPropagator
 from instana.span_context import SpanContext
+from instana.util.ids import hex_id
 
 
 class TestBinaryPropagator:
@@ -37,7 +38,7 @@ class TestBinaryPropagator:
         assert carrier[b"x-instana-t"] == hex_trace_id.encode("utf-8")
         assert carrier[b"x-instana-s"] == hex_span_id.encode("utf-8")
         assert carrier[b"x-instana-l"] == b"1"
-        assert carrier[b"server-timing"] == f"intid;desc={trace_id}".encode("utf-8")
+        assert carrier[b"server-timing"] == f"intid;desc={hex_id(trace_id)}".encode("utf-8")
 
     def test_inject_carrier_dict_w3c_True(self, trace_id: int, span_id: int, hex_trace_id: str, hex_span_id: str) -> None:
         carrier = {}
@@ -55,7 +56,7 @@ class TestBinaryPropagator:
         assert carrier[b"x-instana-t"] == hex_trace_id.encode("utf-8")
         assert carrier[b"x-instana-s"] == hex_span_id.encode("utf-8")
         assert carrier[b"x-instana-l"] == b"1"
-        assert carrier[b"server-timing"] == f"intid;desc={trace_id}".encode("utf-8")
+        assert carrier[b"server-timing"] == f"intid;desc={hex_id(trace_id)}".encode("utf-8")
         assert carrier[
             b"traceparent"
         ] == f"00-{format_trace_id(trace_id)}-{format_span_id(span_id)}-01".encode(
@@ -82,7 +83,7 @@ class TestBinaryPropagator:
         assert carrier[2] == (b"x-instana-l", b"1")
         assert carrier[3] == (
             b"server-timing",
-            f"intid;desc={trace_id}".encode("utf-8"),
+            f"intid;desc={hex_id(trace_id)}".encode("utf-8"),
         )
 
     def test_inject_carrier_list_w3c_True(self, trace_id: int, span_id: int, hex_trace_id: str, hex_span_id: str) -> None:
@@ -114,7 +115,7 @@ class TestBinaryPropagator:
         assert carrier[4] == (b"x-instana-l", b"1")
         assert carrier[5] == (
             b"server-timing",
-            f"intid;desc={trace_id}".encode("utf-8"),
+            f"intid;desc={hex_id(trace_id)}".encode("utf-8"),
         )
 
     def test_inject_carrier_tuple(self, trace_id: int, span_id: int, hex_trace_id: str, hex_span_id: str) -> None:
@@ -136,7 +137,7 @@ class TestBinaryPropagator:
         assert carrier[2] == (b"x-instana-l", b"1")
         assert carrier[3] == (
             b"server-timing",
-            f"intid;desc={trace_id}".encode("utf-8"),
+            f"intid;desc={hex_id(trace_id)}".encode("utf-8"),
         )
 
     def test_inject_carrier_tuple_w3c_True(self, trace_id: int, span_id: int, hex_trace_id: str, hex_span_id: str) -> None:
@@ -168,7 +169,7 @@ class TestBinaryPropagator:
         assert carrier[4] == (b"x-instana-l", b"1")
         assert carrier[5] == (
             b"server-timing",
-            f"intid;desc={trace_id}".encode("utf-8"),
+            f"intid;desc={hex_id(trace_id)}".encode("utf-8"),
         )
 
     def test_inject_carrier_set_exception(self, trace_id: int, span_id: int) -> None:

--- a/tests_aws/01_lambda/test_lambda.py
+++ b/tests_aws/01_lambda/test_lambda.py
@@ -19,6 +19,7 @@ from instana.instrumentation.aws.triggers import read_http_query_params
 from instana.options import AWSLambdaOptions
 from instana.singletons import get_agent
 from instana.util.aws import normalize_aws_lambda_arn
+from instana.util.ids import hex_id
 
 if TYPE_CHECKING:
     from instana.span.span import InstanaSpan
@@ -225,7 +226,7 @@ class TestLambda:
         assert span.p == hex(span_id)[2:]
         assert span.ts
 
-        server_timing_value = f"intid;desc={trace_id}"
+        server_timing_value = f"intid;desc={hex_id(trace_id)}"
         assert result["headers"]["Server-Timing"] == server_timing_value
 
         assert span.f == {
@@ -297,7 +298,7 @@ class TestLambda:
         assert span.p == hex(span_id)[2:]
         assert span.ts
 
-        server_timing_value = f"intid;desc={trace_id}"
+        server_timing_value = f"intid;desc={hex_id(trace_id)}"
         assert result["headers"]["Server-Timing"] == server_timing_value
 
         assert span.f == {
@@ -409,7 +410,7 @@ class TestLambda:
         assert span.p == hex(span_id)[2:]
         assert span.ts
 
-        server_timing_value = f"intid;desc={trace_id}"
+        server_timing_value = f"intid;desc={hex_id(trace_id)}"
         assert result["headers"]["Server-Timing"] == server_timing_value
 
         assert span.f == {
@@ -477,7 +478,7 @@ class TestLambda:
         assert not span.p
         assert span.ts
 
-        server_timing_value = f"intid;desc={int(span.t, 16)}"
+        server_timing_value = f"intid;desc={hex_id(int(span.t, 16))}"
         assert result["headers"]["Server-Timing"] == server_timing_value
 
         assert span.f == {
@@ -554,7 +555,7 @@ class TestLambda:
         assert not span.p
         assert span.ts
 
-        server_timing_value = f"intid;desc={int(span.t, 16)}"
+        server_timing_value = f"intid;desc={hex_id(int(span.t, 16))}"
         assert result["headers"]["Server-Timing"] == server_timing_value
 
         assert span.f == {
@@ -632,7 +633,7 @@ class TestLambda:
         assert not span.p
         assert span.ts
 
-        server_timing_value = f"intid;desc={int(span.t, 16)}"
+        server_timing_value = f"intid;desc={hex_id(int(span.t, 16))}"
         assert result["headers"]["Server-Timing"] == server_timing_value
 
         assert span.f == {
@@ -703,7 +704,7 @@ class TestLambda:
         assert not span.p
         assert span.ts
 
-        server_timing_value = f"intid;desc={int(span.t, 16)}"
+        server_timing_value = f"intid;desc={hex_id(int(span.t, 16))}"
         assert result["headers"]["Server-Timing"] == server_timing_value
 
         assert span.f == {
@@ -807,7 +808,7 @@ class TestLambda:
         assert span.p == hex(int("0000000000004567"))[2:].zfill(16)
         assert span.ts
 
-        server_timing_value = f"intid;desc={int('0000000000001234')}"
+        server_timing_value = f"intid;desc={hex_id(int('0000000000001234'))}"
         assert result["headers"]["Server-Timing"] == server_timing_value
 
         assert span.f == {


### PR DESCRIPTION
### Fix OTel header inject values (Part 1)
Instana's Tracer Specification claims the `X-INSTANA-T` and `X-INSTANA-S ` values injected in returned headers must be 16 lowercase hexadecimal characters.

### Integration test results:
#### Before:
```
  2 passing (11s)
  42 failing
```
#### After:
```
  14 passing (30s)
  30 failing
```