### PR TITLE
ci: Add new pipeline to test Python 3.14.0a2.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,6 +273,34 @@ jobs:
       - store-pytest-results
       - store-coverage-report
 
+  python314:
+    docker:
+      - image: public.ecr.aws/docker/library/python:3.14.0a2
+      - image: public.ecr.aws/docker/library/postgres:16.2-bookworm
+        environment:
+          POSTGRES_USER: root
+          POSTGRES_PASSWORD: passw0rd
+          POSTGRES_DB: instana_test_db
+      - image: public.ecr.aws/docker/library/mariadb:11.3.2
+        environment:
+          MYSQL_ROOT_PASSWORD: passw0rd
+          MYSQL_DATABASE: instana_test_db
+      - image: public.ecr.aws/docker/library/redis:7.2.4-bookworm
+      - image: public.ecr.aws/docker/library/rabbitmq:3.13.0
+      - image: public.ecr.aws/docker/library/mongo:7.0.6
+      - image: quay.io/thekevjames/gcloud-pubsub-emulator:latest
+        environment:
+          PUBSUB_EMULATOR_HOST: 0.0.0.0:8681
+          PUBSUB_PROJECT1: test-project,test-topic
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - pip-install-deps:
+          requirements: "tests/requirements-pre314.txt"
+      - run-tests-with-coverage-report
+      - store-pytest-results
+      - store-coverage-report
+
   py39cassandra:
     docker:
       - image: public.ecr.aws/docker/library/python:3.9
@@ -328,6 +356,7 @@ workflows:
       - python311
       - python312
       - python313
+      - python314
       - py39cassandra
       - py39gevent_starlette
       - py312aws
@@ -339,6 +368,8 @@ workflows:
             - python311
             - python312
             - python313
+            # Uncomment the following when giving real support to 3.14
+            # - python314
             - py39cassandra
             - py39gevent_starlette
             - py312aws

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -38,6 +38,8 @@ spec:
               - "sha256:4429a1580a1db32addb5127499a88a8bc6eecb08c7ea19a77b5b69c32f840acd"
               # public.ecr.aws/docker/library/python:3.13.0-bookworm
               - "sha256:ecd27b6c43d8d84b0058e7db4aaa06a1bfe970d0fb9bb7cf39f9536850f71510"
+              # public.ecr.aws/docker/library/python:3.14.0a2-bookworm
+              - "sha256:67eabdadd211c2768dbe0b4f311b27f889b755a6cb93392f41c8773c15affd67"
       taskRef:
         name: python-tracer-unittest-default-task
       workspaces:

--- a/.tekton/python-tracer-prepuller.yaml
+++ b/.tekton/python-tracer-prepuller.yaml
@@ -66,8 +66,12 @@ spec:
           image: public.ecr.aws/docker/library/python@sha256:4429a1580a1db32addb5127499a88a8bc6eecb08c7ea19a77b5b69c32f840acd
           command: ["sh", "-c", "'true'"]
         - name: prepuller-313
-          # public.ecr.aws/docker/library/python:3.13.0
+          # public.ecr.aws/docker/library/python:3.13.0-bookworm
           image: public.ecr.aws/docker/library/python@sha256:ecd27b6c43d8d84b0058e7db4aaa06a1bfe970d0fb9bb7cf39f9536850f71510
+          command: ["sh", "-c", "'true'"]
+        - name: prepuller-314
+          # public.ecr.aws/docker/library/python:3.14.0a2-bookworm
+          image: public.ecr.aws/docker/library/python@sha256:67eabdadd211c2768dbe0b4f311b27f889b755a6cb93392f41c8773c15affd67
           command: ["sh", "-c", "'true'"]
 
       # Use the pause container to ensure the Pod goes into a `Running` phase

--- a/.tekton/run_unittests.sh
+++ b/.tekton/run_unittests.sh
@@ -17,7 +17,7 @@ PYTHON_MINOR_VERSION="$(echo "${PYTHON_VERSION}" | cut -d'.' -f 2)"
 
 case "${TEST_CONFIGURATION}" in
 default)
-  export REQUIREMENTS='requirements.txt'
+  [ "${PYTHON_MINOR_VERSION}" -eq "14" ] && export REQUIREMENTS='requirements-pre314.txt' || export REQUIREMENTS='requirements.txt'
   export TESTS=('tests') ;;
 cassandra)
   export REQUIREMENTS='requirements-cassandra.txt'
