### PR TITLE
fix: use the correct image for 3.14.0a4

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -39,7 +39,7 @@ spec:
               # public.ecr.aws/docker/library/python:3.13.1-bookworm
               - "sha256:3b1b63f17c5197411ee572be110333dae4b9d6f2fbc4f84c790f644e791d356b"
               # public.ecr.aws/docker/library/python:3.14.0a4-bookworm
-              - "sha256:673113f17486ce8d5cd217f38502b15171164bbd3cb0a727a7de2664ad105956"
+              - "sha256:2b6ff3e4a96f18b7c6a5384cb1c623eec35b93b722da3c4470112435deeca590"
       taskRef:
         name: python-tracer-unittest-default-task
       workspaces:

--- a/.tekton/python-tracer-prepuller.yaml
+++ b/.tekton/python-tracer-prepuller.yaml
@@ -71,7 +71,7 @@ spec:
           command: ["sh", "-c", "'true'"]
         - name: prepuller-314
           # public.ecr.aws/docker/library/python:3.14.0a4-bookworm
-          image: public.ecr.aws/docker/library/python@sha256:673113f17486ce8d5cd217f38502b15171164bbd3cb0a727a7de2664ad105956
+          image: public.ecr.aws/docker/library/python@sha256:2b6ff3e4a96f18b7c6a5384cb1c623eec35b93b722da3c4470112435deeca590
           command: ["sh", "-c", "'true'"]
 
       # Use the pause container to ensure the Pod goes into a `Running` phase


### PR DESCRIPTION
### Before
```
Configuration is 'default' on 3.14.0a3 with dependencies in 'requirements-pre314.txt'
```

### After
```
Configuration is 'default' on 3.14.0a4 with dependencies in 'requirements-pre314.txt'
```