### PR TITLE
Remove six package and its usage since Python 2 is no longer supported

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
     "autowrapt>=1.0",
     "fysom>=2.1.2",
     "requests>=2.6.0",
-    "six>=1.12.0",
     "urllib3>=1.26.5",
     "opentelemetry-api>=1.27.0",
     "opentelemetry-semantic-conventions>=0.48b0",

--- a/src/instana/span/base_span.py
+++ b/src/instana/span/base_span.py
@@ -1,7 +1,6 @@
 # (c) Copyright IBM Corp. 2024
 
 from typing import TYPE_CHECKING, Type
-import six
 
 from instana.log import logger
 from instana.util import DictionaryOfStan
@@ -83,12 +82,12 @@ class BaseSpan(object):
 
         try:
             # Attribute keys must be some type of text or string type
-            if isinstance(key, (six.text_type, six.string_types)):
+            if isinstance(key, str):
                 validated_key = key[0:1024]  # Max key length of 1024 characters
 
                 if isinstance(
                     value,
-                    (bool, float, int, list, dict, six.text_type, six.string_types),
+                    (bool, float, int, list, dict, str),
                 ):
                     validated_value = value
                 else:

--- a/tests/clients/test_google-cloud-pubsub.py
+++ b/tests/clients/test_google-cloud-pubsub.py
@@ -7,7 +7,6 @@ import time
 from typing import Generator
 
 import pytest
-import six
 from google.api_core.exceptions import AlreadyExists
 from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
 from google.cloud.pubsub_v1.publisher import exceptions
@@ -51,7 +50,7 @@ class TestPubSubPublish(_TraceContextMixin):
             )
         time.sleep(2.0)  # for sanity
         result = future.result()
-        assert isinstance(result, six.string_types)
+        assert isinstance(result, str)
 
         spans = self.recorder.queued_spans()
         gcps_span, test_span = spans[0], spans[1]
@@ -80,7 +79,7 @@ class TestPubSubPublish(_TraceContextMixin):
         )
         time.sleep(2.0)  # for sanity
         result = future.result()
-        assert isinstance(result, six.string_types)
+        assert isinstance(result, str)
 
         spans = self.recorder.queued_spans()
         assert len(spans) == 1
@@ -161,7 +160,7 @@ class TestPubSubSubscribe(_TraceContextMixin):
             future = self.publisher.publish(
                 self.topic_path, b"Test Message to PubSub", origin="instana"
             )
-            assert isinstance(future.result(), six.string_types)
+            assert isinstance(future.result(), str)
 
             time.sleep(2.0)  # for sanity
 

--- a/tests/clients/test_google-cloud-storage.py
+++ b/tests/clients/test_google-cloud-storage.py
@@ -14,7 +14,7 @@ from tests.test_utils import _TraceContextMixin
 from opentelemetry.trace import SpanKind
 
 from mock import patch, Mock
-from six.moves import http_client
+from http import client as http_client
 
 from google.cloud import storage
 from google.api_core import iam, page_iterator


### PR DESCRIPTION
The package `six` was used to bridge the gap between Python 2 and Python 3 but since we have removed support for Python 2 long back, it would only make sense to completely remove its usage from our codebase.