### PR TITLE
ci: Improve Kafka CI pipeline.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,9 +241,12 @@ jobs:
       - store-pytest-results
       - store-coverage-report
 
-  py312kafka:
+  pykafka:
+    parameters:
+      py-version:
+        type: string
     docker:
-      - image: public.ecr.aws/docker/library/python:3.12
+      - image: public.ecr.aws/docker/library/python:<<parameters.py-version>>
       - image: public.ecr.aws/bitnami/kafka:3.9.0
         environment:
           KAFKA_CFG_NODE_ID: 0
@@ -309,7 +312,10 @@ workflows:
       - py39cassandra
       - py39gevent_starlette
       - py312aws
-      - py312kafka
+      - pykafka:
+          matrix:
+            parameters:
+              py-version: ["3.11", "3.12", "3.13"]
       - autowrapt:
           matrix:
             parameters:
@@ -322,5 +328,5 @@ workflows:
             - py39cassandra
             - py39gevent_starlette
             - py312aws
-            - py312kafka
+            - pykafka
             - autowrapt

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -92,10 +92,11 @@ spec:
         - clone
       matrix:
         params:
-          - name: imageDigest
+          - name: pythonVersion
             value:
-              # public.ecr.aws/docker/library/python:3.12.10-bookworm
-              - "sha256:4ea730e54e2a87b716ffc58a426bd627baa182a3d4d5696d05c1bca2dde775aa"
+              - "3.11"
+              - "3.12"
+              - "3.13"
       taskRef:
         name: python-tracer-unittest-kafka-task
       workspaces:

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -175,8 +175,7 @@ metadata:
 spec:
   sidecars:
     - name: kafka
-      # public.ecr.aws/bitnami/kafka:3.9.0
-      image: public.ecr.aws/bitnami/kafka@sha256:d2890d68f96b36da3c8413fa94294f018b2f95d87cf108cbf71eab510572d9be
+      image: public.ecr.aws/bitnami/kafka:3.9
       env:
         - name: KAFKA_CFG_NODE_ID
           value: "0"
@@ -193,14 +192,14 @@ spec:
         - name: KAFKA_CFG_ADVERTISED_LISTENERS
           value: "PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094"
   params:
-  - name: imageDigest
+  - name: pythonVersion
     type: string
   workspaces:
     - name: task-pvc
       mountPath: /workspace
   steps:
     - name: unittest
-      image: public.ecr.aws/docker/library/python@$(params.imageDigest)
+      image: public.ecr.aws/docker/library/python@$(params.pythonVersion)
       env:
         - name: TEST_CONFIGURATION
           value: kafka


### PR DESCRIPTION
Since we have constrains to install `kafka-python` depending on the Python runtime, this commit improves the CI pipeline to test in Python versions >= 3.11.

Signed-off-by: Paulo Vital <paulo.vital@ibm.com>