### PR TITLE
ci: Add Ruff linter as GitHub Action.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,13 @@
+name: Ruff
+on: [ push, pull_request ]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+            src: >-
+                ./src
+                ./tests
+                ./tests-aws

--- a/.github/workflows/release-notification-on-slack.yml
+++ b/.github/workflows/release-notification-on-slack.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout the needed file only ./bin/announce_release_on_slack.py'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: |
           if [[ ${{ github.event_name == 'workflow_dispatch' }} == true ]]; then
             export GITHUB_RELEASE_TAG=${{ inputs.github_ref }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: sonarsource/sonarqube-scan-action@master


### PR DESCRIPTION
Executes Ruff as linter tool to check code pattern.

Signed-off-by: Paulo Vital <paulo.vital@ibm.com>