### PR TITLE
Not pull container images from Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,20 +96,23 @@ commands:
 jobs:
   python38:
     docker:
-      - image: cimg/python:3.8
-      - image: cimg/postgres:14.12
+      - image: public.ecr.aws/docker/library/python:3.8
+      - image: public.ecr.aws/docker/library/postgres:16.2-bookworm
         environment:
           POSTGRES_USER: root
           POSTGRES_PASSWORD: passw0rd
           POSTGRES_DB: instana_test_db
-      - image: cimg/mariadb:10.11.2
+      - image: public.ecr.aws/docker/library/mariadb:11.3.2
         environment:
           MYSQL_ROOT_PASSWORD: passw0rd
           MYSQL_DATABASE: instana_test_db
-      - image: cimg/redis:5.0.14
-      - image: rabbitmq:3.9.13
-      - image: mongo:4.2.3
-      - image: vanmoof/pubsub-emulator
+      - image: public.ecr.aws/docker/library/redis:7.2.4-bookworm
+      - image: public.ecr.aws/docker/library/rabbitmq:3.13.0
+      - image: public.ecr.aws/docker/library/mongo:7.0.6
+      - image: quay.io/thekevjames/gcloud-pubsub-emulator:latest
+        environment:
+          PUBSUB_EMULATOR_HOST: 0.0.0.0:8681
+          PUBSUB_PROJECT1: test-project,test-topic
     working_directory: ~/repo
     steps:
       - checkout
@@ -120,20 +123,23 @@ jobs:
 
   python39:
     docker:
-      - image: cimg/python:3.9
-      - image: cimg/postgres:14.12
+      - image: public.ecr.aws/docker/library/python:3.9
+      - image: public.ecr.aws/docker/library/postgres:16.2-bookworm
         environment:
           POSTGRES_USER: root
           POSTGRES_PASSWORD: passw0rd
           POSTGRES_DB: instana_test_db
-      - image: cimg/mariadb:10.11.2
+      - image: public.ecr.aws/docker/library/mariadb:11.3.2
         environment:
           MYSQL_ROOT_PASSWORD: passw0rd
           MYSQL_DATABASE: instana_test_db
-      - image: cimg/redis:5.0.14
-      - image: rabbitmq:3.9.13
-      - image: mongo:4.2.3
-      - image: vanmoof/pubsub-emulator
+      - image: public.ecr.aws/docker/library/redis:7.2.4-bookworm
+      - image: public.ecr.aws/docker/library/rabbitmq:3.13.0
+      - image: public.ecr.aws/docker/library/mongo:7.0.6
+      - image: quay.io/thekevjames/gcloud-pubsub-emulator:latest
+        environment:
+          PUBSUB_EMULATOR_HOST: 0.0.0.0:8681
+          PUBSUB_PROJECT1: test-project,test-topic
     working_directory: ~/repo
     steps:
       - checkout
@@ -144,20 +150,23 @@ jobs:
 
   python310:
     docker:
-      - image: cimg/python:3.10
-      - image: cimg/postgres:14.12
+      - image: public.ecr.aws/docker/library/python:3.10
+      - image: public.ecr.aws/docker/library/postgres:16.2-bookworm
         environment:
           POSTGRES_USER: root
           POSTGRES_PASSWORD: passw0rd
           POSTGRES_DB: instana_test_db
-      - image: cimg/mariadb:10.11.2
+      - image: public.ecr.aws/docker/library/mariadb:11.3.2
         environment:
           MYSQL_ROOT_PASSWORD: passw0rd
           MYSQL_DATABASE: instana_test_db
-      - image: cimg/redis:5.0.14
-      - image: rabbitmq:3.9.13
-      - image: mongo:4.2.3
-      - image: vanmoof/pubsub-emulator
+      - image: public.ecr.aws/docker/library/redis:7.2.4-bookworm
+      - image: public.ecr.aws/docker/library/rabbitmq:3.13.0
+      - image: public.ecr.aws/docker/library/mongo:7.0.6
+      - image: quay.io/thekevjames/gcloud-pubsub-emulator:latest
+        environment:
+          PUBSUB_EMULATOR_HOST: 0.0.0.0:8681
+          PUBSUB_PROJECT1: test-project,test-topic
     working_directory: ~/repo
     steps:
       - checkout
@@ -169,20 +178,23 @@ jobs:
 
   python311:
     docker:
-      - image: cimg/python:3.11
-      - image: cimg/postgres:14.12
+      - image: public.ecr.aws/docker/library/python:3.11
+      - image: public.ecr.aws/docker/library/postgres:16.2-bookworm
         environment:
           POSTGRES_USER: root
           POSTGRES_PASSWORD: passw0rd
           POSTGRES_DB: instana_test_db
-      - image: cimg/mariadb:10.11.2
+      - image: public.ecr.aws/docker/library/mariadb:11.3.2
         environment:
           MYSQL_ROOT_PASSWORD: passw0rd
           MYSQL_DATABASE: instana_test_db
-      - image: cimg/redis:5.0.14
-      - image: rabbitmq:3.9.13
-      - image: mongo:4.2.3
-      - image: vanmoof/pubsub-emulator
+      - image: public.ecr.aws/docker/library/redis:7.2.4-bookworm
+      - image: public.ecr.aws/docker/library/rabbitmq:3.13.0
+      - image: public.ecr.aws/docker/library/mongo:7.0.6
+      - image: quay.io/thekevjames/gcloud-pubsub-emulator:latest
+        environment:
+          PUBSUB_EMULATOR_HOST: 0.0.0.0:8681
+          PUBSUB_PROJECT1: test-project,test-topic
     working_directory: ~/repo
     steps:
       - checkout
