### PR TITLE
[FUP Optimisation] redis: added endpoint filtering

### DIFF
--- a/src/instana/agent/host.py
+++ b/src/instana/agent/host.py
@@ -6,25 +6,30 @@ The in-process Instana agent (for host based processes) that manages
 monitoring state and reporting that data.
 """
 
-import os
 import json
+import os
 from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
+from requests import Response
 
-import urllib3
 import requests
+import urllib3
 
-from ..log import logger
-from .base import BaseAgent
-from ..fsm import TheMachine
-from ..version import VERSION
-from ..options import StandardOptions
-from ..collector.host import HostCollector
-from ..util import to_json
-from ..util.runtime import get_py_source
+from instana.agent.base import BaseAgent
+from instana.collector.host import HostCollector
+from instana.configurator import config
+from instana.fsm import Discovery, TheMachine
+from instana.log import logger
+from instana.options import StandardOptions
+from instana.util import to_json
+from instana.util.config import parse_ignored_endpoints
+from instana.util.runtime import get_py_source
+from instana.version import VERSION
 
 
 class AnnounceData(object):
-    """ The Announce Payload """
+    """The Announce Payload"""
+
     pid = 0
     agentUuid = ""
 
@@ -38,10 +43,11 @@ class HostAgent(BaseAgent):
     parts it handles are the announce state and the collection and reporting of metrics and spans to the
     Instana Host agent.
     """
+
     AGENT_DISCOVERY_PATH = "com.instana.plugin.python.discovery"
     AGENT_DATA_PATH = "com.instana.plugin.python.%d"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(HostAgent, self).__init__()
 
         self.announce_data = None
@@ -54,12 +60,14 @@ class HostAgent(BaseAgent):
         # Update log level from what Options detected
         self.update_log_level()
 
-        logger.info("Stan is on the scene.  Starting Instana instrumentation version: %s", VERSION)
+        logger.info(
+            f"Stan is on the scene.  Starting Instana instrumentation version: {VERSION}"
+        )
 
         self.collector = HostCollector(self)
         self.machine = TheMachine(self)
 
-    def start(self):
+    def start(self) -> None:
         """
         Starts the agent and required threads
 
@@ -68,14 +76,14 @@ class HostAgent(BaseAgent):
         logger.debug("Starting Host Collector")
         self.collector.start()
 
-    def handle_fork(self):
+    def handle_fork(self) -> None:
         """
         Forks happen.  Here we handle them.
         """
         # Reset the Agent
         self.reset()
 
-    def reset(self):
+    def reset(self) -> None:
         """
         This will reset the agent to a fresh unannounced state.
         :return: None
@@ -87,7 +95,7 @@ class HostAgent(BaseAgent):
         # Will schedule a restart of the announce cycle in the future
         self.machine.reset()
 
-    def is_timed_out(self):
+    def is_timed_out(self) -> bool:
         """
         If we haven't heard from the Instana host agent in 60 seconds, this
         method will return True.
@@ -99,7 +107,7 @@ class HostAgent(BaseAgent):
                 return True
         return False
 
-    def can_send(self):
+    def can_send(self) -> bool:
         """
         Are we in a state where we can send data?
         @return: Boolean
@@ -117,73 +125,103 @@ class HostAgent(BaseAgent):
 
         return False
 
-    def set_from(self, res_data):
+    def set_from(
+        self,
+        res_data: Dict[str, Any],
+    ) -> None:
         """
         Sets the source identifiers given to use by the Instana Host agent.
         @param res_data: source identifiers provided as announce response
         @return: None
         """
         if "secrets" in res_data:
-            self.options.secrets_matcher = res_data['secrets']['matcher']
-            self.options.secrets_list = res_data['secrets']['list']
+            self.options.secrets_matcher = res_data["secrets"]["matcher"]
+            self.options.secrets_list = res_data["secrets"]["list"]
 
         if "extraHeaders" in res_data:
             if self.options.extra_http_headers is None:
-                self.options.extra_http_headers = res_data['extraHeaders']
+                self.options.extra_http_headers = res_data["extraHeaders"]
             else:
-                self.options.extra_http_headers.extend(res_data['extraHeaders'])
-            logger.info("Will also capture these custom headers: %s", self.options.extra_http_headers)
+                self.options.extra_http_headers.extend(res_data["extraHeaders"])
+            logger.info(
+                f"Will also capture these custom headers: {self.options.extra_http_headers}"
+            )
 
