### PR TITLE
fix: added protobuf constraint to requirements.txt

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -21,6 +21,7 @@ mysqlclient>=2.0.3
 PyMySQL[rsa]>=1.0.2
 psycopg2-binary>=2.8.6
 pika>=1.2.0
+protobuf<=6.30.2
 pymongo>=3.11.4
 pyramid>=2.0.1
 pytest>=6.2.4


### PR DESCRIPTION
grpcio-tools==1.71.0 supports only protobuf<6.0, yet.