### PR TITLE
Fix Python 3.14.0 CI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,5 @@
 version: 2.1
 
-# More about orbs: https://circleci.com/docs/2.0/using-orbs/
-# orbs:
-#   ruby: circleci/ruby@1.1.2
-
 commands:
   check-if-tests-needed:
     steps:
@@ -29,10 +25,6 @@ commands:
             }
 
   pip-install-deps:
-    parameters:
-      requirements:
-        default: "tests/requirements.txt"
-        type: string
     steps:
       - run:
           name: Install Python Dependencies
@@ -42,6 +34,17 @@ commands:
             pip install --upgrade pip
             pip install 'wheel==0.45.1'
             pip install -r requirements.txt
+
+  pip-install-tests-deps:
+    parameters:
+      requirements:
+        default: "tests/requirements.txt"
+        type: string
+    steps:
+      - run:
+          name: Install Python Tests Dependencies
+          command: |
+            . venv/bin/activate
             pip install -r <<parameters.requirements>>
 
   run-tests-with-coverage-report:
@@ -121,9 +124,12 @@ commands:
           path: htmlcov
 
 jobs:
-  python38:
+  python3x:
+    parameters:
+      py-version:
+        type: string
     docker:
-      - image: public.ecr.aws/docker/library/python:3.8
+      - image: public.ecr.aws/docker/library/python:<<parameters.py-version>>
       - image: public.ecr.aws/docker/library/postgres:16.2-bookworm
         environment:
           POSTGRES_USER: root
@@ -145,203 +151,14 @@ jobs:
       - checkout
       - check-if-tests-needed
       - pip-install-deps