-        self.announce_data = AnnounceData(pid=res_data['pid'], agentUuid=res_data['agentUuid'])
+        if "tracing" in res_data:
+            if (
+                "ignore-endpoints" in res_data["tracing"]
+                and "INSTANA_IGNORE_ENDPOINTS" not in os.environ
+                and "tracing" not in config
+            ):
+                self.options.ignore_endpoints = parse_ignored_endpoints(
+                    res_data["tracing"]["ignore-endpoints"]
+                )
 
-    def get_from_structure(self):
+        self.announce_data = AnnounceData(
+            pid=res_data["pid"],
+            agentUuid=res_data["agentUuid"],
+        )
+
+    def get_from_structure(self) -> Dict[str, str]:
         """
         Retrieves the From data that is reported alongside monitoring data.
         @return: dict()
         """
-        return {'e': self.announce_data.pid, 'h': self.announce_data.agentUuid}
+        return {"e": self.announce_data.pid, "h": self.announce_data.agentUuid}
 
-    def is_agent_listening(self, host, port):
+    def is_agent_listening(
+        self,
+        host: str,
+        port: Union[str, int],
+    ) -> bool:
         """
         Check if the Instana Agent is listening on <host> and <port>.
         @return: Boolean
         """
         result = False
         try:
-            url = "http://%s:%s/" % (host, port)
+            url = f"http://{host}:{port}/"
             response = self.client.get(url, timeout=5)
 
             if 200 <= response.status_code < 300:
-                logger.debug("Instana host agent found on %s:%d", host, port)
+                logger.debug(f"Instana host agent found on {host}:{port}")
                 result = True
             else:
-                logger.debug("The attempt to connect to the Instana host "\
-                             "agent on %s:%d has failed with an unexpected " \
-                             "status code. Expected HTTP 200 but received: %d",
-                             host, port, response.status_code)
+                logger.debug(
+                    "The attempt to connect to the Instana host "
+                    f"agent on {host}:{port} has failed with an unexpected "
+                    f"status code. Expected HTTP 200 but received: {response.status_code}"
+                )
         except Exception:
-            logger.debug("Instana Host Agent not found on %s:%d", host, port)
+            logger.debug(f"Instana Host Agent not found on {host}:{port}")
         return result
 
-    def announce(self, discovery):
+    def announce(
+        self,
+        discovery: Discovery,
+    ) -> Optional[Dict[str, Any]]:
         """
         With the passed in Discovery class, attempt to announce to the host agent.
         """
         try:
             url = self.__discovery_url()
-            response = self.client.put(url,
-                                       data=to_json(discovery),
-                                       headers={"Content-Type": "application/json"},
-                                       timeout=0.8)
+            response = self.client.put(
+                url,
+                data=to_json(discovery),
+                headers={"Content-Type": "application/json"},
+                timeout=0.8,
+            )
         except Exception as exc:
-            logger.debug("announce: connection error (%s)", type(exc))
+            logger.debug(f"announce: connection error ({type(exc)})")
             return None
 
         if 200 <= response.status_code <= 204:
             self.last_seen = datetime.now()
 
         if response.status_code != 200:
-            logger.debug("announce: response status code (%s) is NOT 200", response.status_code)
+            logger.debug(
+                f"announce: response status code ({response.status_code}) is NOT 200"
+            )
             return None
 
         if isinstance(response.content, bytes):
@@ -193,25 +231,28 @@ class HostAgent(BaseAgent):
 
         try:
             payload = json.loads(raw_json)
-        except json.JSONDecodeError as e:
-            logger.debug("announce: response is not JSON: (%s)", raw_json)
+        except json.JSONDecodeError:
+            logger.debug(f"announce: response is not JSON: ({raw_json})")
             return None
 
-        if not hasattr(payload, 'get'):
-            logger.debug("announce: response payload has no fields: (%s)", payload)
+        if not hasattr(payload, "get"):
+            logger.debug(f"announce: response payload has no fields: ({payload})")
             return None
 
-        if not payload.get('pid'):
-            logger.debug("announce: response payload has no pid: (%s)", payload)
+        if not payload.get("pid"):
+            logger.debug(f"announce: response payload has no pid: ({payload})")
             return None
 
-        if not payload.get('agentUuid'):
-            logger.debug("announce: response payload has no agentUuid: (%s)", payload)
+        if not payload.get("agentUuid"):
+            logger.debug(f"announce: response payload has no agentUuid: ({payload})")
             return None
 
         return payload
 
-    def log_message_to_host_agent(self, message):
+    def log_message_to_host_agent(
+        self,
+        message: str,
+    ) -> Optional[Response]:
         """
         Log a message to the discovered host agent
         """
@@ -221,18 +262,19 @@ class HostAgent(BaseAgent):
             payload["m"] = message
 
             url = self.__agent_logger_url()
