### PR TITLE
fix: added exception for pika consumer

### DIFF
--- a/src/instana/instrumentation/pika.py
+++ b/src/instana/instrumentation/pika.py
@@ -255,6 +255,8 @@ try:
 
                     try:
                         yield yielded
+                    except GeneratorExit:
+                        gen.close()
                     except Exception as exc:
                         span.record_exception(exc)
 


### PR DESCRIPTION
Test_consume case was failing due to the break inside __consume function. When we break the for loop, generator propagates GeneratorExit exception. I've added an exception case and closed the generator gracefully.