@@ -194,20 +206,23 @@ jobs:
 
   python312:
     docker:
-      - image: cimg/python:3.12
-      - image: cimg/postgres:14.12
+      - image: public.ecr.aws/docker/library/python:3.12
+      - image: public.ecr.aws/docker/library/postgres:16.2-bookworm
         environment:
           POSTGRES_USER: root
           POSTGRES_PASSWORD: passw0rd
           POSTGRES_DB: instana_test_db
-      - image: cimg/mariadb:10.11.2
+      - image: public.ecr.aws/docker/library/mariadb:11.3.2
         environment:
           MYSQL_ROOT_PASSWORD: passw0rd
           MYSQL_DATABASE: instana_test_db
-      - image: cimg/redis:5.0.14
-      - image: rabbitmq:3.9.13
-      - image: mongo:4.2.3
-      - image: vanmoof/pubsub-emulator
+      - image: public.ecr.aws/docker/library/redis:7.2.4-bookworm
+      - image: public.ecr.aws/docker/library/rabbitmq:3.13.0
+      - image: public.ecr.aws/docker/library/mongo:7.0.6
+      - image: quay.io/thekevjames/gcloud-pubsub-emulator:latest
+        environment:
+          PUBSUB_EMULATOR_HOST: 0.0.0.0:8681
+          PUBSUB_PROJECT1: test-project,test-topic
     working_directory: ~/repo
     steps:
       - checkout
@@ -219,7 +234,7 @@ jobs:
 
   py312aws:
     docker:
-      - image: cimg/python:3.12
+      - image: public.ecr.aws/docker/library/python:3.12
     working_directory: ~/repo
     steps:
       - checkout
@@ -232,20 +247,23 @@ jobs:
 
   python313:
     docker:
-      - image: cimg/python:3.13
-      - image: cimg/postgres:14.12
+      - image: public.ecr.aws/docker/library/python:3.13
+      - image: public.ecr.aws/docker/library/postgres:16.2-bookworm
         environment:
           POSTGRES_USER: root
           POSTGRES_PASSWORD: passw0rd
           POSTGRES_DB: instana_test_db
-      - image: cimg/mariadb:10.11.2
+      - image: public.ecr.aws/docker/library/mariadb:11.3.2
         environment:
           MYSQL_ROOT_PASSWORD: passw0rd
           MYSQL_DATABASE: instana_test_db
-      - image: cimg/redis:5.0.14
-      - image: rabbitmq:3.9.13
-      - image: mongo:4.2.3
-      - image: vanmoof/pubsub-emulator
+      - image: public.ecr.aws/docker/library/redis:7.2.4-bookworm
+      - image: public.ecr.aws/docker/library/rabbitmq:3.13.0
+      - image: public.ecr.aws/docker/library/mongo:7.0.6
+      - image: quay.io/thekevjames/gcloud-pubsub-emulator:latest
+        environment:
+          PUBSUB_EMULATOR_HOST: 0.0.0.0:8681
+          PUBSUB_PROJECT1: test-project,test-topic
     working_directory: ~/repo
     steps:
       - checkout
@@ -257,8 +275,8 @@ jobs:
 
   py39cassandra:
     docker:
-      - image: cimg/python:3.9
-      - image: cassandra:3.11
+      - image: public.ecr.aws/docker/library/python:3.9
+      - image: public.ecr.aws/docker/library/cassandra:3.11.16-jammy
         environment:
           MAX_HEAP_SIZE: 2048m
           HEAP_NEWSIZE: 512m
@@ -275,7 +293,7 @@ jobs:
 
   final_job:
     docker:
-      - image: cimg/python:3.8.20
+      - image: public.ecr.aws/docker/library/python:3.9
     working_directory: ~/repo
     steps:
       - checkout
@@ -286,7 +304,7 @@ jobs:
 
   py39gevent_starlette:
     docker:
-      - image: cimg/python:3.9.20
+      - image: public.ecr.aws/docker/library/python:3.9.20
     working_directory: ~/repo
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,26 +21,9 @@ commands:
             pip install -r requirements.txt
             pip install -r <<parameters.requirements>>
 
-  install-couchbase-deps:
-    steps:
-      - run:
-          name: Install Couchbase Dependencies
-          # Even if we use focal, we need to add the bionic repo
-          # See: https://forums.couchbase.com/
-          # t/installing-libcouchbase-dev-on-ubuntu-20-focal-fossa/25955/3
-          command: |
-            sudo apt update
-            sudo wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | sudo apt-key add -
-            echo "deb http://packages.couchbase.com/ubuntu bionic bionic/main" | sudo tee /etc/apt/sources.list.d/couchbase.list
-            sudo apt update
-            sudo apt install libcouchbase-dev -y
-
   run-tests-with-coverage-report:
     parameters:
       cassandra:
-        default: ""
-        type: string
-      couchbase:
         default: ""
         type: string
       gevent:
@@ -54,7 +37,6 @@ commands:
           name: Run Tests With Coverage Report
           environment:
             CASSANDRA_TEST: "<<parameters.cassandra>>"
-            COUCHBASE_TEST: "<<parameters.couchbase>>"
             GEVENT_STARLETTE_TEST: "<<parameters.gevent>>"
           command: |
             . venv/bin/activate
@@ -273,22 +255,6 @@ jobs:
       - store-pytest-results
       - store-coverage-report
 
