### PR TITLE
CI: Bump up Python version for automated tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,7 +309,7 @@ jobs:
 
   python314:
     docker:
-      - image: public.ecr.aws/docker/library/python:3.14.0a6
+      - image: public.ecr.aws/docker/library/python:3.14.0a7
       - image: public.ecr.aws/docker/library/postgres:16.2-bookworm
         environment:
           POSTGRES_USER: root

--- a/.tekton/.currency/currency-tasks.yaml
+++ b/.tekton/.currency/currency-tasks.yaml
@@ -33,8 +33,8 @@ spec:
       mountPath: /workspace
   steps:
     - name: generate-currency-report
-      # public.ecr.aws/docker/library/python:3.12.9-bookworm
-      image: public.ecr.aws/docker/library/python@sha256:ae24158f83adcb3ec1dead14356e6debc9f3125167624408d95338faacc5cce3
+      # public.ecr.aws/docker/library/python:3.12.10-bookworm
+      image: public.ecr.aws/docker/library/python@sha256:4ea730e54e2a87b716ffc58a426bd627baa182a3d4d5696d05c1bca2dde775aa
       script: |
         #!/usr/bin/env bash
         cd /workspace/python-sensor/.tekton/.currency

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -38,8 +38,8 @@ spec:
               - "sha256:ae24158f83adcb3ec1dead14356e6debc9f3125167624408d95338faacc5cce3"
               # public.ecr.aws/docker/library/python:3.13.2-bookworm
               - "sha256:90a15cf04e17111d514958f3b17186f2e239546f75530b1e301059f0b70de41f"
-              # public.ecr.aws/docker/library/python:3.14.0a6-bookworm
-              - "sha256:cc1702492859ae14ce2c417060215a94153a51f42954eb7fd5f275b5b3039926"
+              # public.ecr.aws/docker/library/python:3.14.0a7-bookworm
+              - "sha256:4c1f7c905b091408b27eba4a7fa84e6e866da0e6dabb29a397a444946e10627f"
       taskRef:
         name: python-tracer-unittest-default-task
       workspaces:

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -28,16 +28,16 @@ spec:
             value:
               # public.ecr.aws/docker/library/python:3.8.20-bookworm
               - "sha256:7aa279fb41dad2962d3c915aa6f6615134baa412ab5aafa9d4384dcaaa0af15d"
-              # public.ecr.aws/docker/library/python:3.9.21-bookworm
-              - "sha256:dd8b65c39a729f946398d2e03a3e6defc8c0cfec409b9f536200634ad6408b54"
-              # public.ecr.aws/docker/library/python:3.10.16-bookworm
-              - "sha256:3ba2e48b887586835af6a0c35fc6fc6086fb4881e963082330ab0a35f3f42c16"
-              # public.ecr.aws/docker/library/python:3.11.11-bookworm
-              - "sha256:2c80c66d876952e04fa74113864903198b7cfb36b839acb7a8fef82e94ed067c"
-              # public.ecr.aws/docker/library/python:3.12.9-bookworm
-              - "sha256:ae24158f83adcb3ec1dead14356e6debc9f3125167624408d95338faacc5cce3"
-              # public.ecr.aws/docker/library/python:3.13.2-bookworm
-              - "sha256:90a15cf04e17111d514958f3b17186f2e239546f75530b1e301059f0b70de41f"
+              # public.ecr.aws/docker/library/python:3.9.22-bookworm
+              - "sha256:a847112640804ed2d03bb774d46bb1619bd37862fb2b7e48eebe425a168c153b"
+              # public.ecr.aws/docker/library/python:3.10.17-bookworm
+              - "sha256:e2c7fb05741c735679b26eda7dd34575151079f8c615875fbefe401972b14d85"
+              # public.ecr.aws/docker/library/python:3.11.12-bookworm
+              - "sha256:a3e280261e448b95d49423532ccd6e5329c39d171c10df1457891ff7c5e2301b"
+              # public.ecr.aws/docker/library/python:3.12.10-bookworm
+              - "sha256:4ea730e54e2a87b716ffc58a426bd627baa182a3d4d5696d05c1bca2dde775aa"
+              # public.ecr.aws/docker/library/python:3.13.3-bookworm
+              - "sha256:07bf1bd38e191e3ed18b5f3eb0006d5ab260cb8c967f49d3bf947e5c2e44d8a9"
               # public.ecr.aws/docker/library/python:3.14.0a7-bookworm
               - "sha256:4c1f7c905b091408b27eba4a7fa84e6e866da0e6dabb29a397a444946e10627f"
       taskRef:
@@ -52,8 +52,8 @@ spec:
         params:
           - name: imageDigest
             value:
-              # public.ecr.aws/docker/library/python:3.9.21-bookworm
-              - "sha256:dd8b65c39a729f946398d2e03a3e6defc8c0cfec409b9f536200634ad6408b54"
+              # public.ecr.aws/docker/library/python:3.9.22-bookworm
+              - "sha256:a847112640804ed2d03bb774d46bb1619bd37862fb2b7e48eebe425a168c153b"
       taskRef:
         name: python-tracer-unittest-cassandra-task
       workspaces:
@@ -66,8 +66,8 @@ spec:
         params:
           - name: imageDigest
             value:
-              # public.ecr.aws/docker/library/python:3.9.21-bookworm
-              - "sha256:dd8b65c39a729f946398d2e03a3e6defc8c0cfec409b9f536200634ad6408b54"
+              # public.ecr.aws/docker/library/python:3.9.22-bookworm
+              - "sha256:a847112640804ed2d03bb774d46bb1619bd37862fb2b7e48eebe425a168c153b"
       taskRef:
         name: python-tracer-unittest-gevent-starlette-task
       workspaces:
