### PR TITLE
Update InstanaTracer to utilize kind argument

### DIFF
--- a/src/instana/tracer.py
+++ b/src/instana/tracer.py
@@ -138,6 +138,10 @@ class InstanaTracer(Tracer):
             # events: Sequence[Event] = None,
         )
 
+        # Auto add span kind if provided
+        if kind:
+            span.set_attribute("span.kind", kind)
+
         if name in EXIT_SPANS:
             self._add_stack(span)
 


### PR DESCRIPTION
Hello,

I am working on instrumenting an application with instana and I was really confused on why the `kind` argument was not working for setting span kinds. I then realized it's because it's not used! This PR fixes that and automatically adds the kind if one was provided