### PR TITLE
ci: Automate package release and publish.

### DIFF
--- a/.github/workflows/pkg_release.yml
+++ b/.github/workflows/pkg_release.yml
@@ -1,0 +1,82 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Release new version
+
+on:
+  push:
+    tags:
+      - v3.*
+
+jobs:
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref_name, 'v0') }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "pyproject.toml"
+      - name: Install pip/build
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install build --user
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions-${{ github.ref_name }}
+          path: dist/
+
+  github-release:
+    name: Release on GitHub
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+    needs: 
+      - build
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions-${{ github.ref_name }}
+          path: dist/
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          '${{ github.ref_name }}'
+          dist/**
+          --repo '${{ github.repository }}'
+          --title '${{ github.ref_name }}'
+          --generate-notes
+          --latest
+          --verify-tag
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/instana/
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions-${{ github.ref_name }}
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This commit adds automation to release and publish into GitHub and PyPI.org any new package version based on the creation of a new tag.