-      - run-tests-with-coverage-report
-      - store-pytest-results
-      - store-coverage-report
-
-  python39:
-    docker:
-      - image: public.ecr.aws/docker/library/python:3.9
-      - image: public.ecr.aws/docker/library/postgres:16.2-bookworm
-        environment:
-          POSTGRES_USER: root
-          POSTGRES_PASSWORD: passw0rd
-          POSTGRES_DB: instana_test_db
-      - image: public.ecr.aws/docker/library/mariadb:11.3.2
-        environment:
-          MYSQL_ROOT_PASSWORD: passw0rd
-          MYSQL_DATABASE: instana_test_db
-      - image: public.ecr.aws/docker/library/redis:7.2.4-bookworm
-      - image: public.ecr.aws/docker/library/rabbitmq:3.13.0
-      - image: public.ecr.aws/docker/library/mongo:7.0.6
-      - image: quay.io/thekevjames/gcloud-pubsub-emulator:latest
-        environment:
-          PUBSUB_EMULATOR_HOST: 0.0.0.0:8681
-          PUBSUB_PROJECT1: test-project,test-topic
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - check-if-tests-needed
-      - pip-install-deps
-      - run-tests-with-coverage-report
-      - store-pytest-results
-      - store-coverage-report
-
-  python310:
-    docker:
-      - image: public.ecr.aws/docker/library/python:3.10
-      - image: public.ecr.aws/docker/library/postgres:16.2-bookworm
-        environment:
-          POSTGRES_USER: root
-          POSTGRES_PASSWORD: passw0rd
-          POSTGRES_DB: instana_test_db
-      - image: public.ecr.aws/docker/library/mariadb:11.3.2
-        environment:
-          MYSQL_ROOT_PASSWORD: passw0rd
-          MYSQL_DATABASE: instana_test_db
-      - image: public.ecr.aws/docker/library/redis:7.2.4-bookworm
-      - image: public.ecr.aws/docker/library/rabbitmq:3.13.0
-      - image: public.ecr.aws/docker/library/mongo:7.0.6
-      - image: quay.io/thekevjames/gcloud-pubsub-emulator:latest
-        environment:
-          PUBSUB_EMULATOR_HOST: 0.0.0.0:8681
-          PUBSUB_PROJECT1: test-project,test-topic
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - check-if-tests-needed
-      - pip-install-deps:
-          requirements: "tests/requirements.txt"
-      - run-tests-with-coverage-report
-      - store-pytest-results
-      - store-coverage-report
-
-  python311:
-    docker:
-      - image: public.ecr.aws/docker/library/python:3.11
-      - image: public.ecr.aws/docker/library/postgres:16.2-bookworm
-        environment:
-          POSTGRES_USER: root
-          POSTGRES_PASSWORD: passw0rd
-          POSTGRES_DB: instana_test_db
-      - image: public.ecr.aws/docker/library/mariadb:11.3.2
-        environment:
-          MYSQL_ROOT_PASSWORD: passw0rd
-          MYSQL_DATABASE: instana_test_db
-      - image: public.ecr.aws/docker/library/redis:7.2.4-bookworm
-      - image: public.ecr.aws/docker/library/rabbitmq:3.13.0
-      - image: public.ecr.aws/docker/library/mongo:7.0.6
-      - image: quay.io/thekevjames/gcloud-pubsub-emulator:latest
-        environment:
-          PUBSUB_EMULATOR_HOST: 0.0.0.0:8681
-          PUBSUB_PROJECT1: test-project,test-topic
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - check-if-tests-needed
-      - pip-install-deps:
-          requirements: "tests/requirements.txt"
-      - run-tests-with-coverage-report
-      - store-pytest-results
-      - store-coverage-report
-
-  python312:
-    docker:
-      - image: public.ecr.aws/docker/library/python:3.12
-      - image: public.ecr.aws/docker/library/postgres:16.2-bookworm
-        environment:
-          POSTGRES_USER: root
-          POSTGRES_PASSWORD: passw0rd
-          POSTGRES_DB: instana_test_db
-      - image: public.ecr.aws/docker/library/mariadb:11.3.2
-        environment:
-          MYSQL_ROOT_PASSWORD: passw0rd
-          MYSQL_DATABASE: instana_test_db
-      - image: public.ecr.aws/docker/library/redis:7.2.4-bookworm
-      - image: public.ecr.aws/docker/library/rabbitmq:3.13.0
-      - image: public.ecr.aws/docker/library/mongo:7.0.6
-      - image: quay.io/thekevjames/gcloud-pubsub-emulator:latest
-        environment:
-          PUBSUB_EMULATOR_HOST: 0.0.0.0:8681
-          PUBSUB_PROJECT1: test-project,test-topic
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - check-if-tests-needed
-      - pip-install-deps:
-          requirements: "tests/requirements.txt"
-      - run-tests-with-coverage-report
-      - store-pytest-results
-      - store-coverage-report
-
-  py312aws:
-    docker:
-      - image: public.ecr.aws/docker/library/python:3.12
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - check-if-tests-needed
-      - pip-install-deps:
-          requirements: "tests/requirements-aws.txt"
-      - run-tests-with-coverage-report:
-          tests: "tests_aws"
-      - store-pytest-results
-      - store-coverage-report
-
-  py312autowrapt:
-    docker:
-      - image: public.ecr.aws/docker/library/python:3.12
-        environment:
-          AUTOWRAPT_BOOTSTRAP: instana
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - check-if-tests-needed
-      - pip-install-deps:
-          requirements: "tests/requirements-minimal.txt"
-      - run-tests-with-coverage-report:
-          tests: "tests_autowrapt"
-      - store-pytest-results
-      - store-coverage-report
-
-  py313autowrapt:
-    docker:
-      - image: public.ecr.aws/docker/library/python:3.13
-        environment:
-          AUTOWRAPT_BOOTSTRAP: instana
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - check-if-tests-needed
-      - pip-install-deps:
-          requirements: "tests/requirements-minimal.txt"
-      - run-tests-with-coverage-report:
-          tests: "tests_autowrapt"
-      - store-pytest-results
-      - store-coverage-report
-
-  python313:
-    docker:
-      - image: public.ecr.aws/docker/library/python:3.13
-      - image: public.ecr.aws/docker/library/postgres:16.2-bookworm
-        environment:
-          POSTGRES_USER: root
-          POSTGRES_PASSWORD: passw0rd
-          POSTGRES_DB: instana_test_db
-      - image: public.ecr.aws/docker/library/mariadb:11.3.2
-        environment:
-          MYSQL_ROOT_PASSWORD: passw0rd
-          MYSQL_DATABASE: instana_test_db
-      - image: public.ecr.aws/docker/library/redis:7.2.4-bookworm
-      - image: public.ecr.aws/docker/library/rabbitmq:3.13.0
-      - image: public.ecr.aws/docker/library/mongo:7.0.6
-      - image: quay.io/thekevjames/gcloud-pubsub-emulator:latest
-        environment:
-          PUBSUB_EMULATOR_HOST: 0.0.0.0:8681
-          PUBSUB_PROJECT1: test-project,test-topic
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - check-if-tests-needed
-      - pip-install-deps:
-          requirements: "tests/requirements.txt"
+      - pip-install-tests-deps
       - run-tests-with-coverage-report
       - store-pytest-results
       - store-coverage-report
 
   python314:
     docker:
