### PR TITLE
Improve kafka-python

### DIFF
--- a/tests/clients/kafka/test_kafka_python.py
+++ b/tests/clients/kafka/test_kafka_python.py
@@ -81,8 +81,6 @@ class TestKafkaPython:
         assert kafka_span.data["kafka"]["access"] == "send"
 
     def test_trace_kafka_python_consume(self) -> None:
-        agent.options.allow_exit_as_root = False
-
         # Produce some events
         self.producer.send(testenv["kafka_topic"], b"raw_bytes1")
         self.producer.send(testenv["kafka_topic"], b"raw_bytes2")
@@ -125,9 +123,48 @@ class TestKafkaPython:
         assert kafka_span.data["kafka"]["service"] == testenv["kafka_topic"]
         assert kafka_span.data["kafka"]["access"] == "consume"
 
-    def test_trace_kafka_python_error(self) -> None:
-        agent.options.allow_exit_as_root = False
+    def test_trace_kafka_python_poll(self) -> None:
+        # Produce some events
+        self.producer.send(testenv["kafka_topic"], b"raw_bytes1")
+        self.producer.send(testenv["kafka_topic"], b"raw_bytes2")
+        self.producer.flush()
 
+        # Consume the events
+        consumer = KafkaConsumer(
+            testenv["kafka_topic"],
+            bootstrap_servers=testenv["kafka_bootstrap_servers"],
+            auto_offset_reset="earliest",  # consume earliest available messages
+            enable_auto_commit=False,  # do not auto-commit offsets
+            consumer_timeout_ms=1000,
+        )
+
+        with tracer.start_as_current_span("test"):
+            msg = consumer.poll()  # noqa: F841
+
+        consumer.close()
+
+        spans = self.recorder.queued_spans()
+        assert len(spans) == 2
+
+        kafka_span = spans[0]
+        test_span = spans[1]
+
+        # Same traceId
+        assert test_span.t == kafka_span.t
+
+        # Parent relationships
+        assert kafka_span.p == test_span.s
+
+        # Error logging
+        assert not test_span.ec
+        assert not kafka_span.ec
+
+        assert kafka_span.n == "kafka"
+        assert kafka_span.k == SpanKind.SERVER
+        assert kafka_span.data["kafka"]["service"] == testenv["kafka_topic"]
+        assert kafka_span.data["kafka"]["access"] == "poll"
+
+    def test_trace_kafka_python_error(self) -> None:
         # Consume the events
         consumer = KafkaConsumer(
             "inexistent_kafka_topic",


### PR DESCRIPTION
Add instrumentation support for the `KafkaConsumer.poll()` and make the `confluent-kafka.poll()` test faster.