### PR TITLE
fix: capture headers

### DIFF
--- a/src/instana/util/traceutils.py
+++ b/src/instana/util/traceutils.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from instana.span.span import InstanaSpan
 
 def extract_custom_headers(span: "InstanaSpan", headers: Optional[Union[Dict[str, Any], List[Tuple[object, ...]], Iterable]] = None, format: Optional[bool] = False) -> None:
-    if not headers:
+    if not (agent.options.extra_http_headers and headers):
         return
     try:
         for custom_header in agent.options.extra_http_headers:


### PR DESCRIPTION
### bug
```
2025-01-20 20:18:39,760: 71181 DEBUG instana: Agent is ready.  Getting to work.
2025-01-20 20:19:09,467: 71181 DEBUG instana: Flask(blinker): Applying flask before/after instrumentation funcs
2025-01-20 20:19:09,469: 71181 DEBUG instana: extract_custom_headers: 
Traceback (most recent call last):
  File "/Users/varsha/Documents/GitHub/tracer-repos/python-sensor-example-flask/.venv/lib/python3.9/site-packages/instana/util/traceutils.py", line 18, in extract_custom_headers
    for custom_header in agent.options.extra_http_headers:
TypeError: 'NoneType' object is not iterable
127.0.0.1 - - [20/Jan/2025 20:19:09] "GET / HTTP/1.1" 200 -
2025-01-20 20:19:09,747: 71181 DEBUG instana: Reporting 1 spans
```

### fix
```
2025-01-20 20:43:04,924: 76086 DEBUG instana: Agent is ready.  Getting to work.
2025-01-20 20:43:05,963: 76086 DEBUG instana: Flask(blinker): Applying flask before/after instrumentation funcs
127.0.0.1 - - [20/Jan/2025 20:43:05] "GET / HTTP/1.1" 200 -
2025-01-20 20:43:06,909: 76086 DEBUG instana: Reporting 1 spans
```