### PR TITLE
Adapt to logger's incoming stacklevel

### DIFF
--- a/src/instana/instrumentation/logging.py
+++ b/src/instana/instrumentation/logging.py
@@ -22,16 +22,22 @@ def log_with_instana(
     # argv[0] = level
     # argv[1] = message
     # argv[2] = args for message
-    if sys.version_info >= (3, 13):
-        stacklevel = 3
+
+    # We take into consideration if `stacklevel` is already present in `kwargs`.
+    # This prevents the error `_log() got multiple values for keyword argument 'stacklevel'`
+    if "stacklevel" in kwargs.keys():
+        stacklevel = kwargs.pop("stacklevel")
     else:
         stacklevel = 2
+        if sys.version_info >= (3, 13):
+            stacklevel = 3
+        
     try:
-        tracer, parent_span, _ = get_tracer_tuple()
-
         # Only needed if we're tracing and serious log
         if tracing_is_off() or argv[0] < logging.WARN:
             return wrapped(*argv, **kwargs, stacklevel=stacklevel)
+
+        tracer, parent_span, _ = get_tracer_tuple()
 
         msg = str(argv[1])
         args = argv[2]

--- a/src/instana/instrumentation/logging.py
+++ b/src/instana/instrumentation/logging.py
@@ -25,13 +25,9 @@ def log_with_instana(
 
     # We take into consideration if `stacklevel` is already present in `kwargs`.
     # This prevents the error `_log() got multiple values for keyword argument 'stacklevel'`
-    if "stacklevel" in kwargs.keys():
-        stacklevel = kwargs.pop("stacklevel")
-    else:
-        stacklevel = 2
-        if sys.version_info >= (3, 13):
-            stacklevel = 3
-        
+    stacklevel_in = kwargs.pop("stacklevel", 1)
+    stacklevel = stacklevel_in + 1 + (sys.version_info >= (3, 13))
+
     try:
         # Only needed if we're tracing and serious log
         if tracing_is_off() or argv[0] < logging.WARN:

--- a/tests/clients/test_logging.py
+++ b/tests/clients/test_logging.py
@@ -126,3 +126,13 @@ class TestLogging:
         assert caplog.records[-1].funcName == "log_custom_warning"
 
         self.logger.removeHandler(handler)
+
+    def test_stacklevel_as_kwarg(self):
+        with tracer.start_as_current_span("test"):
+            self.logger.warning("foo %s", "bar", stacklevel=2)
+
+        spans = self.recorder.queued_spans()
+        assert len(spans) == 2
+        assert spans[0].k == SpanKind.CLIENT
+
+        assert spans[0].data["log"].get("message") == "foo bar"


### PR DESCRIPTION
Related to https://github.com/instana/python-sensor/pull/652

Bypass the stack level of our instrumentation when the keyword `stacklevel` is set as well.

### Before the changes <sup>py3.11</sup>
log_with_instana -> log_custom_warning -> main
`stacklevel1 -> stacklevel2 -> stacklevel3`

### After the changes <sup>py3.11</sup>
log_custom_warning -> main -> test_log_caller_with_stacklevel
`stacklevel1 -> stacklevel2 -> stacklevel3`