-  py39couchbase:
-    docker:
-      - image: cimg/python:3.9
-      - image: couchbase/server-sandbox:5.5.0
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - install-couchbase-deps
-      - pip-install-deps:
-          requirements: "tests/requirements-couchbase.txt"
-      - run-tests-with-coverage-report:
-          couchbase: "true"
-          tests: "tests/clients/test_couchbase.py"
-      - store-pytest-results
-      - store-coverage-report
-
   py39cassandra:
     docker:
       - image: cimg/python:3.9
@@ -345,7 +311,6 @@ workflows:
       - python312
       - python313
       - py39cassandra
-      - py39couchbase
       - py39gevent_starlette
       - py312aws
       - final_job:
@@ -357,6 +322,5 @@ workflows:
             - python312
             - python313
             - py39cassandra
-            - py39couchbase
             - py39gevent_starlette
             - py312aws

--- a/.tekton/.currency/currency-scheduled-eventlistener.yaml
+++ b/.tekton/.currency/currency-scheduled-eventlistener.yaml
@@ -48,8 +48,8 @@ spec:
         spec:
           containers:
           - name: http-request-to-el-svc
-            # curlimages/curl:8.6.0
-            image: curlimages/curl@sha256:f2237028bed58de91f62aea74260bb2a299cf12fbcabc23cfaf125fef276c884
+            # quay.io/curl/curl:8.11.0
+            image: quay.io/curl/curl@sha256:b90c4281fe1a4c6cc2b6a665c531d448bba078d75ffa98187e7d7e530fca5209
             imagePullPolicy: IfNotPresent
             args: ["curl", "-X", "POST", "--data", "{}", "el-python-currency-cron-listener.default.svc.cluster.local:8080"]
           restartPolicy: OnFailure

--- a/.tekton/.currency/currency-tasks.yaml
+++ b/.tekton/.currency/currency-tasks.yaml
@@ -11,10 +11,12 @@ spec:
       mountPath: /workspace
   steps:
     - name: clone-repo
-      # alpine/git:2.43.0
-      image: alpine/git@sha256:6ff4de047dcc8f0c7d75d2efff63fbc189e87d2f458305f2cc8f165ff83309cf
+      # public.ecr.aws/docker/library/alpine:3.20.3
+      image: public.ecr.aws/docker/library/alpine@sha256:029a752048e32e843bd6defe3841186fb8d19a28dae8ec287f433bb9d6d1ad85
       script: |
         #!/bin/sh
+        echo "Installing git"
+        apk fix && apk --no-cache --update add git gpg less openssh patch
         echo "Cloning repo"
         cd /workspace && git clone --filter=blob:none --sparse --depth 1 https://github.com/instana/python-sensor -b $(params.revision)
         cd python-sensor
@@ -31,8 +33,8 @@ spec:
       mountPath: /workspace
   steps:
     - name: generate-currency-report
-      # 3.10.15-bookworm
-      image: python@sha256:b346d9d55e40cd6079db55370581b3bd24067acf5f1acc386107ec0843102ec9
+      # public.ecr.aws/docker/library/python:3.10.15-bookworm
+      image: public.ecr.aws/docker/library/python@sha256:2eb72484c25c39aba019b0ab5679c2436833a0b705e955ed8e13c06ee900dd63
       script: |
         #!/usr/bin/env bash
         cd /workspace/python-sensor/.tekton/.currency
@@ -61,8 +63,8 @@ spec:
       mountPath: /workspace
   steps:
     - name: upload-currency-report
-      # alpine/git:2.43.0
-      image: alpine/git@sha256:6ff4de047dcc8f0c7d75d2efff63fbc189e87d2f458305f2cc8f165ff83309cf
+      # public.ecr.aws/docker/library/alpine:3.20.3
+      image: public.ecr.aws/docker/library/alpine@sha256:029a752048e32e843bd6defe3841186fb8d19a28dae8ec287f433bb9d6d1ad85
       env:
         - name: GH_ENTERPRISE_TOKEN
           valueFrom:
@@ -71,7 +73,10 @@ spec:
               key: "GH_ENTERPRISE_TOKEN"
       script: |
         #!/bin/sh
+        echo "Installing git"
+        apk fix && apk --no-cache --update add git gpg less openssh patch
 
+        echo "Cloning repo"
         cd /workspace        
         git clone https://oauth2:$GH_ENTERPRISE_TOKEN@github.ibm.com/instana/tracer-reports.git
 

--- a/.tekton/github-pr-pipeline.yaml.part
+++ b/.tekton/github-pr-pipeline.yaml.part
@@ -27,7 +27,6 @@ spec:
       - github-set-check-status-to-pending
       - unittest-default
       - unittest-cassandra
-      - unittest-couchbase
       - unittest-gevent-starlette
       taskRef:
         kind: Task

--- a/.tekton/github-set-status-task.yaml
+++ b/.tekton/github-set-status-task.yaml
@@ -14,8 +14,8 @@ spec:
       secretName: githubtoken
   steps:
     - name: set-status
-      # curlimages/curl:8.6.0
-      image: curlimages/curl@sha256:f2237028bed58de91f62aea74260bb2a299cf12fbcabc23cfaf125fef276c884
+      # quay.io/curl/curl:8.11.0
+      image: quay.io/curl/curl@sha256:b90c4281fe1a4c6cc2b6a665c531d448bba078d75ffa98187e7d7e530fca5209
       env:
       - name: SHA
         value: $(params.SHA)

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -56,20 +56,6 @@ spec:
       workspaces:
         - name: task-pvc
           workspace: python-tracer-ci-pipeline-pvc
