### PR TITLE
chore(docker-compose): remove top-level `version` attribute

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   redis:
     image: public.ecr.aws/docker/library/redis


### PR DESCRIPTION
### Description

```
WARN[0000] /python-sensor/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, 
please remove it to avoid potential confusion 
```
Compose doesn't use version to select an exact schema to validate the Compose file, but prefers the most recent schema when it's implemented.

Reference: [link](https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-top-level-element-obsolete)