### PR TITLE
fix: add setuptools as dependency for Python >= 3.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,7 +313,7 @@ workflows:
       - autowrapt:
           matrix:
             parameters:
-              py-version: ["3.12", "3.13"]
+              py-version: ["3.11", "3.12", "3.13"]
       - final_job:
           requires:
             - python3x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "opentelemetry-api>=1.27.0",
     "opentelemetry-semantic-conventions>=0.48b0",
     "typing_extensions>=4.12.2",
+    "setuptools>=69.0.0; python_version >= \"3.12\"", 
 ]
 
 [project.entry-points."instana"]

--- a/tests/requirements-minimal.txt
+++ b/tests/requirements-minimal.txt
@@ -1,3 +1,2 @@
 coverage>=5.5
 pytest>=4.6
-setuptools


### PR DESCRIPTION
The `autowrapt` has a cross in-code dependency on `setuptools` which are not solved by the authors. This fix adds the package `setuptools` as dependency for environments running Python >= 3.12 to prevent issues when instrumenting with the `AUTOWRAPT_BOOTSTRAP` variable.