### PR TITLE
fix: provide ASGI support with Django

### DIFF
--- a/src/instana/instrumentation/django/middleware.py
+++ b/src/instana/instrumentation/django/middleware.py
@@ -2,7 +2,6 @@
 # (c) Copyright Instana Inc. 2018
 
 
-import os
 import sys
 
 import opentracing as ot
@@ -45,7 +44,7 @@ class InstanaMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         try:
-            env = request.environ
+            env = request.META
 
             ctx = tracer.extract(ot.Format.HTTP_HEADERS, env)
             request.iscope = tracer.start_active_span('django', child_of=ctx)
@@ -92,7 +91,7 @@ class InstanaMiddleware(MiddlewareMixin):
         except Exception:
             logger.debug("Instana middleware @ process_response", exc_info=True)
         finally:
-            if request.iscope is not None:
+            if hasattr(request, "iscope") and request.iscope:
                 request.iscope.close()
                 request.iscope = None
         return response


### PR DESCRIPTION
Fix: Provide ASGI support with Django.

#### Why?
`request.environ` is available only with requests of type `WSGIRequest` and not `ASGIRequest`.
[`request.headers`](https://docs.djangoproject.com/en/3.0/ref/request-response/#django.http.HttpRequest.headers) is only available from `django-2.2`.

Since we provide support for `django>=1.11` we'll use [`request.META`](https://docs.djangoproject.com/en/5.1/ref/request-response/#django.http.HttpRequest.META).