### PR TITLE
Fix TypeError of non-dict response data from Agent announcement.

### DIFF
--- a/src/instana/options.py
+++ b/src/instana/options.py
@@ -139,6 +139,10 @@ class StandardOptions(BaseOptions):
         @param res_data: source identifiers provided as announce response
         @return: None
         """
+        if not res_data or not isinstance(res_data, dict):
+            logger.debug(f"options.set_from: Wrong data type - {type(res_data)}")
+            return 
+
         if "secrets" in res_data:
             self.set_secrets(res_data["secrets"])
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -188,6 +188,27 @@ class TestStandardOptions:
 
         assert test_standard_options.extra_http_headers == test_res_data["extraHeaders"]
 
+    def test_set_from_bool(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger="instana")
+        caplog.clear()
+
+        test_standard_options = StandardOptions()
+        test_res_data = True
+        test_standard_options.set_from(test_res_data)
+
+        assert len(caplog.messages) == 1
+        assert len(caplog.records) == 1
+        assert (
+            "options.set_from: Wrong data type - <class 'bool'>" in caplog.messages[0]
+        )
+
+        assert test_standard_options.secrets_list == ["key", "pass", "secret"]
+        assert test_standard_options.ignore_endpoints == []
+        assert not test_standard_options.extra_http_headers
+
 
 class TestServerlessOptions:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
This PR fixes the TypeError of non-dict response data from Agent announcement.

```
tests/clients/kafka/test_confluent_kafka.py::TestConfluentKafka::test_trace_confluent_kafka_produce
  /root/repo/venv/lib/python3.12/site-packages/_pytest/threadexception.py:82: PytestUnhandledThreadExceptionWarning: Exception in thread Instana Machine
  
  Traceback (most recent call last):
    File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
      self.run()
    File "/usr/local/lib/python3.12/threading.py", line 1433, in run
      self.function(*self.args, **self.kwargs)
    File "/root/repo/venv/lib/python3.12/site-packages/fysom/__init__.py", line 315, in fn
      self.transition()
    File "/root/repo/venv/lib/python3.12/site-packages/fysom/__init__.py", line 310, in _tran
      self._after_event(e)
    File "/root/repo/venv/lib/python3.12/site-packages/fysom/__init__.py", line 342, in _after_event
      return getattr(self, fnname)(e)
             ^^^^^^^^^^^^^^^^^^^^^^^^
    File "/root/repo/venv/lib/python3.12/site-packages/fysom/__init__.py", line 99, in _callback
      return func(obj, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/root/repo/src/instana/fsm.py", line 95, in lookup_agent_host
      self.fsm.announce()
    File "/root/repo/venv/lib/python3.12/site-packages/fysom/__init__.py", line 315, in fn
      self.transition()
    File "/root/repo/venv/lib/python3.12/site-packages/fysom/__init__.py", line 310, in _tran
      self._after_event(e)
    File "/root/repo/venv/lib/python3.12/site-packages/fysom/__init__.py", line 342, in _after_event
      return getattr(self, fnname)(e)
             ^^^^^^^^^^^^^^^^^^^^^^^^
    File "/root/repo/venv/lib/python3.12/site-packages/fysom/__init__.py", line 99, in _callback
      return func(obj, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/root/repo/src/instana/fsm.py", line 163, in announce_sensor
      self.agent.set_from(payload)
    File "/root/repo/src/instana/agent/host.py", line 136, in set_from
      self.options.set_from(res_data)
    File "/root/repo/src/instana/options.py", line 142, in set_from
      if "secrets" in res_data:
         ^^^^^^^^^^^^^^^^^^^^^
  TypeError: argument of type 'bool' is not iterable

```

https://app.circleci.com/pipelines/github/instana/python-sensor/3917/workflows/5df45e12-c567-4688-82af-9a0f51f72bd4/jobs/29635?invite=true#step-104-6215_80 