### PR TITLE
chore: Ignore uv.lock file on Git.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ ENV/
 # Visual Studio Code
 *.code-workspace
 .vscode
+
+# uv (https://docs.astral.sh/uv/)
+uv.lock


### PR DESCRIPTION
Signed-off-by: Paulo Vital <paulo.vital@ibm.com>