### PR TITLE
Fix flaky tests with inconsistent trace and span ids

### DIFF
--- a/src/instana/util/ids.py
+++ b/src/instana/util/ids.py
@@ -135,12 +135,17 @@ def internal_id(id: Union[int, str]) -> int:
     """
     if isinstance(id, int):
         return id
+    
+    length = len(id)
 
     if isinstance(id, str) and id.isdigit():
-        return int(id)
+        if length == 16:
+            return int(id, 16)
+        else:
+            return int(id)
 
     try:
-        if len(id) < 16:
+        if length < 16:
             # Left pad ID with zeros
             id = id.zfill(16)
 
@@ -157,11 +162,15 @@ def internal_id_limited(id: Union[int, str]) -> int:
     if isinstance(id, int):
         return id
 
+    length = len(id)
+
     if isinstance(id, str) and id.isdigit():
-        return int(id)
+        if length == 16:
+            return int(id, 16)
+        else:
+            return int(id)
 
     try:
-        length = len(id)
         if length < 16:
             # Left pad ID with zeros
             id = id.zfill(16)

--- a/tests_aws/01_lambda/test_lambda.py
+++ b/tests_aws/01_lambda/test_lambda.py
@@ -803,12 +803,13 @@ class TestLambda:
 
         span = payload["spans"].pop()
         assert span.n == "aws.lambda.entry"
-        assert span.t == hex_id("0000000000001234")
+        trace_id = "0000000000001234"
+        assert span.t == trace_id
         assert span.s
-        assert span.p == hex_id("0000000000004567")
+        assert span.p == "0000000000004567"
         assert span.ts
 
-        server_timing_value = f"intid;desc={hex_id(int('0000000000001234'))}"
+        server_timing_value = f"intid;desc={trace_id}"
         assert result["headers"]["Server-Timing"] == server_timing_value
 
         assert span.f == {


### PR DESCRIPTION
Failure scenarios: [case-1](https://app.circleci.com/pipelines/github/instana/python-sensor/3374/workflows/4b6ccede-4ff2-43e6-b1e3-a5df87b70c6f/jobs/24244/tests#failed-test-0) with trace_id, [case-2](https://app.circleci.com/pipelines/github/instana/python-sensor/3362/workflows/f269fb28-b8c8-4fef-a721-d73baf01da6d/jobs/24064/tests#failed-test-0) with parent relationship (parent_id, span_id)

Considering cases when the hexadecimal string contains all the characters as digits.
```
>>> id=8360669476235335784
>>> hexid=hex(id)[2:]
>>> hexid
'7407109787755868'
>>> hexid.isdigit()
True
```