### PR TITLE
fix(sanic): remove 3.8 support for latest versions

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -30,7 +30,8 @@ requests-mock
 responses<=0.17.0
 # Sanic is not installable on 3.13 because `httptools, uvloop` dependencies fail to compile:
 # `too few arguments to function ‘_PyLong_AsByteArray’`
-sanic>=19.9.0; python_version < "3.13"
+sanic<=24.6.0; python_version < "3.9"
+sanic>=19.9.0; python_version >= "3.9" and python_version < "3.13"
 sanic-testing>=24.6.0; python_version < "3.13"
 starlette>=0.38.2; python_version == "3.13"
 sqlalchemy>=2.0.0


### PR DESCRIPTION
This change fixes [this](https://app.circleci.com/pipelines/github/instana/python-sensor/3602/workflows/b7416b9b-07d5-4b6e-831d-611ef8ec96d9/jobs/26300/parallel-runs/0/steps/0-103) CI error for `python38` job.
Reference: https://github.com/sanic-org/sanic/pull/3020