-    - name: unittest-couchbase
-      runAfter:
-        - clone
-      matrix:
-        params:
-          - name: imageDigest
-            value:
-              # 3.9.20-bookworm
-              - "sha256:dbb0be5b67aa84b9e3e4f325c7844ab439f40a5cca717c5b24e671cfb41dbb46"
-      taskRef:
-        name: python-tracer-unittest-couchbase-task
-      workspaces:
-        - name: task-pvc
-          workspace: python-tracer-ci-pipeline-pvc
     - name: unittest-gevent-starlette
       runAfter:
         - clone

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -19,24 +19,25 @@ spec:
         - name: task-pvc
           workspace: python-tracer-ci-pipeline-pvc
     - name: unittest-default
+      displayName: "Platforms and Browsers: $(params.platform) and $(params.browser)"
       runAfter:
         - clone
       matrix:
         params:
           - name: imageDigest
             value:
-              # 3.8.20-bookworm
-              - "sha256:f53fd710218c3c5415229037afaf04d0f32acba87dd90d48863fbdab4227ac89"
-              # 3.9.20-bookworm
-              - "sha256:dbb0be5b67aa84b9e3e4f325c7844ab439f40a5cca717c5b24e671cfb41dbb46"
-              # 3.10.15-bookworm
-              - "sha256:b346d9d55e40cd6079db55370581b3bd24067acf5f1acc386107ec0843102ec9"
-              # 3.11.10-bookworm
-              - "sha256:3cd9b520be95c671135ea1318f32be6912876024ee16d0f472669d3878801651"
-              # 3.12.6-bookworm
-              - "sha256:af6fa5c329d6bd6dec52855ccb8bb37c30fb8f00819953a035d49499e43b2c9b"
-              # 3.13.0-bookworm
-              - "sha256:feee4734fdc44cc09a3c9cdb72e05bb8ff7e964f64766bc1a68638b2c667cf35"
+              # public.ecr.aws/docker/library/python:3.8.20-bookworm
+              - "sha256:7aa279fb41dad2962d3c915aa6f6615134baa412ab5aafa9d4384dcaaa0af15d"
+              # public.ecr.aws/docker/library/python:3.9.20-bookworm
+              - "sha256:54b70fa5a9a48299b6c8b47e3c1a0b969271f9769810f1ab17547f1fecdd72cc"
+              # public.ecr.aws/docker/library/python:3.10.15-bookworm
+              - "sha256:2eb72484c25c39aba019b0ab5679c2436833a0b705e955ed8e13c06ee900dd63"
+              # public.ecr.aws/docker/library/python:3.11.10-bookworm
+              - "sha256:15f10b142547000e2429615b3d314474ae7d6ac062a8dd2c9246adcee7068e55"
+              # public.ecr.aws/docker/library/python:3.12.7-bookworm
+              - "sha256:4429a1580a1db32addb5127499a88a8bc6eecb08c7ea19a77b5b69c32f840acd"
+              # public.ecr.aws/docker/library/python:3.13.0-bookworm
+              - "sha256:ecd27b6c43d8d84b0058e7db4aaa06a1bfe970d0fb9bb7cf39f9536850f71510"
       taskRef:
         name: python-tracer-unittest-default-task
       workspaces:
@@ -49,8 +50,8 @@ spec:
         params:
           - name: imageDigest
             value:
-              # 3.9.20-bookworm
-              - "sha256:dbb0be5b67aa84b9e3e4f325c7844ab439f40a5cca717c5b24e671cfb41dbb46"
+              # public.ecr.aws/docker/library/python:3.9.20-bookworm
+              - "sha256:54b70fa5a9a48299b6c8b47e3c1a0b969271f9769810f1ab17547f1fecdd72cc"
       taskRef:
         name: python-tracer-unittest-cassandra-task
       workspaces:
@@ -63,8 +64,8 @@ spec:
         params:
           - name: imageDigest
             value:
-              # 3.9.20-bookworm
-              - "sha256:dbb0be5b67aa84b9e3e4f325c7844ab439f40a5cca717c5b24e671cfb41dbb46"
+              # public.ecr.aws/docker/library/python:3.9.20-bookworm
+              - "sha256:54b70fa5a9a48299b6c8b47e3c1a0b969271f9769810f1ab17547f1fecdd72cc"
       taskRef:
         name: python-tracer-unittest-gevent-starlette-task
       workspaces:
@@ -77,8 +78,8 @@ spec:
         params:
           - name: imageDigest
             value:
-              # 3.12.6-bookworm
-              - "sha256:af6fa5c329d6bd6dec52855ccb8bb37c30fb8f00819953a035d49499e43b2c9b"
+              # public.ecr.aws/docker/library/python:3.12.7-bookworm
+              - "sha256:4429a1580a1db32addb5127499a88a8bc6eecb08c7ea19a77b5b69c32f840acd"
       taskRef:
         name: python-tracer-unittest-aws-task
       workspaces:

--- a/.tekton/python-tracer-prepuller.yaml
+++ b/.tekton/python-tracer-prepuller.yaml
@@ -14,60 +14,60 @@ spec:
       # Configure an init container for each image you want to pull
       initContainers:
         - name: prepuller-git
-          # alpine/git:2.43.0
-          image: alpine/git@sha256:6ff4de047dcc8f0c7d75d2efff63fbc189e87d2f458305f2cc8f165ff83309cf
+          # public.ecr.aws/docker/library/alpine:3.20.3
+          image: public.ecr.aws/docker/library/alpine@sha256:029a752048e32e843bd6defe3841186fb8d19a28dae8ec287f433bb9d6d1ad85
           command: ["sh", "-c", "'true'"]
         - name: prepuller-google-cloud-pubsub
