### PR TITLE
chore: Add GitHub CODEOWNERS file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo.
+# Unless a later match takes precedence, @eng-python will be
+# requested for review when someone opens a pull request.
+* @instana/eng-python
+
+# Order is important; the last matching pattern takes the most
+# precedence.
+/.github/CODEOWNERS @pvital @GSVarsha


### PR DESCRIPTION
Adding GitHub [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file to extend branch protection on the repo.