-            response = self.client.post(url,
-                                       data=to_json(payload),
-                                       headers={"Content-Type": "application/json",
-                                                "X-Log-Level": "INFO"},
-                                       timeout=0.8)
+            response = self.client.post(
+                url,
+                data=to_json(payload),
+                headers={"Content-Type": "application/json", "X-Log-Level": "INFO"},
+                timeout=0.8,
+            )
 
             if 200 <= response.status_code <= 204:
                 self.last_seen = datetime.now()
         except Exception as exc:
-            logger.debug("agent logging: connection error (%s)", type(exc))
+            logger.debug(f"agent logging: connection error ({type(exc)})")
 
-    def is_agent_ready(self):
+    def is_agent_ready(self) -> bool:
         """
         Used after making a successful announce to test when the agent is ready to accept data.
         """
@@ -243,47 +285,32 @@ class HostAgent(BaseAgent):
             if response.status_code == 200:
                 ready = True
         except Exception as exc:
-            logger.debug("is_agent_ready: connection error (%s)", type(exc))
+            logger.debug(f"is_agent_ready: connection error ({type(exc)})")
         return ready
 
-    def report_data_payload(self, payload):
+    def report_data_payload(
+        self,
+        payload: Dict[str, Any],
+    ) -> Optional[Response]:
         """
         Used to report collection payload to the host agent.  This can be metrics, spans and snapshot data.
         """
         response = None
         try:
             # Report spans (if any)
-            span_count = len(payload['spans'])
-            if span_count > 0:
-                logger.debug("Reporting %d spans", span_count)
-                response = self.client.post(self.__traces_url(),
-                                            data=to_json(payload['spans']),
-                                            headers={"Content-Type": "application/json"},
-                                            timeout=0.8)
+            response = self.report_spans(payload)
 
             if response is not None and 200 <= response.status_code <= 204:
                 self.last_seen = datetime.now()
 
             # Report profiles (if any)
-            profile_count = len(payload['profiles'])
-            if profile_count > 0:
-                logger.debug("Reporting %d profiles", profile_count)
-                response = self.client.post(self.__profiles_url(),
-                                            data=to_json(payload['profiles']),
-                                            headers={"Content-Type": "application/json"},
-                                            timeout=0.8)
+            response = self.report_profiles(payload)
 
             if response is not None and 200 <= response.status_code <= 204:
                 self.last_seen = datetime.now()
 
             # Report metrics
-            metric_count = len(payload['metrics'])
-            if metric_count > 0:
-                metric_bundle = payload["metrics"]["plugins"][0]["data"]
-                response = self.client.post(self.__data_url(),
-                                            data=to_json(metric_bundle),
-                                            headers={"Content-Type": "application/json"},
-                                            timeout=0.8)
+            response = self.report_metrics(payload)
 
             if response is not None and 200 <= response.status_code <= 204:
                 self.last_seen = datetime.now()
@@ -297,73 +324,147 @@ class HostAgent(BaseAgent):
         except urllib3.exceptions.MaxRetryError:
             pass
         except Exception as exc:
-            logger.debug("report_data_payload: Instana host agent connection error (%s)", type(exc), exc_info=True)
+            logger.debug(
+                f"report_data_payload: Instana host agent connection error ({type(exc)})",
+                exc_info=True,
+            )
         return response
 