-          # vanmoof/pubsub-emulator:latest
-          image: vanmoof/pubsub-emulator@sha256:ff71206d65589b58a8b6928c35349a58dbfd7f20eb2dc7822e0f32e5c40791c8
+          # quay.io/thekevjames/gcloud-pubsub-emulator:501.0.0
+          image: quay.io/thekevjames/gcloud-pubsub-emulator@sha256:9bad1f28e6a3d6cd5f462c654c736faa4cf49732d9422ddb427ad30f3037c0ff
           command: ["sh", "-c", "'true'"]
         - name: prepuller-cassandra
-          # cassandra:3.11.16-jammy
-          image: cassandra@sha256:7d32a79e9adb4ca8c26f798e4a44ec8438da99c6bda2969410ea46cbdb0b4b94
+          # public.ecr.aws/docker/library/cassandra:3.11.16-jammy
+          image: public.ecr.aws/docker/library/cassandra@sha256:b175d99b80f8108594d00c705288fdb3186b9fc07b30b4c292c3592cddb5f0b5
           command: ["sh", "-c", "'true'"]
         - name: prepuller-rabbitmq
-          # rabbitmq:3.13.0
-          image: rabbitmq@sha256:27819d7be883b8aea04b9a244460181ef97427a98f8323b39402d65e6eb2ce6f
+          # public.ecr.aws/docker/library/rabbitmq:3.13.0
+          image: public.ecr.aws/docker/library/rabbitmq@sha256:39de1a4fc6c72d12bd5dfa23e8576536fd1c0cc8418344cd5a51addfc9a1145d
           command: ["sh", "-c", "'true'"]
         - name: prepuller-redis
-          # redis:7.2.4-bookworm
-          image: redis@sha256:fe98b2d39d462d06a7360e2860dd6ceff930745e3731eccb3c1406dd0dd7f744
+          # public.ecr.aws/docker/library/redis:7.2.4-bookworm
+          image: public.ecr.aws/docker/library/redis@sha256:9341b6548cc35b64a6de0085555264336e2f570e17ecff20190bf62222f2bd64
           command: ["sh", "-c", "'true'"]
         - name: prepuller-mongo
-          # mongo:7.0.6
-          image: mongo@sha256:125bda8abe859bcebc47e4a7e0921508d3bcb47725d261f0a2bcf4ea5c837dd5
+          # public.ecr.aws/docker/library/mongo:7.0.6
+          image: public.ecr.aws/docker/library/mongo@sha256:3a023748ee30e915dd51642f1ef430c73c4e54937060054ca84c70417f510cc5
           command: ["sh", "-c", "'true'"]
         - name: prepuller-mariadb
-          # mariadb:11.3.2
-          image: mariadb@sha256:851f05fe1e4cb290442c1b12b7108436a33fd8f6a733d4989950322d06d45c65
+          # public.ecr.aws/docker/library/mariadb:11.3.2
+          image: public.ecr.aws/docker/library/mariadb@sha256:a4a81ab6d190db84b67f286fd0511cdea619a24b63790b3db4fb69d263a5cd37
           command: ["sh", "-c", "'true'"]
         - name: prepuller-postgres
-          # postgres:16.2-bookworm
-          image: postgres@sha256:3bfb87432e26badf72d727a0c5f5bb7b81438cd9baec5be8531c70a42b07adc6
+          # public.ecr.aws/docker/library/postgres:16.2-bookworm
+          image: public.ecr.aws/docker/library/postgres@sha256:07572430dbcd821f9f978899c3ab3a727f5029be9298a41662e1b5404d5b73e0
           command: ["sh", "-c", "'true'"]
         - name: prepuller-38
-          # 3.8.20-bookworm
-          image: "python@sha256:f53fd710218c3c5415229037afaf04d0f32acba87dd90d48863fbdab4227ac89"
+          # public.ecr.aws/docker/library/python:3.8.20-bookworm
+          image: public.ecr.aws/docker/library/python@
           command: ["sh", "-c", "'true'"]
         - name: prepuller-39
-          # 3.9.20-bookworm
-          image: "python@sha256:dbb0be5b67aa84b9e3e4f325c7844ab439f40a5cca717c5b24e671cfb41dbb46"
+          # public.ecr.aws/docker/library/python:3.9.20-bookworm
+          image: public.ecr.aws/docker/library/python@sha256:54b70fa5a9a48299b6c8b47e3c1a0b969271f9769810f1ab17547f1fecdd72cc
           command: ["sh", "-c", "'true'"]
         - name: prepuller-310
-          # 3.10.15-bookworm
-          image: "python@sha256:b346d9d55e40cd6079db55370581b3bd24067acf5f1acc386107ec0843102ec9"
+          # public.ecr.aws/docker/library/python:3.10.15-bookworm
+          image: public.ecr.aws/docker/library/python@sha256:2eb72484c25c39aba019b0ab5679c2436833a0b705e955ed8e13c06ee900dd63
           command: ["sh", "-c", "'true'"]
         - name: prepuller-311
-          # 3.11.10-bookworm
-          image: "python@sha256:3cd9b520be95c671135ea1318f32be6912876024ee16d0f472669d3878801651"
+          # public.ecr.aws/docker/library/python:3.11.10-bookworm
+          image: public.ecr.aws/docker/library/python@sha256:15f10b142547000e2429615b3d314474ae7d6ac062a8dd2c9246adcee7068e55
           command: ["sh", "-c", "'true'"]
         - name: prepuller-312
