### PR TITLE
fix(sanic): Handle headers extraction after `multidict` update

### DIFF
--- a/src/instana/propagators/base_propagator.py
+++ b/src/instana/propagators/base_propagator.py
@@ -89,6 +89,8 @@ class BasePropagator(object):
                 dc = carrier
             elif hasattr(carrier, "__dict__"):
                 dc = carrier.__dict__
+                if not dc:
+                    dc = dict(carrier)
             else:
                 dc = dict(carrier)
         except Exception:


### PR DESCRIPTION
### Overview
- `sanic.compat.Header` contains `__dict__` attribute but does not store the headers dictionary in it. Hence directly convert the `CIMultiDict` instance to dictionary using `dict()`.