### PR TITLE
feat(config): add support for multiple boolean formats in environment variables.

### DIFF
--- a/src/instana/util/config.py
+++ b/src/instana/util/config.py
@@ -146,3 +146,34 @@ def parse_ignored_endpoints_from_yaml(file_path: str) -> List[str]:
         return ignored_endpoints
     else:
         return []
+
+
+def is_truthy(value: Any) -> bool:
+    """
+    Check if a value is truthy, accepting various formats.
+    
+    @param value: The value to check
+    @return: True if the value is considered truthy, False otherwise
+    
+    Accepts the following as True:
+    - True (Python boolean)
+    - "True", "true" (case-insensitive string)
+    - "1" (string)
+    - 1 (integer)
+    """
+    if value is None:
+        return False
+    
+    if isinstance(value, bool):
+        return value
+    
+    if isinstance(value, int):
+        return value == 1
+    
+    if isinstance(value, str):
+        value_lower = value.lower()
+        return value_lower == "true" or value == "1"
+    
+    return False
+
+# Made with Bob

--- a/tests/util/test_config.py
+++ b/tests/util/test_config.py
@@ -1,12 +1,11 @@
 # (c) Copyright IBM Corp. 2025
 
-from instana.util.config import (
-    parse_endpoints_of_service,
-    parse_ignored_endpoints,
-    parse_ignored_endpoints_dict,
-    parse_kafka_methods,
-    parse_service_pair,
-)
+import pytest
+
+from instana.util.config import (is_truthy, parse_endpoints_of_service,
+                                 parse_ignored_endpoints,
+                                 parse_ignored_endpoints_dict,
+                                 parse_kafka_methods, parse_service_pair)
 
 
 class TestConfig:
@@ -168,3 +167,24 @@ class TestConfig:
         test_rule_as_str = ["send"]
         parsed_rule = parse_kafka_methods(test_rule_as_str)
         assert parsed_rule == ["kafka.send.*"]
+        
+    @pytest.mark.parametrize("value, expected", [
+        (True, True),
+        (False, False),
+        ("True", True),
+        ("true", True),
+        ("1", True),
+        (1, True),
+        ("False", False),
+        ("false", False),
+        ("0", False),
+        (0, False),
+        (None, False),
+        ("TRUE", True),
+        ("FALSE", False),
+        ("yes", False),  # Only "true" and "1" are considered truthy
+        ("no", False),
+    ])
+    def test_is_truthy(self, value, expected) -> None:
+        """Test the is_truthy function with various input values."""
+        assert is_truthy(value) == expected


### PR DESCRIPTION
Add `is_truthy()` function to accept `True`, `true`, and `1` as boolean `True` values when reading environment variables. This makes configuration more flexible and user-friendly.

- Add new `is_truthy()` utility function in config.py
- Update environment variable checks in options.py to use the new function
- Add parametrized tests to verify functionality with various input values

Signed-off-by: Paulo Vital <paulo.vital@ibm.com>