-      - image: public.ecr.aws/docker/library/python:3.14.0a7
+      - image: ghcr.io/pvital/pvital-py3.14.0:latest
       - image: public.ecr.aws/docker/library/postgres:16.2-bookworm
         environment:
           POSTGRES_USER: root
@@ -362,8 +179,11 @@ jobs:
     steps:
       - checkout
       - check-if-tests-needed
-      - pip-install-deps:
-          requirements: "tests/requirements-pre314.txt"
+      - run: |
+          cp -a /root/base/venv ./venv
+          . venv/bin/activate
+          pip install 'wheel==0.45.1'
+          pip install -r requirements.txt
       - run-tests-with-coverage-report
       - store-pytest-results
       - store-coverage-report
@@ -379,25 +199,14 @@ jobs:
     steps:
       - checkout
       - check-if-tests-needed
-      - pip-install-deps:
+      - pip-install-deps
+      - pip-install-tests-deps:
           requirements: "tests/requirements-cassandra.txt"
       - run-tests-with-coverage-report:
           cassandra: "true"
           tests: "tests/clients/test_cassandra-driver.py"
       - store-pytest-results
       - store-coverage-report
-
-  final_job:
-    docker:
-      - image: public.ecr.aws/docker/library/python:3.9
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - check-if-tests-needed
-      - pip-install-deps:
-            requirements: "tests/requirements.txt"
-      - store-pytest-results
-      # - run_sonarqube
 
   py39gevent_starlette:
     docker:
@@ -406,13 +215,29 @@ jobs:
     steps:
       - checkout
       - check-if-tests-needed
-      - pip-install-deps:
+      - pip-install-deps
+      - pip-install-tests-deps:
           requirements: "tests/requirements-gevent-starlette.txt"
       - run-tests-with-coverage-report:
           # TODO: uncomment once gevent instrumentation is done
           # gevent: "true"
           # tests: "tests/frameworks/test_gevent.py tests/frameworks/test_starlette.py"
           tests: "tests/frameworks/test_starlette.py"
+      - store-pytest-results
+      - store-coverage-report
+
+  py312aws:
+    docker:
+      - image: public.ecr.aws/docker/library/python:3.12
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - check-if-tests-needed
+      - pip-install-deps
+      - pip-install-tests-deps:
+          requirements: "tests/requirements-aws.txt"
+      - run-tests-with-coverage-report:
+          tests: "tests_aws"
       - store-pytest-results
       - store-coverage-report
 
@@ -432,7 +257,8 @@ jobs:
     steps:
       - checkout
       - check-if-tests-needed
-      - pip-install-deps:
+      - pip-install-deps
+      - pip-install-tests-deps:
           requirements: "tests/requirements-kafka.txt"
       - run-tests-with-coverage-report:
           kafka: "true"
@@ -440,35 +266,61 @@ jobs:
       - store-pytest-results
       - store-coverage-report
 
+  autowrapt:
+    parameters:
+      py-version:
+        type: string
+    docker:
+      - image: public.ecr.aws/docker/library/python:<<parameters.py-version>>
+        environment:
+          AUTOWRAPT_BOOTSTRAP: instana
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - check-if-tests-needed
+      - pip-install-deps
+      - pip-install-tests-deps:
+          requirements: "tests/requirements-minimal.txt"
+      - run-tests-with-coverage-report:
+          tests: "tests_autowrapt"
+      - store-pytest-results
+      - store-coverage-report
+
+  final_job:
+    docker:
+      - image: public.ecr.aws/docker/library/python:3.9
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - check-if-tests-needed
+      - pip-install-deps
+      - pip-install-tests-deps
+      - store-pytest-results
+      # - run_sonarqube
+
 workflows:
-  version: 2
-  build:
+  tests:
     jobs:
