### PR TITLE
Add tests to verify activating the tracer without code changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,6 +278,38 @@ jobs:
       - store-pytest-results
       - store-coverage-report
 
+  py312autowrapt:
+    docker:
+      - image: public.ecr.aws/docker/library/python:3.12
+        environment:
+          AUTOWRAPT_BOOTSTRAP: instana
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - check-if-tests-needed
+      - pip-install-deps:
+          requirements: "tests/requirements-minimal.txt"
+      - run-tests-with-coverage-report:
+          tests: "tests_autowrapt"
+      - store-pytest-results
+      - store-coverage-report
+
+  py313autowrapt:
+    docker:
+      - image: public.ecr.aws/docker/library/python:3.13
+        environment:
+          AUTOWRAPT_BOOTSTRAP: instana
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - check-if-tests-needed
+      - pip-install-deps:
+          requirements: "tests/requirements-minimal.txt"
+      - run-tests-with-coverage-report:
+          tests: "tests_autowrapt"
+      - store-pytest-results
+      - store-coverage-report
+
   python313:
     docker:
       - image: public.ecr.aws/docker/library/python:3.13
@@ -423,6 +455,8 @@ workflows:
       - py39gevent_starlette
       - py312aws
       - py312kafka
+      - py312autowrapt
+      - py313autowrapt
       - final_job:
           requires:
             - python38
@@ -436,3 +470,5 @@ workflows:
             - py39cassandra
             - py39gevent_starlette
             - py312aws
+            - py312autowrapt
+            - py313autowrapt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,7 @@ jobs:
       - checkout
       - check-if-tests-needed
       - pip-install-deps:
-          requirements: "tests/requirements.txt"
+          requirements: "tests/requirements-aws.txt"
       - run-tests-with-coverage-report:
           tests: "tests_aws"
       - store-pytest-results

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,5 +7,6 @@ pythonpath = src
 testpaths = 
     tests
     tests_aws
+    tests_autowrapt
 markers =
     original: mark test to use the original method instead of the mocked ones under `conftest.py`

--- a/tests/requirements-aws.txt
+++ b/tests/requirements-aws.txt
@@ -1,0 +1,2 @@
+-r requirements-minimal.txt
+boto3

--- a/tests/requirements-minimal.txt
+++ b/tests/requirements-minimal.txt
@@ -1,0 +1,3 @@
+coverage>=5.5
+pytest>=4.6
+setuptools

--- a/tests_autowrapt/test_autowrapt.py
+++ b/tests_autowrapt/test_autowrapt.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+def test_autowrapt_bootstrap():
+    assert os.environ.get("AUTOWRAPT_BOOTSTRAP") == "instana"
+    assert "instana" in sys.modules


### PR DESCRIPTION
### Description

Only checking if `instana` is present in `sys.modules` and not explicitly recording/checking if any spans are recorded because any import like `from instana.<module> import <method>` loads auto-instrumentation [here](https://github.com/instana/python-sensor/blob/main/src/instana/__init__.py#L255) and hence failing the purpose of the intended tests.