-          # 3.12.6-bookworm
-          image: "python@sha256:af6fa5c329d6bd6dec52855ccb8bb37c30fb8f00819953a035d49499e43b2c9b"
+          # public.ecr.aws/docker/library/python:3.12.7-bookworm
+          image: public.ecr.aws/docker/library/python@sha256:4429a1580a1db32addb5127499a88a8bc6eecb08c7ea19a77b5b69c32f840acd
           command: ["sh", "-c", "'true'"]
         - name: prepuller-313
-          # 3.13.0rc2-bookworm
-          image: "python@sha256:3aed70fd4585395e47c6005f0082b966151561f3c4070a3ed9d2fb594bbf44b8"
+          # public.ecr.aws/docker/library/python:3.13.0
+          image: public.ecr.aws/docker/library/python@sha256:ecd27b6c43d8d84b0058e7db4aaa06a1bfe970d0fb9bb7cf39f9536850f71510
           command: ["sh", "-c", "'true'"]
 
       # Use the pause container to ensure the Pod goes into a `Running` phase

--- a/.tekton/python-tracer-prepuller.yaml
+++ b/.tekton/python-tracer-prepuller.yaml
@@ -29,10 +29,6 @@ spec:
           # rabbitmq:3.13.0
           image: rabbitmq@sha256:27819d7be883b8aea04b9a244460181ef97427a98f8323b39402d65e6eb2ce6f
           command: ["sh", "-c", "'true'"]
-        - name: prepuller-couchbase
-          # couchbase/server-sandbox:5.5.1
-          image: couchbase/server-sandbox@sha256:d04302ea7782a0f53c3f371971138b339097d5e41f4154def5bdecc5bbb2e1da
-          command: ["sh", "-c", "'true'"]
         - name: prepuller-redis
           # redis:7.2.4-bookworm
           image: redis@sha256:fe98b2d39d462d06a7360e2860dd6ceff930745e3731eccb3c1406dd0dd7f744

--- a/.tekton/run_unittests.sh
+++ b/.tekton/run_unittests.sh
@@ -23,10 +23,6 @@ cassandra)
   export REQUIREMENTS='requirements-cassandra.txt'
   export TESTS=('tests/clients/test_cassandra-driver.py')
   export CASSANDRA_TEST='true' ;;
-couchbase)
-  export REQUIREMENTS='requirements-couchbase.txt'
-  export TESTS=('tests/clients/test_couchbase.py')
-  export COUCHBASE_TEST='true' ;;
 gevent_starlette)
   export REQUIREMENTS='requirements-gevent-starlette.txt'
   # TODO: uncomment once gevent instrumentation is done
@@ -38,29 +34,18 @@ aws)
   export TESTS=('tests_aws') ;;
 *)
   echo "ERROR \$TEST_CONFIGURATION='${TEST_CONFIGURATION}' is unsupported " \
-       "not in (default|cassandra|couchbase|gevent_starlette)" >&2
+       "not in (default|cassandra|gevent_starlette)" >&2
   exit 3 ;;
 esac
 
 echo -n "Configuration is '${TEST_CONFIGURATION}' on ${PYTHON_VERSION} "
 echo    "with dependencies in '${REQUIREMENTS}'"
 ls -lah .
-if [[ -n "${COUCHBASE_TEST}" ]]; then
-  echo "Install Couchbase Dependencies"
-  # Even if we use bookworm for running this, we need to add the bionic repo
-  # See: https://forums.couchbase.com/
-  # t/installing-libcouchbase-dev-on-ubuntu-20-focal-fossa/25955/3
-  wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | apt-key add -
-  echo "deb http://packages.couchbase.com/ubuntu bionic bionic/main" \
-       > /etc/apt/sources.list.d/couchbase.list
-  apt update
-  apt install libcouchbase-dev -y
-fi
 
 python -m venv /tmp/venv
 # shellcheck disable=SC1091
 source /tmp/venv/bin/activate
-pip install --upgrade pip "$([[ -n ${COUCHBASE_TEST} ]] && echo wheel || echo pip)"
+pip install --upgrade pip
 pip install -e .
 pip install -r "tests/${REQUIREMENTS}"
 

--- a/.tekton/scheduled-eventlistener.yaml
+++ b/.tekton/scheduled-eventlistener.yaml
@@ -61,12 +61,12 @@ spec:
         spec:
           containers:
           - name: git
-            # alpine/git:2.43.0
-            image: alpine/git@sha256:6ff4de047dcc8f0c7d75d2efff63fbc189e87d2f458305f2cc8f165ff83309cf
-            command:
-            - sh
-            - -c
-            - |
+            # public.ecr.aws/docker/library/alpine:3.20.3
+            image: public.ecr.aws/docker/library/alpine@sha256:029a752048e32e843bd6defe3841186fb8d19a28dae8ec287f433bb9d6d1ad85
+            script: |
+              #!/bin/sh
+              echo "Installing git"
+              apk fix && apk --no-cache --update add git gpg less openssh patch
               wget -O- \
                    --header 'Content-Type: application/json' \
                    --post-data '{

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -60,40 +60,6 @@ spec:
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: python-tracer-unittest-couchbase-task
-spec:
-  sidecars:
-    - name: couchbase
-      # couchbase/server-sandbox:5.5.1
-      image: couchbase/server-sandbox@sha256:d04302ea7782a0f53c3f371971138b339097d5e41f4154def5bdecc5bbb2e1da
-      readinessProbe:
-        httpGet:
-          path: /ui/index.html
-          port: 8091
-        # This Couchbase image recommends 60sec waiting for initial configuration
-        # Starting the tests too soon may result in
-        # "Error during initial configuration - aborting container"
-        # apparently because "vbucket map not available yet"
-        initialDelaySeconds: 60
-  params:
-  - name: imageDigest
-    type: string
-  workspaces:
-    - name: task-pvc
-      mountPath: /workspace
-  steps:
-    - name: unittest
-      image: python@$(params.imageDigest)
-      env:
-        - name: TEST_CONFIGURATION
-          value: couchbase
-      workingDir: /workspace/python-sensor/
-      command:
-      - /workspace/python-sensor/.tekton/run_unittests.sh
----
-apiVersion: tekton.dev/v1
-kind: Task
-metadata:
   name: python-tracer-unittest-gevent-starlette-task
 spec:
   params:

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -12,10 +12,12 @@ spec:
       mountPath: /workspace
   steps:
     - name: clone