-      - python38
-      - python39
-      - python310
-      - python311
-      - python312
-      - python313
+      - python3x:
+          matrix:
+            parameters:
+              py-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
       - python314
       - py39cassandra
       - py39gevent_starlette
       - py312aws
       - py312kafka
-      - py312autowrapt
-      - py313autowrapt
+      - autowrapt:
+          matrix:
+            parameters:
+              py-version: ["3.12", "3.13"]
       - final_job:
           requires:
-            - python38
-            - python39
-            - python310
-            - python311
-            - python312
-            - python313
+            - python3x
             # Uncomment the following when giving real support to 3.14
             # - python314
             - py39cassandra
             - py39gevent_starlette
             - py312aws
-            - py312autowrapt
-            - py313autowrapt
+            - py312kafka
+            - autowrapt

--- a/.github/workflows/py3140_build.yml
+++ b/.github/workflows/py3140_build.yml
@@ -1,0 +1,58 @@
+# This workflow builds a container image on top of the Python 3.14.0 RC images
+# with all dependencies already compiled and installed to be used in the tests
+# CI pipelines.
+
+name: Build Instana python-sensor-test-py3.14.0
+on:
+  workflow_dispatch:        # Manual trigger.
+  schedule:
+    - cron: '1 0 * * 1,3'   # Every Monday and Wednesday at midnight and one.
+env:
+  IMAGE_NAME: python-sensor-test-py3.14.0
+  IMAGE_TAG: latest
+  CONTAINER_FILE: ./Dockerfile-py3140
+  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+  REGISTRY_USER: ${{ github.actor }}
+  REGISTRY_PASSWORD: ${{ github.token }}
+jobs:
+  build-and-push:
+    name: Build container image.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+          tags: ${{ env.IMAGE_TAG }}
+          containerfiles: ${{ env.CONTAINER_FILE }}            
+
+      - name: Echo Outputs
+        run: |
+          echo "Image: ${{ steps.build_image.outputs.image }}"
+          echo "Tags: ${{ steps.build_image.outputs.tags }}"
+          echo "Tagged Image: ${{ steps.build_image.outputs.image-with-tag }}"
+
+      - name: Check images created
+        run: buildah images | grep '${{ env.IMAGE_NAME }}'
+
+      # Push the image to GHCR (Image Registry)
+      - name: Push To GHCR
+        uses: redhat-actions/push-to-registry@v2
+        id: push-to-ghcr
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          tags: ${{ steps.build_image.outputs.tags }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+          extra-args: |
+            --disable-content-trust
+
+      - name: Print image URL
+        run: echo "Image pushed to ${{ steps.push-to-ghcr.outputs.registry-paths }}"

--- a/Dockerfile-py3140
+++ b/Dockerfile-py3140
@@ -1,0 +1,20 @@
+FROM public.ecr.aws/docker/library/python:3.14.0b1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential python3-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV WORKDIR_=/root/base
+
+WORKDIR $WORKDIR_
+COPY ./tests/requirements-pre314.txt .
+
+ENV VIRTUAL_ENV="$WORKDIR_/venv"
+RUN python -m venv $VIRTUAL_ENV
+
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install -r requirements-pre314.txt

--- a/tests/clients/test_sqlalchemy.py
+++ b/tests/clients/test_sqlalchemy.py
@@ -22,6 +22,7 @@ Base = declarative_base()
 
 class StanUser(Base):
     __tablename__ = "churchofstan"
+    __allow_unmapped__ = True
 
     id = Column(Integer, primary_key=True)
     name = Column(String)

--- a/tests/requirements-pre314.txt
+++ b/tests/requirements-pre314.txt
@@ -40,3 +40,4 @@ tornado>=6.4.1
 uvicorn>=0.13.4
 urllib3>=1.26.5
 httpx>=0.27.0
+protobuf<=6.30.2


### PR DESCRIPTION
This PR proposes to fix the CircleCI failure when running the tests on top of Python 3.14.0. 

It uses a GitHub Actions workflow to build a container image with all test dependencies and publish it in the GitHub Container Registry every Monday and Wednesday at 00:01. This was pre-tested in a personal repository [here](https://github.com/pvital/stunning-octo-couscous).

In addition, this PR modified the CircleCI configuration file to use matrix parameters and point to the new container image as the base image to test Python 3.14.0.