### PR TITLE
ci: downgrade wheel package version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ commands:
             python -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
-            pip install 'wheel>=0.29.0'
+            pip install 'wheel==0.45.1'
             pip install -r requirements.txt
             pip install -r <<parameters.requirements>>
 


### PR DESCRIPTION
Circle CI pipelines were failing for Python 3.9-3.10-3.11 versions due to the last version of `wheels` package. This PR temporarily fixes the issue until a new version of the Wheels package is released.

Main Pipeline
![image](https://github.com/user-attachments/assets/559c0e31-524f-4722-a83c-23452f663e62)






