### PR TITLE
fix: post branch rename changes

### DIFF
--- a/.github/workflows/pr_commits_signed_off.yml
+++ b/.github/workflows/pr_commits_signed_off.yml
@@ -2,7 +2,7 @@ name: Find signed commits
 on:
   pull_request_target:
     branches:
-      - master # or the name of your main branch
+      - main # or the name of your main branch
 jobs:
   check-sign-off:
     name: Write comment if unsigned commits found

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -2,7 +2,7 @@ name: Build
 on:
   push:
     branches:
-      - master # or the name of your main branch
+      - main # or the name of your main branch
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/.tekton/.currency/currency-pipelinerun.yaml
+++ b/.tekton/.currency/currency-pipelinerun.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   params:
   - name: revision
-    value: "master"
+    value: "main"
   pipelineRef:
     name: python-currency-pipeline
   serviceAccountName: currency-serviceaccount

--- a/.tekton/.currency/currency-scheduled-eventlistener.yaml
+++ b/.tekton/.currency/currency-scheduled-eventlistener.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: currency-serviceaccount
       params:
       - name: revision
-        value: "master"
+        value: "main"
       workspaces:
       - name: currency-pvc
         volumeClaimTemplate:

--- a/.tekton/README.md
+++ b/.tekton/README.md
@@ -47,9 +47,9 @@ http://localhost:8001/api/v1/namespaces/tekton-pipelines/services/tekton-dashboa
 1. Click `Create`
 2. Select the `Namespace` (where the `Pipeline` resource is created by default it is `default`)
 3. Select the `Pipeline` created in the `pipeline.yaml` right now it is `python-tracer-ci-pipeline`
-4. Fill in `Params`. The `revision` should be `master` for the `master` branch
+4. Fill in `Params`. The `revision` should be `main` for the `main` branch
 4. Select the `ServiceAccount` set to `default`
-5. Optionally, enter a `PipelineRun name` for example `my-master-test-pipeline`,
+5. Optionally, enter a `PipelineRun name` for example `my-main-test-pipeline`,
    but if you don't then the Dashboard will generate a unique one for you.
 6. As long as [the known issue with Tekton Dashboard Workspace binding](
    https://github.com/tektoncd/dashboard/issues/1283), is not resolved.
@@ -293,5 +293,5 @@ The current schedule is `"5 0 * * Mon-Fri`,
 whic means every weekday 00:05 in the pod's timezone.
 This can be adjusted by editing the `schedule` attribute.
 Currently this triggers the `github-pr-python-tracer-ci-pipeline`
-on the head of the `master` branch.
+on the head of the `main` branch.
 These can also be changed on demand.

--- a/.tekton/github-pr-pipeline.yaml.part
+++ b/.tekton/github-pr-pipeline.yaml.part
@@ -28,7 +28,7 @@ spec:
       - unittest-default
       - unittest-cassandra
       - unittest-couchbase
-      #- unittest-gevent-starlette
+      - unittest-gevent-starlette
       taskRef:
         kind: Task
         name: github-set-status

--- a/.tekton/scheduled-eventlistener.yaml
+++ b/.tekton/scheduled-eventlistener.yaml
@@ -21,7 +21,7 @@ spec:
       spec:
         params:
         - name: revision
-          value: master
+          value: main
         - name: git-commit-sha
           value: $(tt.params.git-commit-sha)
         pipelineRef:
@@ -45,7 +45,7 @@ spec:
     - name: date-time-normalized
       value: $(extensions.normalized_date_time)
     - name: git-commit-sha
-      value: $(body.git_master_head_commit_sha)
+      value: $(body.git_main_head_commit_sha)
     - name: git-commit-short-sha
       value: $(extensions.truncated_sha)
 ---
@@ -70,7 +70,7 @@ spec:
               wget -O- \
                    --header 'Content-Type: application/json' \
                    --post-data '{
-                                 "git_master_head_commit_sha":"'"$(git ls-remote https://github.com/instana/python-sensor master | cut -f1)"'",
+                                 "git_main_head_commit_sha":"'"$(git ls-remote https://github.com/instana/python-sensor main | cut -f1)"'",
                                  "date_time":"'"$(date -u -Iminutes )"'"
                                 }' \
                   'http://el-python-tracer-scheduled-pipeline-listener.default.svc.cluster.local:8080'
@@ -92,7 +92,7 @@ spec:
             - name: "overlays"
               value:
               - key: truncated_sha
-                expression: "body.git_master_head_commit_sha.truncate(7)"
+                expression: "body.git_main_head_commit_sha.truncate(7)"
         - name: add-normalized-date-time
           ref:
             name: "cel"

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ The `instana` Python package collects key metrics and distributed traces for [In
 
 Any feedback is welcome.  Happy Python visibility.
 
-[![CircleCI](https://circleci.com/gh/instana/python-sensor/tree/master.svg?style=svg)](https://circleci.com/gh/instana/python-sensor/tree/master)
+[![CircleCI](https://circleci.com/gh/instana/python-sensor/tree/main.svg?style=svg)](https://circleci.com/gh/instana/python-sensor/tree/main)
 [![OpenTracing Badge](https://img.shields.io/badge/OpenTracing-disabled-red.svg)](http://opentracing.io)
 [![OpenTelemetry Badge](https://img.shields.io/badge/OpenTelemetry-enabled-blue.svg)](http://opentelemetry.io)
-![Python Version from PEP 621 TOML](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Finstana%2Fpython-sensor%2Frefs%2Fheads%2Fmaster%2Fpyproject.toml)
+![Python Version from PEP 621 TOML](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Finstana%2Fpython-sensor%2Frefs%2Fheads%2Fmain%2Fpyproject.toml)
 ![GitHub Release](https://img.shields.io/github/v/release/instana/python-sensor)
 
 > [!NOTE]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,9 +6,9 @@ _Note: To release a new Instana package, you must be a project member of the [In
 Contact [Peter Giacomo Lombardo](https://github.com/pglombardo) to be added._
 
 1. Before releasing, assure that [tests have passed](https://circleci.com/gh/instana/workflows/python-sensor) and that the package has also been manually validated in various stacks.
-2. `git checkout master && git pull --rebase && pip install -U twine`
-3. Bump the package version in `instana/version.py`. `git` commit & push the version change to the master branch
-4. Create a [draft Release on Github](https://github.com/instana/python-sensor/releases) using [./bin/create_general_release.py](https://github.com/instana/python-sensor/blob/master/bin/create_general_release.py)
+2. `git checkout main && git pull --rebase && pip install -U twine`
+3. Bump the package version in `instana/version.py`. `git` commit & push the version change to the `main` branch
+4. Create a [draft Release on Github](https://github.com/instana/python-sensor/releases) using [./bin/create_general_release.py](https://github.com/instana/python-sensor/blob/main/bin/create_general_release.py)
 5. Run `python setup.py sdist bdist_wheel` to create the packages file in `./dist/`
 6. Upload the package to Pypi with twine: `twine upload dist/instana-<version>*`
 7. Validate the new release on https://pypi.org/project/instana/


### PR DESCRIPTION
Post work after the branch `master` has been renamed to `main`.