@@ -34,7 +34,7 @@ aws)
   export TESTS=('tests_aws') ;;
 *)
   echo "ERROR \$TEST_CONFIGURATION='${TEST_CONFIGURATION}' is unsupported " \
-       "not in (default|cassandra|gevent_starlette)" >&2
+       "not in (default|cassandra|gevent_starlette|aws)" >&2
   exit 3 ;;
 esac
 

--- a/src/instana/instrumentation/logging.py
+++ b/src/instana/instrumentation/logging.py
@@ -26,7 +26,7 @@ def log_with_instana(
     # We take into consideration if `stacklevel` is already present in `kwargs`.
     # This prevents the error `_log() got multiple values for keyword argument 'stacklevel'`
     stacklevel_in = kwargs.pop("stacklevel", 1)
-    stacklevel = stacklevel_in + 1
+    stacklevel = stacklevel_in + 1 + (sys.version_info >= (3, 14))
 
     try:
         # Only needed if we're tracing and serious log

--- a/tests/clients/test_google-cloud-storage.py
+++ b/tests/clients/test_google-cloud-storage.py
@@ -1,6 +1,7 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2020
 
+import sys
 from typing import Generator
 import json
 import pytest
@@ -538,6 +539,10 @@ class TestGoogleCloudStorage(_TraceContextMixin):
         assert gcs_span.data["gcs"]["bucket"] == "test bucket"
         assert gcs_span.data["gcs"]["object"] == "test object"
 
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 14),
+        reason='Avoiding "Fatal Python error: Segmentation fault"',
+    )
     @patch("requests.Session.request")
     def test_objects_get(self, mock_requests: Mock) -> None:
         mock_requests.return_value = self._mock_response(
@@ -1077,6 +1082,10 @@ class TestGoogleCloudStorage(_TraceContextMixin):
             response = client.list_buckets()
             assert isinstance(response.client, storage.Client)
 
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 14),
+        reason='Avoiding "Fatal Python error: Segmentation fault"',
+    )
     @patch("requests.Session.request")
     def test_download_with_instana_tracing_is_off(self, mock_requests: Mock) -> None:
         mock_requests.return_value = self._mock_response(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,13 @@ if sys.version_info >= (3, 13):
     collect_ignore_glob.append("*test_sanic*")
 
 
+if sys.version_info >= (3, 14):
+    # Currently not installable dependencies because of 3.14 incompatibilities
+    collect_ignore_glob.append("*test_fastapi*")
+    # aiohttp-server tests failing due to deprecated methods used
+    collect_ignore_glob.append("*test_aiohttp_server*")
+
+
 @pytest.fixture(scope="session")
 def celery_config():
     return {

--- a/tests/requirements-pre314.txt
+++ b/tests/requirements-pre314.txt
@@ -1,0 +1,42 @@
+aiofiles>=0.5.0
+aiohttp>=3.8.3
+boto3>=1.17.74
+bottle>=0.12.25
+celery>=5.2.7
+coverage>=5.5
+Django>=4.2.16
+# FastAPI depends on pydantic-core which requires rust to be installed and
+# it's not compiling due to python_version restrictions.
+# fastapi>=0.115.0; python_version >= "3.13"
+flask>=2.3.2
+# gevent is taking more than 20min to build on 3.14
+# gevent>=1.4.0
+grpcio>=1.14.1
+google-cloud-pubsub>=2.0.0
+google-cloud-storage>=1.24.0
+legacy-cgi>=2.6.1
+lxml>=4.9.2
+mock>=4.0.3
+moto>=4.1.2
+mysqlclient>=2.0.3
+PyMySQL[rsa]>=1.0.2
+psycopg2-binary>=2.8.6
+pika>=1.2.0
+pymongo>=3.11.4
+pyramid>=2.0.1
+pytest>=6.2.4
+pytest-mock>=3.12.0
+pytz>=2024.1
+redis>=3.5.3
+requests-mock
+responses<=0.17.0
+# Sanic is not installable on 3.13 because `httptools, uvloop` dependencies fail to compile:
+# `too few arguments to function ‘_PyLong_AsByteArray’`
+sanic>=19.9.0; python_version < "3.13"
+sanic-testing>=24.6.0; python_version < "3.13"
+starlette>=0.38.2
+sqlalchemy>=2.0.0
+tornado>=6.4.1
+uvicorn>=0.13.4
+urllib3>=1.26.5
+httpx>=0.27.0


### PR DESCRIPTION
Add the new alpha2 test build for Python 3.14.0 after being announced [here](https://www.python.org/downloads/release/python-3140a2/).