### PR TITLE
ci: Revert temporary fix for failures caused by `sanic` for `python>3.8`

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -38,7 +38,7 @@ spyne>=2.14.0; python_version < "3.12"
 sqlalchemy>=2.0.0
 starlette>=0.38.2; python_version == "3.13"
 tornado>=6.4.1
-tracerite<=1.1.1
+tracerite<=1.1.1; python_version < "3.9"
 uvicorn>=0.13.4
 urllib3>=1.26.5
 httpx>=0.27.0


### PR DESCRIPTION
New `tracerite` version `1.1.3` with the fix for [this](https://github.com/sanic-org/tracerite/issues/20) bug has been released. But a different bug still exists in `tracerite-1.1.2` for python version `3.8`

```python
venv/lib/python3.8/site-packages/sanic/errorpages.py:27: in <module>
    from sanic.pages.error import ErrorPage
venv/lib/python3.8/site-packages/sanic/pages/error.py:3: in <module>
    import tracerite.html
venv/lib/python3.8/site-packages/tracerite/__init__.py:1: in <module>
    from .html import html_traceback
venv/lib/python3.8/site-packages/tracerite/html.py:5: in <module>
    from importlib.resources import files
E   ImportError: cannot import name 'files' from 'importlib.resources' (/usr/local/lib/python3.8/importlib/resources.py)
``` 

Signed-off-by: Varsha GS <varsha.gs@ibm.com>