-      # alpine/git:2.43.0
-      image: alpine/git@sha256:6ff4de047dcc8f0c7d75d2efff63fbc189e87d2f458305f2cc8f165ff83309cf
+      # public.ecr.aws/docker/library/alpine:3.20.3
+      image: public.ecr.aws/docker/library/alpine@sha256:029a752048e32e843bd6defe3841186fb8d19a28dae8ec287f433bb9d6d1ad85
       script: |
         #!/bin/sh
+        echo "Installing git"
+        apk fix && apk --no-cache --update add git gpg less openssh patch
         echo "Cloning repo"
         cd /workspace && git clone --depth 1 -b $(params.revision) https://github.com/instana/python-sensor
         ls -lah /workspace
@@ -27,8 +29,8 @@ metadata:
 spec:
   sidecars:
     - name: cassandra
-      # cassandra:3.11.16-jammy
-      image: cassandra@sha256:7d32a79e9adb4ca8c26f798e4a44ec8438da99c6bda2969410ea46cbdb0b4b94
+      # public.ecr.aws/docker/library/cassandra:3.11.16-jammy
+      image: public.ecr.aws/docker/library/cassandra@sha256:b175d99b80f8108594d00c705288fdb3186b9fc07b30b4c292c3592cddb5f0b5
       env:
         - name: MAX_HEAP_SIZE
           value: 2048m
@@ -49,7 +51,7 @@ spec:
       mountPath: /workspace
   steps:
     - name: unittest
-      image: python@$(params.imageDigest)
+      image: public.ecr.aws/docker/library/python@$(params.imageDigest)
       env:
         - name: TEST_CONFIGURATION
           value: cassandra
@@ -70,7 +72,7 @@ spec:
       mountPath: /workspace
   steps:
     - name: unittest
-      image: python@$(params.imageDigest)
+      image: public.ecr.aws/docker/library/python@$(params.imageDigest)
       env:
         - name: TEST_CONFIGURATION
           value: gevent_starlette
@@ -85,28 +87,30 @@ metadata:
 spec:
   sidecars:
     - name: google-cloud-pubsub
-      # vanmoof/pubsub-emulator:latest
-      image: vanmoof/pubsub-emulator@sha256:ff71206d65589b58a8b6928c35349a58dbfd7f20eb2dc7822e0f32e5c40791c8
+      # quay.io/thekevjames/gcloud-pubsub-emulator
+      image: quay.io/thekevjames/gcloud-pubsub-emulator@sha256:9bad1f28e6a3d6cd5f462c654c736faa4cf49732d9422ddb427ad30f3037c0ff
       env:
         - name: PUBSUB_EMULATOR_HOST
-          value: 0.0.0.0:8085
+          value: 0.0.0.0:8681
+        - name: PUBSUB_PROJECT1
+          value: test-project,test-topic
       ports:
-        - containerPort: 8085
-          hostPort: 8085
+        - containerPort: 8681
+          hostPort: 8681
     - name: mariadb
-      # mariadb:11.3.2
-      image: mariadb@sha256:851f05fe1e4cb290442c1b12b7108436a33fd8f6a733d4989950322d06d45c65
+      # public.ecr.aws/docker/library/mariadb:11.3.2
+      image: public.ecr.aws/docker/library/mariadb@sha256:a4a81ab6d190db84b67f286fd0511cdea619a24b63790b3db4fb69d263a5cd37
       env:
         - name: MYSQL_ROOT_PASSWORD # or MARIADB_ROOT_PASSWORD
           value: passw0rd
         - name: MYSQL_DATABASE # or MARIADB_DATABASE
           value: instana_test_db
     - name: mongo
-      # mongo:7.0.6
-      image: mongo@sha256:125bda8abe859bcebc47e4a7e0921508d3bcb47725d261f0a2bcf4ea5c837dd5
+      # public.ecr.aws/docker/library/mongo:7.0.6
+      image: public.ecr.aws/docker/library/mongo@sha256:3a023748ee30e915dd51642f1ef430c73c4e54937060054ca84c70417f510cc5
     - name: postgres
-      # postgres:16.2-bookworm
-      image: postgres@sha256:3bfb87432e26badf72d727a0c5f5bb7b81438cd9baec5be8531c70a42b07adc6
+      # public.ecr.aws/docker/library/postgres:16.2-bookworm
+      image: public.ecr.aws/docker/library/postgres@sha256:07572430dbcd821f9f978899c3ab3a727f5029be9298a41662e1b5404d5b73e0
       env:
         - name: POSTGRES_USER
           value: root
