### PR TITLE
Fix: CI errors with sanic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,16 +50,13 @@ if sys.version_info >= (3, 12):
     collect_ignore_glob.append("*test_spyne*")
 
 
-if sys.version_info >= (3, 13):
-    # Currently not installable dependencies because of 3.13 incompatibilities
-    collect_ignore_glob.append("*test_sanic*")
-
-
 if sys.version_info >= (3, 14):
     # Currently not installable dependencies because of 3.14 incompatibilities
     collect_ignore_glob.append("*test_fastapi*")
     # aiohttp-server tests failing due to deprecated methods used
     collect_ignore_glob.append("*test_aiohttp_server*")
+    # Currently Saniic does not support python >= 3.14
+    collect_ignore_glob.append("*test_sanic*")
 
 
 @pytest.fixture(scope="session")

--- a/tests/requirements-pre314.txt
+++ b/tests/requirements-pre314.txt
@@ -31,10 +31,9 @@ pytz>=2024.1
 redis>=3.5.3
 requests-mock
 responses<=0.17.0
-# Sanic is not installable on 3.13 because `httptools, uvloop` dependencies fail to compile:
-# `too few arguments to function ‘_PyLong_AsByteArray’`
-sanic>=19.9.0; python_version < "3.13"
-sanic-testing>=24.6.0; python_version < "3.13"
+# Sanic doesn't support python-3.14 yet
+# sanic>=19.9.0
+# sanic-testing>=24.6.0
 starlette>=0.38.2
 sqlalchemy>=2.0.0
 tornado>=6.4.1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -40,6 +40,7 @@ spyne>=2.14.0; python_version < "3.12"
 sqlalchemy>=2.0.0
 starlette>=0.38.2; python_version == "3.13"
 tornado>=6.4.1
+tracerite<=1.1.1
 uvicorn>=0.13.4
 urllib3>=1.26.5
 httpx>=0.27.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -31,11 +31,9 @@ pytz>=2024.1
 redis>=3.5.3
 requests-mock
 responses<=0.17.0
-# Sanic is not installable on 3.13 because `httptools, uvloop` dependencies fail to compile:
-# `too few arguments to function ‘_PyLong_AsByteArray’`
 sanic<=24.6.0; python_version < "3.9"
-sanic>=19.9.0; python_version >= "3.9" and python_version < "3.13"
-sanic-testing>=24.6.0; python_version < "3.13"
+sanic>=19.9.0; python_version >= "3.9"
+sanic-testing>=24.6.0
 spyne>=2.14.0; python_version < "3.12"
 sqlalchemy>=2.0.0
 starlette>=0.38.2; python_version == "3.13"


### PR DESCRIPTION
``` python
venv/lib/python3.9/site-packages/sanic/pages/error.py:4: in <module>
    import tracerite.html
venv/lib/python3.9/site-packages/tracerite/__init__.py:1: in <module>
    from .html import html_traceback
venv/lib/python3.9/site-packages/tracerite/html.py:3: in <module>
    from .trace import extract_chain
venv/lib/python3.9/site-packages/tracerite/trace.py:11: in <module>
    from .inspector import extract_variables
E     File "/root/repo/venv/lib/python3.9/site-packages/tracerite/inspector.py", line 119
E       except AttributeError, TypeError:
E                            ^
E   SyntaxError: invalid syntax
```

Error comes from [this](https://github.com/sanic-org/tracerite/pull/17/files#diff-5d409ed00bbdfa1af787bb228eada817ee27013f88370edde4698bc86f9ad9b0R122) change that was released in the latest version (1.1.2) 5 hours ago in `tracerite` (`sanic`'s dependency)