### PR TITLE
fix/tekton: updated currency generation

### DIFF
--- a/.tekton/.currency/scripts/generate_report.py
+++ b/.tekton/.currency/scripts/generate_report.py
@@ -170,6 +170,7 @@ def get_taskruns(namespace, task_name, taskrun_filter, is_default_task=False):
     name_pattern = re.compile(r".*-(\d+)$")
 
     if is_default_task:
+        print(filtered_taskruns)
         filtered_taskruns.sort(
             key=lambda tr: int(name_pattern.search(tr["metadata"]["name"]).group(1)),
             reverse=True,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,8 @@
 -r requirements-minimal.txt
 aioamqp>=0.15.0
 aiofiles>=0.5.0
-aiohttp>=3.8.3
+aiohttp<=3.10.11; python_version <= "3.8"
+aiohttp>=3.10.11; python_version > "3.8"
 boto3>=1.17.74
 bottle>=0.12.25
 celery>=5.2.7


### PR DESCRIPTION
The latest version of aiohttp package is not supported for Python 3.8. Since the currency generation works for all python versions except 3.8 and we sort pipeline runs based on creation time, it was creating a currency record for aiohttp.

In this PR, I've changed the code to sort pipeline runs based on task numbers (so depending on python versions)