-    def handle_agent_tasks(self, task):
+    def report_metrics(self, payload: Dict[str, Any]) -> Optional[Response]:
+        metrics = payload.get("metrics", [])
+        if len(metrics) > 0:
+            metric_bundle = metrics["plugins"][0]["data"]
+            response = self.client.post(
+                self.__data_url(),
+                data=to_json(metric_bundle),
+                headers={"Content-Type": "application/json"},
+                timeout=0.8,
+            )
+            return response
+        return
+
+    def report_profiles(self, payload: Dict[str, Any]) -> Optional[Response]:
+        profiles = payload.get("profiles", [])
+        if len(profiles) > 0:
+            logger.debug(f"Reporting {len(profiles)} profiles")
+            response = self.client.post(
+                self.__profiles_url(),
+                data=to_json(profiles),
+                headers={"Content-Type": "application/json"},
+                timeout=0.8,
+            )
+            return response
+        return
+
+    def report_spans(self, payload: Dict[str, Any]) -> Optional[Response]:
+        filtered_spans = self.filter_spans(payload.get("spans", []))
+        if len(filtered_spans) > 0:
+            logger.debug(f"Reporting {len(filtered_spans)} spans")
+            response = self.client.post(
+                self.__traces_url(),
+                data=to_json(filtered_spans),
+                headers={"Content-Type": "application/json"},
+                timeout=0.8,
+            )
+            return response
+        return
+
+    def filter_spans(self, spans: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        from instana.util.traceutils import is_service_or_endpoint_ignored
+
+        filtered_spans = []
+        for span in spans:
+            if (hasattr(span, "n") or hasattr(span, "name")) and hasattr(span, "data"):
+                service = span.n
+                endpoint = span.data[service]["command"]
+                if isinstance(endpoint, str) and is_service_or_endpoint_ignored(
+                    service, endpoint
+                ):
+                    continue
+                else:
+                    filtered_spans.append(span)
+            else:
+                filtered_spans.append(span)
+        return filtered_spans
+
+    def handle_agent_tasks(self, task: Dict[str, Any]) -> None:
         """
         When request(s) are received by the host agent, it is sent here
         for handling & processing.
         """
-        logger.debug("Received agent request with messageId: %s", task["messageId"])
+        logger.debug(f"Received agent request with messageId: {task['messageId']}")
         if "action" in task:
             if task["action"] == "python.source":
                 payload = get_py_source(task["args"]["file"])
             else:
-                message = "Unrecognized action: %s. An newer Instana package may be required " \
-                          "for this. Current version: %s" % (task["action"], VERSION)
+                message = (
+                    f"Unrecognized action: {task['action']}. An newer Instana package may be required "
+                    f"for this. Current version: {VERSION}"
+                )
                 payload = {"error": message}
         else:
             payload = {"error": "Instana Python: No action specified in request."}
 
         self.__task_response(task["messageId"], payload)
 
-
-    def diagnostics(self):
+    def diagnostics(self) -> None:
         """
         Helper function to dump out state.
         """
         try:
             import threading
+
             dt_format = "%Y-%m-%d %H:%M:%S"
 
             logger.warning("====> Instana Python Language Agent Diagnostics <====")
 
             logger.warning("----> Agent <----")
-            logger.warning("is_agent_ready: %s", self.is_agent_ready())
-            logger.warning("is_timed_out: %s", self.is_timed_out())
+            logger.warning(f"is_agent_ready: {self.is_agent_ready()}")
+            logger.warning(f"is_timed_out: {self.is_timed_out()}")
             if self.last_seen is None:
                 logger.warning("last_seen: None")
             else:
-                logger.warning("last_seen: %s", self.last_seen.strftime(dt_format))
+                logger.warning(f"last_seen: {self.last_seen.strftime(dt_format)}")
 
             if self.announce_data is not None:
-                logger.warning("announce_data: %s", self.announce_data.__dict__)
+                logger.warning(f"announce_data: {self.announce_data.__dict__}")
             else:
                 logger.warning("announce_data: None")
 
-            logger.warning("Options: %s", self.options.__dict__)
+            logger.warning(f"Options: {self.options.__dict__}")
 
             logger.warning("----> StateMachine <----")
-            logger.warning("State: %s", self.machine.fsm.current)
+            logger.warning(f"State: {self.machine.fsm.current}")
 
             logger.warning("----> Collector <----")
-            logger.warning("Collector: %s", self.collector)
-            logger.warning("is_collector_thread_running?: %s", self.collector.is_reporting_thread_running())
-            logger.warning("background_report_lock.locked?: %s", self.collector.background_report_lock.locked())
-            logger.warning("ready_to_start: %s", self.collector.ready_to_start)
-            logger.warning("reporting_thread: %s", self.collector.reporting_thread)
-            logger.warning("report_interval: %s", self.collector.report_interval)
-            logger.warning("should_send_snapshot_data: %s", self.collector.should_send_snapshot_data())
-            logger.warning("spans in queue: %s", self.collector.span_queue.qsize())
-            logger.warning("thread_shutdown is_set: %s", self.collector.thread_shutdown.is_set())
+            logger.warning(f"Collector: {self.collector}")
+            logger.warning(
+                f"is_collector_thread_running?: {self.collector.is_reporting_thread_running()}"
+            )
+            logger.warning(
+                f"background_report_lock.locked?: {self.collector.background_report_lock.locked()}"
+            )
+            logger.warning(f"ready_to_start: {self.collector.ready_to_start}")
+            logger.warning(f"reporting_thread: {self.collector.reporting_thread}")
+            logger.warning(f"report_interval: {self.collector.report_interval}")
+            logger.warning(
+                f"should_send_snapshot_data: {self.collector.should_send_snapshot_data()}"
+            )
+            logger.warning(f"spans in queue: {self.collector.span_queue.qsize()}")
+            logger.warning(
+                f"thread_shutdown is_set: {self.collector.thread_shutdown.is_set()}"
+            )
 
             logger.warning("----> Threads <----")
-            logger.warning("Threads: %s", threading.enumerate())
+            logger.warning(f"Threads: {threading.enumerate()}")
         except Exception:
             logger.warning("Non-fatal diagnostics exception: ", exc_info=True)
 
-    def __task_response(self, message_id, data):
+    def __task_response(
+        self,
+        message_id: str,
+        data: Dict[str, Any],
+    ) -> Optional[Response]:
         """
         When the host agent passes us a task and we do it, this function is used to
         respond with the results of the task.
@@ -372,52 +473,58 @@ class HostAgent(BaseAgent):
         try:
             payload = json.dumps(data)
 
-            logger.debug("Task response is %s: %s", self.__response_url(message_id), payload)
+            logger.debug(
+                f"Task response is {self.__response_url(message_id)}: {payload}"
+            )
 
-            response = self.client.post(self.__response_url(message_id),
-                                        data=payload,
-                                        headers={"Content-Type": "application/json"},
-                                        timeout=0.8)
+            response = self.client.post(
+                self.__response_url(message_id),
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                timeout=0.8,
+            )
         except Exception as exc:
-            logger.debug("__task_response: Instana host agent connection error (%s)", type(exc))
+            logger.debug(
+                f"__task_response: Instana host agent connection error ({type(exc)})"
+            )
         return response
 
-    def __discovery_url(self):
+    def __discovery_url(self) -> str:
         """
         URL for announcing to the host agent
         """
-        return "http://%s:%s/%s" % (self.options.agent_host, self.options.agent_port, self.AGENT_DISCOVERY_PATH)
+        return f"http://{self.options.agent_host}:{self.options.agent_port}/{self.AGENT_DISCOVERY_PATH}"
 
-    def __data_url(self):
+    def __data_url(self) -> str:
         """
         URL for posting metrics to the host agent.  Only valid when announced.
         """
         path = self.AGENT_DATA_PATH % self.announce_data.pid
-        return "http://%s:%s/%s" % (self.options.agent_host, self.options.agent_port, path)
+        return f"http://{self.options.agent_host}:{self.options.agent_port}/{path}"
 
-    def __traces_url(self):
+    def __traces_url(self) -> str:
         """
         URL for posting traces to the host agent.  Only valid when announced.
         """
-        path = "com.instana.plugin.python/traces.%d" % self.announce_data.pid
-        return "http://%s:%s/%s" % (self.options.agent_host, self.options.agent_port, path)
+        path = f"com.instana.plugin.python/traces.{self.announce_data.pid}"
+        return f"http://{self.options.agent_host}:{self.options.agent_port}/{path}"
 
-    def __profiles_url(self):
+    def __profiles_url(self) -> str:
         """
         URL for posting profiles to the host agent.  Only valid when announced.
         """
-        path = "com.instana.plugin.python/profiles.%d" % self.announce_data.pid
-        return "http://%s:%s/%s" % (self.options.agent_host, self.options.agent_port, path)
+        path = f"com.instana.plugin.python/profiles.{self.announce_data.pid}"
+        return f"http://{self.options.agent_host}:{self.options.agent_port}/{path}"
 
-    def __response_url(self, message_id):
+    def __response_url(self, message_id: str) -> str:
         """
         URL for responding to agent requests.
         """
-        path = "com.instana.plugin.python/response.%d?messageId=%s" % (int(self.announce_data.pid), message_id)
-        return "http://%s:%s/%s" % (self.options.agent_host, self.options.agent_port, path)
+        path = f"com.instana.plugin.python/response.{int(self.announce_data.pid)}?messageId={message_id}"
+        return f"http://{self.options.agent_host}:{self.options.agent_port}/{path}"
 
-    def __agent_logger_url(self):
+    def __agent_logger_url(self) -> str:
         """
         URL for logging messages to the discovered host agent.
         """
-        return "http://%s:%s/%s" % (self.options.agent_host, self.options.agent_port, "com.instana.agent.logger")
+        return f"http://{self.options.agent_host}:{self.options.agent_port}/com.instana.agent.logger"

--- a/src/instana/util/config.py
+++ b/src/instana/util/config.py
@@ -1,0 +1,82 @@
+from typing import Any, Dict, List, Union
+from instana.log import logger
+
+
+def parse_service_pair(pair: str) -> List[str]:
+    """
+    Parses a pair string to prepare a list of ignored endpoints.
+
+    @param pair: String format:
+        - "service1:endpoint1,endpoint2" or "service1:endpoint1" or "service1"
+    @return: List of strings in format ["service1.endpoint1", "service1.endpoint2", "service2"]
+    """
+    pair_list = []
+    if ":" in pair:
+        service, endpoints = pair.split(":", 1)
+        service = service.strip()
+        endpoint_list = [ep.strip() for ep in endpoints.split(",") if ep.strip()]
+
+        for endpoint in endpoint_list:
+            pair_list.append(f"{service}.{endpoint}")
+    else:
+        pair_list.append(pair)
+    return pair_list
+
+
+def parse_ignored_endpoints_string(params: str) -> List[str]:
+    """
+    Parses a string to prepare a list of ignored endpoints.
+
+    @param params: String format:
+        - "service1:endpoint1,endpoint2;service2:endpoint3" or "service1;service2"
+    @return: List of strings in format ["service1.endpoint1", "service1.endpoint2", "service2"]
+    """
+    ignore_endpoints = []
+    if params:
+        service_pairs = params.lower().split(";")
+
+        for pair in service_pairs:
+            if pair.strip():
+                ignore_endpoints += parse_service_pair(pair)
+    return ignore_endpoints
+
+
+def parse_ignored_endpoints_dict(params: Dict[str, Any]) -> List[str]:
+    """
+    Parses a dictionary to prepare a list of ignored endpoints.
+
+    @param params: Dict format:
+        - {"service1": ["endpoint1", "endpoint2"], "service2": ["endpoint3"]}
+    @return: List of strings in format ["service1.endpoint1", "service1.endpoint2", "service2"]
+    """
+    ignore_endpoints = []
+
+    for service, endpoints in params.items():
+        if not endpoints:  # filtering all service
+            ignore_endpoints.append(service.lower())
+        else:  # filtering specific endpoints
+            for endpoint in endpoints:
+                ignore_endpoints.append(f"{service.lower()}.{endpoint.lower()}")
+
+    return ignore_endpoints
+
+
+def parse_ignored_endpoints(params: Union[Dict[str, Any], str]) -> List[str]:
+    """
+    Parses input to prepare a list for ignored endpoints.
+
+    @param params: Can be either:
+        - String: "service1:endpoint1,endpoint2;service2:endpoint3" or "service1;service2"
+        - Dict: {"service1": ["endpoint1", "endpoint2"], "service2": ["endpoint3"]}
+    @return: List of strings in format ["service1.endpoint1", "service1.endpoint2", "service2"]
+    """
+    try:
+        if isinstance(params, str):
+            return parse_ignored_endpoints_string(params)
+        elif isinstance(params, dict):
+            return parse_ignored_endpoints_dict(params)
+        else:
+            return []
+    except Exception as e:
+        logger.debug("Error parsing ignored endpoints: %s", str(e))
+        return []

--- a/tests/agent/test_host.py
+++ b/tests/agent/test_host.py
@@ -575,6 +575,90 @@ class TestHostAgent:
             assert isinstance(agent.last_seen, datetime.datetime)
             assert test_response.content == sample_response
 
+    def test_report_metrics(self) -> None:
+        agent = HostAgent()
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.return_value = "Success"
+
+        payload = {
+            "metrics": {
+                "plugins": [
+                    {"data": "sample data"},
+                ]
+            },
+        }
+
+        with patch.object(requests.Session, "post", return_value=mock_response), patch(
+            "instana.agent.host.HostAgent._HostAgent__traces_url",
+            return_value="localhost",
+        ), patch(
+            "instana.agent.host.HostAgent._HostAgent__profiles_url",
+            return_value="localhost",
+        ), patch(
+            "instana.agent.host.HostAgent._HostAgent__data_url",
+            return_value="localhost",
+        ):
+            test_response = agent.report_metrics(payload)
+            assert test_response.return_value == "Success"
+
+    def test_report_profiles(self) -> None:
+        agent = HostAgent()
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.return_value = "Success"
+
+        payload = {
+            "profiles": ["profile-1", "profile-2"],
+        }
+
+        with patch.object(requests.Session, "post", return_value=mock_response), patch(
+            "instana.agent.host.HostAgent._HostAgent__traces_url",
+            return_value="localhost",
+        ), patch(
+            "instana.agent.host.HostAgent._HostAgent__profiles_url",
+            return_value="localhost",
+        ), patch(
+            "instana.agent.host.HostAgent._HostAgent__data_url",
+            return_value="localhost",
+        ):
+            test_response = agent.report_profiles(payload)
+            assert test_response.return_value == "Success"
+
+    def test_report_spans(
+        self,
+        span_context: SpanContext,
+        span_processor: StanRecorder,
+    ) -> None:
+        agent = HostAgent()
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.return_value = "Success"
+
+        span_name = "test_span"
+        span_1 = InstanaSpan(span_name, span_context, span_processor)
+        span_2 = InstanaSpan(span_name, span_context, span_processor)
+
+        payload = {
+            "spans": [span_1, span_2],
+        }
+
+        with patch.object(requests.Session, "post", return_value=mock_response), patch(
+            "instana.agent.host.HostAgent._HostAgent__traces_url",
+            return_value="localhost",
+        ), patch(
+            "instana.agent.host.HostAgent._HostAgent__profiles_url",
+            return_value="localhost",
+        ), patch(
+            "instana.agent.host.HostAgent._HostAgent__data_url",
+            return_value="localhost",
+        ):
+            test_response = agent.report_spans(payload)
+            assert test_response.return_value == "Success"
+
     def test_diagnostics(self, caplog: pytest.LogCaptureFixture) -> None:
         caplog.set_level(logging.WARNING, logger="instana")
 

--- a/tests/util/test_config.py
+++ b/tests/util/test_config.py
@@ -1,0 +1,139 @@
+from typing import Generator
+
+import pytest
+
+from instana.util.config import (
+    parse_ignored_endpoints,
+    parse_ignored_endpoints_dict,
+    parse_service_pair,
+)
+
+
+class TestConfig:
+    @pytest.fixture(autouse=True)
+    def _resource(self) -> Generator[None, None, None]:
+        yield
+
+    def test_parse_service_pair(self) -> None:
+        test_string = "service1:endpoint1,endpoint2"
+        response = parse_service_pair(test_string)
+        assert response == ["service1.endpoint1", "service1.endpoint2"]
+
+        test_string = "service1;service2"
+        response = parse_ignored_endpoints(test_string)
+        assert response == ["service1", "service2"]
+
+        test_string = "service1"
+        response = parse_ignored_endpoints(test_string)
+        assert response == ["service1"]
+
+        test_string = ";"
+        response = parse_ignored_endpoints(test_string)
+        assert response == []
+
+        test_string = "service1:endpoint1,endpoint2;;;service2:endpoint1;;"
+        response = parse_ignored_endpoints(test_string)
+        assert response == [
+            "service1.endpoint1",
+            "service1.endpoint2",
+            "service2.endpoint1",
+        ]
+
+        test_string = ""
+        response = parse_ignored_endpoints(test_string)
+        assert response == []
+
+    def test_parse_ignored_endpoints_string(self) -> None:
+        test_string = "service1:endpoint1,endpoint2"
+        response = parse_service_pair(test_string)
+        assert response == ["service1.endpoint1", "service1.endpoint2"]
+
+        test_string = "service1;service2"
+        response = parse_ignored_endpoints(test_string)
+        assert response == ["service1", "service2"]
+
+        test_string = "service1"
+        response = parse_ignored_endpoints(test_string)
+        assert response == ["service1"]
+
+        test_string = ";"
+        response = parse_ignored_endpoints(test_string)
+        assert response == []
+
+        test_string = "service1:endpoint1,endpoint2;;;service2:endpoint1;;"
+        response = parse_ignored_endpoints(test_string)
+        assert response == [
+            "service1.endpoint1",
+            "service1.endpoint2",
+            "service2.endpoint1",
+        ]
+
+        test_string = ""
+        response = parse_ignored_endpoints(test_string)
+        assert response == []
+
+    def test_parse_ignored_endpoints_dict(self) -> None:
+        test_dict = {"service1": ["endpoint1", "endpoint2"]}
+        response = parse_ignored_endpoints_dict(test_dict)
+        assert response == ["service1.endpoint1", "service1.endpoint2"]
+
+        test_dict = {"SERVICE1": ["ENDPOINT1", "ENDPOINT2"]}
+        response = parse_ignored_endpoints_dict(test_dict)
+        assert response == ["service1.endpoint1", "service1.endpoint2"]
+
+        test_dict = {"service1": [], "service2": []}
+        response = parse_ignored_endpoints_dict(test_dict)
+        assert response == ["service1", "service2"]
+
+        test_dict = {"service1": []}
+        response = parse_ignored_endpoints_dict(test_dict)
+        assert response == ["service1"]
+
+        test_dict = {}
+        response = parse_ignored_endpoints_dict(test_dict)
+        assert response == []
+
+    def test_parse_ignored_endpoints(self) -> None:
+        test_pair = "service1:endpoint1,endpoint2"
+        response = parse_ignored_endpoints(test_pair)
+        assert response == ["service1.endpoint1", "service1.endpoint2"]
+
+        test_pair = "service1;service2"
+        response = parse_ignored_endpoints(test_pair)
+        assert response == ["service1", "service2"]
+
+        test_pair = "service1"
+        response = parse_ignored_endpoints(test_pair)
+        assert response == ["service1"]
+
+        test_pair = ";"
+        response = parse_ignored_endpoints(test_pair)
+        assert response == []
+
+        test_pair = "service1:endpoint1,endpoint2;;;service2:endpoint1;;"
+        response = parse_ignored_endpoints(test_pair)
+        assert response == [
+            "service1.endpoint1",
+            "service1.endpoint2",
+            "service2.endpoint1",
+        ]
+
+        test_pair = ""
+        response = parse_ignored_endpoints(test_pair)
+        assert response == []
+
+        test_dict = {"service1": ["endpoint1", "endpoint2"]}
+        response = parse_ignored_endpoints(test_dict)
+        assert response == ["service1.endpoint1", "service1.endpoint2"]
+
+        test_dict = {"service1": [], "service2": []}
+        response = parse_ignored_endpoints(test_dict)
+        assert response == ["service1", "service2"]
+
+        test_dict = {"service1": []}
+        response = parse_ignored_endpoints(test_dict)
+        assert response == ["service1"]
+
+        test_dict = {}
+        response = parse_ignored_endpoints(test_dict)
+        assert response == []

--- a/tests/util/test_traceutils.py
+++ b/tests/util/test_traceutils.py
@@ -8,6 +8,7 @@ from instana.util.traceutils import (
     extract_custom_headers,
     get_active_tracer,
     get_tracer_tuple,
+    is_service_or_endpoint_ignored,
     tracing_is_off,
 )
 
@@ -95,3 +96,24 @@ def test_tracing_is_off() -> None:
     response = tracing_is_off()
     assert not response
     agent.options.allow_exit_as_root = False
+
+
+def test_is_service_or_endpoint_ignored() -> None:
+    agent.options.ignore_endpoints.append("service1")
+    agent.options.ignore_endpoints.append("service2.endpoint1")
+
+    # ignore all endpoints of service1
+    assert is_service_or_endpoint_ignored("service1")
+    assert is_service_or_endpoint_ignored("service1", "endpoint1")
+    assert is_service_or_endpoint_ignored("service1", "endpoint2")
+
+    # case-insensitive
+    assert is_service_or_endpoint_ignored("SERVICE1")
+    assert is_service_or_endpoint_ignored("service1", "ENDPOINT1")
+
+    # ignore only endpoint1 of service2
+    assert is_service_or_endpoint_ignored("service2", "endpoint1")
+    assert not is_service_or_endpoint_ignored("service2", "endpoint2")
+
+    # don't ignore other services
+    assert not is_service_or_endpoint_ignored("service3")


### PR DESCRIPTION
Added endpoint filtering for redis instrumentation. We've aligned with Java and NodeJS teams. The customer has three options to filter endpoints:
- Defining ignore-endpoint through the configuration.yaml file of the agent
- Using environment-variable before initialisation
- Using src/instana/configurator.py

If the customer used more than one way of these three, we'd be using one according to this priority:
- Environment variable > in-code setting > agent configuration

## Ignoring endpoints through env variable
The customer can use filtering with the environment variable below. If the env variable is set, other two ways will be ignored.

- `INSTANA_IGNORE_ENDPOINTS="service:endpoint"`
- `INSTANA_IGNORE_ENDPOINTS="service:endpoint1,endpoint2"`
- Filtering redis instrumentation at all:
  `INSTANA_IGNORE_ENDPOINTS="service"`
- Filtering multiple instrumentations:
  `INSTANA_IGNORE_ENDPOINTS="service1:endpoint1;service2:endpoint1"`
  `INSTANA_IGNORE_ENDPOINTS="service1;service2"`

## Ignoring endpoints through the configurator.py file
The customer can add a configuration line like below:

- `config["tracing"]["ignore_endpoints"] = {"service1": ["endpoint1", "endpoint2"], "service2": []}`

## Ignoring endpoints through the agent configuration
The customer can add a configuration to agent-folder/etc/instana/configuration.yaml

``` yaml
com.instana.tracing:
  ignore-endpoints:
    service1:    # Add package name, e.g., redis, dynamodb
      - 'endpoint1' # Add endpoint
      - 'endpoint2'
    service2:
      - 'endpoint1'
```


Reference: https://github.ibm.com/instana/technical-documentation/tree/master/tracing/specification#ignoring-endpoints