@@ -122,11 +126,11 @@ spec:
           - pg_isready --host 127.0.0.1 --port 5432 --dbname=${POSTGRES_DB}
         timeoutSeconds: 10
     - name: redis
-      # redis:7.2.4-bookworm
-      image: redis@sha256:fe98b2d39d462d06a7360e2860dd6ceff930745e3731eccb3c1406dd0dd7f744
+      # public.ecr.aws/docker/library/redis:7.2.4-bookworm
+      image: public.ecr.aws/docker/library/redis@sha256:9341b6548cc35b64a6de0085555264336e2f570e17ecff20190bf62222f2bd64
     - name: rabbitmq
-      # rabbitmq:3.13.0
-      image: rabbitmq@sha256:27819d7be883b8aea04b9a244460181ef97427a98f8323b39402d65e6eb2ce6f
+      # public.ecr.aws/docker/library/rabbitmq:3.13.0
+      image: public.ecr.aws/docker/library/rabbitmq@sha256:39de1a4fc6c72d12bd5dfa23e8576536fd1c0cc8418344cd5a51addfc9a1145d
   params:
   - name: imageDigest
     type: string
@@ -135,7 +139,7 @@ spec:
       mountPath: /workspace
   steps:
     - name: unittest
-      image: python@$(params.imageDigest)
+      image: public.ecr.aws/docker/library/python@$(params.imageDigest)
       env:
         - name: TEST_CONFIGURATION
           value: default
@@ -156,7 +160,7 @@ spec:
       mountPath: /workspace
   steps:
     - name: unittest
-      image: python@$(params.imageDigest)
+      image: public.ecr.aws/docker/library/python@$(params.imageDigest)
       env:
         - name: TEST_CONFIGURATION
           value: aws

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
 # Development Container
-FROM python:3.8.5
+FROM public.ecr.aws/docker/library/python:3.12-slim-bookworm
 
-RUN apt update -q
-RUN apt install -qy vim 
+RUN apt-get -y -qq update && \
+    apt-get -y -qq upgrade && \
+    apt-get -y -qq install --no-install-recommends git && \
+    apt-get -y -qq clean
 
-WORKDIR /python-sensor
-
-ENV INSTANA_DEBUG=true
-ENV PYTHONPATH=/python-sensor
-ENV AUTOWRAPT_BOOTSTRAP=instana
-
+WORKDIR /python-tracer
 COPY . ./
 
-RUN pip install -e .
+RUN pip install --upgrade pip && \
+    pip install -e .
+
+ENV INSTANA_DEBUG=true
+ENV PYTHONPATH=/python-tracer
+ENV AUTOWRAPT_BOOTSTRAP=instana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   redis:
-    image: docker.io/library/redis
+    image: public.ecr.aws/docker/library/redis
     volumes:
       - ./tests/conf/redis.conf:/usr/local/etc/redis/redis.conf:Z
     command: redis-server /usr/local/etc/redis/redis.conf
@@ -9,19 +9,19 @@ services:
       - "0.0.0.0:6379:6379"
 
   cassandra:
-    image: docker.io/library/cassandra
+    image: public.ecr.aws/docker/library/cassandra
     ports:
       - 9042:9042
 
 
   couchbase:
-    image: docker.io/library/couchbase
+    image: public.ecr.aws/docker/library/couchbase:community
     ports:
       - 8091-8094:8091-8094
       - 11210:11210
 
   mariadb:
-    image: docker.io/library/mariadb
+    image: public.ecr.aws/docker/library/mariadb
     ports:
       - 3306:3306
     environment:
@@ -33,12 +33,12 @@ services:
       - ./tests/config/database/mysql/conf.d/mysql.cnf:/etc/mysql/conf.d/mysql.cnf:Z
 
   mongodb:
-    image: docker.io/library/mongo
+    image: public.ecr.aws/docker/library/mongo
     ports:
       - '27017:27017'
 
   postgres:
-    image: docker.io/library/postgres
+    image: public.ecr.aws/docker/library/postgres
     ports:
       - 5432:5432
     environment:
@@ -47,7 +47,7 @@ services:
       POSTGRES_DB: instana_test_db
 
   rabbitmq:
-    image: docker.io/library/rabbitmq
+    image: public.ecr.aws/docker/library/rabbitmq
     environment:
       - RABBITMQ_NODENAME=rabbit@localhost
     ports:
@@ -55,8 +55,10 @@ services:
       - 5672:5672
 
   pubsub:
-    image: docker.io/vanmoof/pubsub-emulator
+    image: quay.io/thekevjames/gcloud-pubsub-emulator:latest
     environment:
-      - PUBSUB_EMULATOR_HOST=0.0.0.0:8085
+      - PUBSUB_EMULATOR_HOST=0.0.0.0:8681
+      - PUBSUB_PROJECT1=test-project,test-topic
     ports:
-      - "8085:8085"
+      - "8681:8681"
+      - "8682:8682"

--- a/tests/clients/test_google-cloud-pubsub.py
+++ b/tests/clients/test_google-cloud-pubsub.py
@@ -18,7 +18,7 @@ from instana.span.span import get_current_span
 from tests.test_utils import _TraceContextMixin
 
 # Use PubSub Emulator exposed at :8085
-os.environ["PUBSUB_EMULATOR_HOST"] = "localhost:8085"
+os.environ["PUBSUB_EMULATOR_HOST"] = "localhost:8681"
 
 
 class TestPubSubPublish(_TraceContextMixin):


### PR DESCRIPTION
This PR:
1. Remove the Couchbase tests from the CI pipeline and 
2. Change the development files and CI configuration to stop pulling container images from the Docker Hub.