@@ -80,8 +80,8 @@ spec:
         params:
           - name: imageDigest
             value:
-              # public.ecr.aws/docker/library/python:3.12.9-bookworm
-              - "sha256:ae24158f83adcb3ec1dead14356e6debc9f3125167624408d95338faacc5cce3"
+              # public.ecr.aws/docker/library/python:3.12.10-bookworm
+              - "sha256:4ea730e54e2a87b716ffc58a426bd627baa182a3d4d5696d05c1bca2dde775aa"
       taskRef:
         name: python-tracer-unittest-aws-task
       workspaces:
@@ -94,8 +94,8 @@ spec:
         params:
           - name: imageDigest
             value:
-              # public.ecr.aws/docker/library/python:3.12.9-bookworm
-              - "sha256:ae24158f83adcb3ec1dead14356e6debc9f3125167624408d95338faacc5cce3"
+              # public.ecr.aws/docker/library/python:3.12.10-bookworm
+              - "sha256:4ea730e54e2a87b716ffc58a426bd627baa182a3d4d5696d05c1bca2dde775aa"
       taskRef:
         name: python-tracer-unittest-kafka-task
       workspaces:

--- a/.tekton/python-tracer-prepuller.yaml
+++ b/.tekton/python-tracer-prepuller.yaml
@@ -54,24 +54,24 @@ spec:
           image: public.ecr.aws/docker/library/python@
           command: ["sh", "-c", "'true'"]
         - name: prepuller-39
-          # public.ecr.aws/docker/library/python:3.9.21-bookworm
-          image: public.ecr.aws/docker/library/python@sha256:dd8b65c39a729f946398d2e03a3e6defc8c0cfec409b9f536200634ad6408b54
+          # public.ecr.aws/docker/library/python:3.9.22-bookworm
+          image: public.ecr.aws/docker/library/python@sha256:a847112640804ed2d03bb774d46bb1619bd37862fb2b7e48eebe425a168c153b
           command: ["sh", "-c", "'true'"]
         - name: prepuller-310
-          # public.ecr.aws/docker/library/python:3.10.16-bookworm
-          image: public.ecr.aws/docker/library/python@sha256:3ba2e48b887586835af6a0c35fc6fc6086fb4881e963082330ab0a35f3f42c16
+          # public.ecr.aws/docker/library/python:3.10.17-bookworm
+          image: public.ecr.aws/docker/library/python@sha256:e2c7fb05741c735679b26eda7dd34575151079f8c615875fbefe401972b14d85
           command: ["sh", "-c", "'true'"]
         - name: prepuller-311
-          # public.ecr.aws/docker/library/python:3.11.11-bookworm
-          image: public.ecr.aws/docker/library/python@sha256:2c80c66d876952e04fa74113864903198b7cfb36b839acb7a8fef82e94ed067c
+          # public.ecr.aws/docker/library/python:3.11.12-bookworm
+          image: public.ecr.aws/docker/library/python@sha256:a3e280261e448b95d49423532ccd6e5329c39d171c10df1457891ff7c5e2301b
           command: ["sh", "-c", "'true'"]
         - name: prepuller-312
-          # public.ecr.aws/docker/library/python:3.12.9-bookworm
-          image: public.ecr.aws/docker/library/python@sha256:ae24158f83adcb3ec1dead14356e6debc9f3125167624408d95338faacc5cce3
+          # public.ecr.aws/docker/library/python:3.12.10-bookworm
+          image: public.ecr.aws/docker/library/python@sha256:4ea730e54e2a87b716ffc58a426bd627baa182a3d4d5696d05c1bca2dde775aa
           command: ["sh", "-c", "'true'"]
         - name: prepuller-313
-          # public.ecr.aws/docker/library/python:3.13.2-bookworm
-          image: public.ecr.aws/docker/library/python@sha256:90a15cf04e17111d514958f3b17186f2e239546f75530b1e301059f0b70de41f
+          # public.ecr.aws/docker/library/python:3.13.3-bookworm
+          image: public.ecr.aws/docker/library/python@sha256:07bf1bd38e191e3ed18b5f3eb0006d5ab260cb8c967f49d3bf947e5c2e44d8a9
           command: ["sh", "-c", "'true'"]
         - name: prepuller-314
           # public.ecr.aws/docker/library/python:3.14.0a7-bookworm

--- a/.tekton/python-tracer-prepuller.yaml
+++ b/.tekton/python-tracer-prepuller.yaml
@@ -74,8 +74,8 @@ spec:
           image: public.ecr.aws/docker/library/python@sha256:90a15cf04e17111d514958f3b17186f2e239546f75530b1e301059f0b70de41f
           command: ["sh", "-c", "'true'"]
         - name: prepuller-314
-          # public.ecr.aws/docker/library/python:3.14.0a6-bookworm
-          image: public.ecr.aws/docker/library/python@sha256:cc1702492859ae14ce2c417060215a94153a51f42954eb7fd5f275b5b3039926
+          # public.ecr.aws/docker/library/python:3.14.0a7-bookworm
+          image: public.ecr.aws/docker/library/python@sha256:4c1f7c905b091408b27eba4a7fa84e6e866da0e6dabb29a397a444946e10627f
           command: ["sh", "-c", "'true'"]
 
       # Use the pause container to ensure the Pod goes into a `Running` phase


### PR DESCRIPTION
The Python-3.14.0a7 (together with 3.13.3, 3.12.10, 3.11.12, 3.10.17 and 3.9.22) was released on April 8th, 2025.