### PR TITLE
fix: remove unsupported span attribute

### DIFF
--- a/src/instana/instrumentation/asgi.py
+++ b/src/instana/instrumentation/asgi.py
@@ -31,7 +31,6 @@ class InstanaASGIMiddleware:
 
     def _collect_kvs(self, scope: Dict[str, Any], span: "InstanaSpan") -> None:
         try:
-            span.set_attribute("span.kind", SpanKind.SERVER)
             span.set_attribute("http.path", scope.get("path"))
             span.set_attribute(SpanAttributes.HTTP_METHOD, scope.get("method"))
 

--- a/src/instana/instrumentation/pep0249.py
+++ b/src/instana/instrumentation/pep0249.py
@@ -38,8 +38,6 @@ class CursorWrapper(wrapt.ObjectProxy):
         sql: str,
     ) -> None:
         try:
-            span.set_attribute("span.kind", SpanKind.CLIENT)
-
             db_parameter_name = next(
                 (
                     p

--- a/src/instana/instrumentation/pyramid.py
+++ b/src/instana/instrumentation/pyramid.py
@@ -36,7 +36,6 @@ try:
             ctx = tracer.extract(Format.HTTP_HEADERS, dict(request.headers))
 
             with tracer.start_as_current_span("wsgi", span_context=ctx) as span:
-                span.set_attribute("span.kind", SpanKind.SERVER)
                 span.set_attribute("http.host", request.host)
                 span.set_attribute(SpanAttributes.HTTP_METHOD, request.method)
                 span.set_attribute(SpanAttributes.HTTP_URL, request.path)

--- a/src/instana/instrumentation/sanic_inst.py
+++ b/src/instana/instrumentation/sanic_inst.py
@@ -58,7 +58,6 @@ try:
                 token = context.attach(ctx)
                 request.ctx.token = token
 
-                span.set_attribute("span.kind", SpanKind.SERVER)
                 span.set_attribute("http.path", request.path)
                 span.set_attribute(SpanAttributes.HTTP_METHOD, request.method)
                 span.set_attribute(SpanAttributes.HTTP_HOST, request.host)

--- a/src/instana/span/registered_span.py
+++ b/src/instana/span/registered_span.py
@@ -34,9 +34,9 @@ class RegisteredSpan(BaseSpan):
         if "gcps" in span.name:
             self.n = "gcps"
 
-        # Store any leftover attributes in the custom section
+        # Logic to store custom attributes for registered spans (not used yet)
         if len(span.attributes) > 0:
-            self.data["custom"]["attributes"] = self._validate_attributes(
+            self.data["sdk"]["custom"]["tags"] = self._validate_attributes(
                 span.attributes
             )
 

--- a/tests/clients/test_pep0249.py
+++ b/tests/clients/test_pep0249.py
@@ -116,7 +116,6 @@ class TestCursorWrapper:
                 select * from tests;
             """
             self.test_wrapper._collect_kvs(span, sample_sql)
-            assert span.attributes["span.kind"] == SpanKind.CLIENT
             assert span.attributes["db.name"] == "instana_test_db"
             assert span.attributes["db.statement"] == sample_sql
             assert span.attributes["db.user"] == "root"

--- a/tests/span/test_registered_span.py
+++ b/tests/span/test_registered_span.py
@@ -66,7 +66,6 @@ class TestRegisteredSpan:
     ) -> None:
         span_name = "test-registered-span"
         attributes = {
-            "span.kind": "entry",
             "http.host": "localhost",
             "http.url": "https://www.instana.com",
             "http.header.test": "one more test",


### PR DESCRIPTION
Remove unsupported redundant span attribute `span.data.custom.attributes`

```
{"data":{...,"custom":{"attributes":{"span.kind":"<SpanKind.SERVER: 1>"}}},...}
```