### PR TITLE
Fix announce of processes on Windows.

### DIFF
--- a/src/instana/agent/host.py
+++ b/src/instana/agent/host.py
@@ -9,7 +9,7 @@ monitoring state and reporting that data.
 import json
 import os
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import requests
 import urllib3
@@ -17,13 +17,16 @@ from requests import Response
 
 from instana.agent.base import BaseAgent
 from instana.collector.host import HostCollector
-from instana.fsm import Discovery, TheMachine
+from instana.fsm import TheMachine
 from instana.log import logger
 from instana.options import StandardOptions
 from instana.util import to_json
 from instana.util.runtime import get_py_source, log_runtime_env_info
 from instana.util.span_utils import get_operation_specifiers
 from instana.version import VERSION
+
+if TYPE_CHECKING:
+    from instana.util.process_discovery import Discovery
 
 
 class AnnounceData(object):
@@ -176,7 +179,7 @@ class HostAgent(BaseAgent):
 
     def announce(
         self,
-        discovery: Discovery,
+        discovery: "Discovery",
     ) -> Optional[Dict[str, Any]]:
         """
         With the passed in Discovery class, attempt to announce to the host agent.

--- a/src/instana/fsm.py
+++ b/src/instana/fsm.py
@@ -8,45 +8,22 @@ import socket
 import subprocess
 import sys
 import threading
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable
 
 from fysom import Fysom
 
 from instana.log import logger
 from instana.util import get_default_gateway
+from instana.util.process_discovery import Discovery
 from instana.version import VERSION
 
 if TYPE_CHECKING:
     from instana.agent.host import HostAgent
 
 
-class Discovery:
-    pid: int = 0
-    name: Optional[str] = None
-    args: Optional[List[str]] = None
-    fd: int = -1
-    inode: str = ""
-
-    def __init__(self, **kwds: Any) -> None:
-        self.__dict__.update(kwds)
-
-    def to_dict(self) -> Dict[str, Any]:
-        kvs: Dict[str, Any] = dict()
-        kvs["pid"] = self.pid
-        kvs["name"] = self.name
-        kvs["args"] = self.args
-        kvs["fd"] = self.fd
-        kvs["inode"] = self.inode
-        return kvs
-
-
 class TheMachine:
     RETRY_PERIOD = 30
     THREAD_NAME = "Instana Machine"
-
-    agent: Optional["HostAgent"] = None
-    fsm = None
-    timer = None
 
     warnedPeriodic = False
 

--- a/src/instana/fsm.py
+++ b/src/instana/fsm.py
@@ -8,13 +8,14 @@ import socket
 import subprocess
 import sys
 import threading
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, List
 
 from fysom import Fysom
 
 from instana.log import logger
 from instana.util import get_default_gateway
 from instana.util.process_discovery import Discovery
+from instana.util.runtime import is_windows
 from instana.version import VERSION
 
 if TYPE_CHECKING:
@@ -103,48 +104,16 @@ class TheMachine:
         return False
 
     def announce_sensor(self, e: Any) -> bool:
+        pid: int = os.getpid()
         logger.debug(
-            f"Attempting to make an announcement to the agent on {self.agent.options.agent_host}:{self.agent.options.agent_port}"
+            f"Attempting to announce PID {pid} to the agent on {self.agent.options.agent_host}:{self.agent.options.agent_port}"
         )
-        pid = os.getpid()
 
-        try:
-            if os.path.isfile("/proc/self/cmdline"):
-                with open("/proc/self/cmdline") as cmd:
-                    cmdinfo = cmd.read()
-                cmdline = cmdinfo.split("\x00")
-            else:
-                # Python doesn't provide a reliable method to determine what
-                # the OS process command line may be.  Here we are forced to
-                # rely on ps rather than adding a dependency on something like
-                # psutil which requires dev packages, gcc etc...
-                proc = subprocess.Popen(
-                    ["ps", "-p", str(pid), "-o", "command"], stdout=subprocess.PIPE
-                )
-                (out, _) = proc.communicate()
-                parts = out.split(b"\n")
-                cmdline = [parts[1].decode("utf-8")]
-        except Exception:
-            cmdline = sys.argv
-            logger.debug("announce_sensor", exc_info=True)
+        cmdline = self._get_cmdline(pid)
 
         d = Discovery(pid=self.__get_real_pid(), name=cmdline[0], args=cmdline[1:])
 
-        # If we're on a system with a procfs
-        if os.path.exists("/proc/"):
-            try:
-                # In CentOS 7, some odd things can happen such as:
-                # PermissionError: [Errno 13] Permission denied: '/proc/6/fd/8'
-                # Use a try/except as a safety
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                sock.connect(
-                    (self.agent.options.agent_host, self.agent.options.agent_port)
-                )
-                path = f"/proc/{pid}/fd/{sock.fileno()}"
-                d.fd = sock.fileno()
-                d.inode = os.readlink(path)
-            except:  # noqa: E722
-                logger.debug("Error generating file descriptor: ", exc_info=True)
+        self._setup_socket_connection(d, pid)
 
         payload = self.agent.announce(d)
 
@@ -189,28 +158,112 @@ class TheMachine:
     def __get_real_pid(self) -> int:
         """
         Attempts to determine the true process ID by querying the
-        /proc/<pid>/sched file.  This works on systems with a proc filesystem.
-        Otherwise default to os default.
+        /proc/<pid>/sched file on Linux systems or using the OS default PID.
+        For Windows, we use the standard OS PID as there's no equivalent concept
+        of container PIDs vs host PIDs.
         """
         pid = None
 
+        # For Linux systems with procfs
         if os.path.exists("/proc/"):
             sched_file = f"/proc/{os.getpid()}/sched"
 
             if os.path.isfile(sched_file):
                 try:
-                    file = open(sched_file)
-                    line = file.readline()
-                    g = re.search(r"\((\d+),", line)
-                    if g and len(g.groups()) == 1:
-                        pid = int(g.groups()[0])
+                    with open(sched_file) as file:
+                        line = file.readline()
+                        g = re.search(r"\((\d+),", line)
+                        if g and len(g.groups()) == 1:
+                            pid = int(g.groups()[0])
                 except Exception:
                     logger.debug("parsing sched file failed", exc_info=True)
 
+        # For Windows or if Linux method failed
         if pid is None:
             pid = os.getpid()
 
         return pid
+
+    def _get_cmdline_windows(self) -> List[str]:
+        """
+        Get command line using Windows API
+        """
+        import ctypes
+        from ctypes import wintypes
+
+        GetCommandLineW = ctypes.windll.kernel32.GetCommandLineW
+        GetCommandLineW.argtypes = []
+        GetCommandLineW.restype = wintypes.LPCWSTR
+
+        cmd = GetCommandLineW()
+        # Simple parsing - this is a basic approach and might need refinement
+        # for complex command lines with quotes and spaces
+        return cmd.split()
+
+    def _get_cmdline_linux_proc(self) -> List[str]:
+        """
+        Get command line from Linux /proc filesystem
+        """
+        with open("/proc/self/cmdline") as cmd:
+            cmdinfo = cmd.read()
+        return cmdinfo.split("\x00")
+
+    def _get_cmdline_unix_ps(self, pid: int) -> List[str]:
+        """
+        Get command line using ps command (for Unix-like systems without /proc)
+        """
+        proc = subprocess.Popen(
+            ["ps", "-p", str(pid), "-o", "command"], stdout=subprocess.PIPE
+        )
+        (out, _) = proc.communicate()
+        parts = out.split(b"\n")
+        return [parts[1].decode("utf-8")]
+
+    def _get_cmdline_unix(self, pid: int) -> List[str]:
+        """
+        Get command line using Unix
+        """
+        if os.path.isfile("/proc/self/cmdline"):
+            return self._get_cmdline_linux_proc()
+        else:
+            return self._get_cmdline_unix_ps(pid)
+
+    def _get_cmdline(self, pid: int) -> List[str]:
+        """
+        Get command line in a platform-independent way
+        """
+        try:
+            if is_windows():
+                return self._get_cmdline_windows()
+            else:
+                return self._get_cmdline_unix(pid)
+        except Exception:
+            logger.debug("Error getting command line", exc_info=True)
+            return sys.argv
+
+    def _setup_socket_connection(self, discovery: Discovery, pid: int) -> None:
+        """
+        Set up socket connection and populate discovery object with socket details
+        """
+        try:
+            # In CentOS 7, some odd things can happen such as:
+            # PermissionError: [Errno 13] Permission denied: '/proc/6/fd/8'
+            # Use a try/except as a safety
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.connect((self.agent.options.agent_host, self.agent.options.agent_port))
+            discovery.fd = sock.fileno()
+
+            # If we're on a system with a procfs (Linux)
+            if os.path.exists("/proc/"):
+                try:
+                    path = "/proc/%d/fd/%d" % (pid, sock.fileno())
+                    discovery.inode = os.readlink(path)
+                except Exception:
+                    logger.debug(
+                        "Error generating file descriptor inode: ", exc_info=True
+                    )
+        except Exception:
+            logger.debug("Error creating socket connection: ", exc_info=True)
 
 
 # Made with Bob

--- a/src/instana/fsm.py
+++ b/src/instana/fsm.py
@@ -8,61 +8,70 @@ import socket
 import subprocess
 import sys
 import threading
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from fysom import Fysom
 
-from .log import logger
-from .util import get_default_gateway
-from .version import VERSION
+from instana.log import logger
+from instana.util import get_default_gateway
+from instana.version import VERSION
+
+if TYPE_CHECKING:
+    from instana.agent.host import HostAgent
 
 
-class Discovery(object):
-    pid = 0
-    name = None
-    args = None
-    fd = -1
-    inode = ""
+class Discovery:
+    pid: int = 0
+    name: Optional[str] = None
+    args: Optional[List[str]] = None
+    fd: int = -1
+    inode: str = ""
 
-    def __init__(self, **kwds):
+    def __init__(self, **kwds: Any) -> None:
         self.__dict__.update(kwds)
 
-    def to_dict(self):
-        kvs = dict()
-        kvs['pid'] = self.pid
-        kvs['name'] = self.name
-        kvs['args'] = self.args
-        kvs['fd'] = self.fd
-        kvs['inode'] = self.inode
+    def to_dict(self) -> Dict[str, Any]:
+        kvs: Dict[str, Any] = dict()
+        kvs["pid"] = self.pid
+        kvs["name"] = self.name
+        kvs["args"] = self.args
+        kvs["fd"] = self.fd
+        kvs["inode"] = self.inode
         return kvs
 
 
-class TheMachine(object):
+class TheMachine:
     RETRY_PERIOD = 30
     THREAD_NAME = "Instana Machine"
 
-    agent = None
+    agent: Optional["HostAgent"] = None
     fsm = None
     timer = None
 
     warnedPeriodic = False
 
-    def __init__(self, agent):
+    def __init__(self, agent: "HostAgent") -> None:
         logger.debug("Initializing host agent state machine")
 
         self.agent = agent
-        self.fsm = Fysom({
-            "events": [
-                ("lookup",   "*",            "found"),
-                ("announce", "found",        "announced"),
-                ("pending",  "announced",    "wait4init"),
-                ("ready",    "wait4init",    "good2go")],
-            "callbacks": {
-                # Can add the following to debug
-                # "onchangestate":  self.print_state_change,
-                "onlookup":       self.lookup_agent_host,
-                "onannounce":     self.announce_sensor,
-                "onpending":      self.on_ready,
-                "ongood2go":      self.on_good2go}})
+        self.fsm = Fysom(
+            {
+                "events": [
+                    ("lookup", "*", "found"),
+                    ("announce", "found", "announced"),
+                    ("pending", "announced", "wait4init"),
+                    ("ready", "wait4init", "good2go"),
+                ],
+                "callbacks": {
+                    # Can add the following to debug
+                    # "onchangestate":  self.print_state_change,
+                    "onlookup": self.lookup_agent_host,
+                    "onannounce": self.announce_sensor,
+                    "onpending": self.on_ready,
+                    "ongood2go": self.on_good2go,
+                },
+            }
+        )
 
         self.timer = threading.Timer(1, self.fsm.lookup)
         self.timer.daemon = True
@@ -70,11 +79,12 @@ class TheMachine(object):
         self.timer.start()
 
     @staticmethod
-    def print_state_change(e):
-        logger.debug('========= (%i#%s) FSM event: %s, src: %s, dst: %s ==========',
-                     os.getpid(), threading.current_thread().name, e.event, e.src, e.dst)
+    def print_state_change(e: Any) -> None:
+        logger.debug(
+            f"========= ({os.getpid()}#{threading.current_thread().name}) FSM event: {e.event}, src: {e.src}, dst: {e.dst} =========="
+        )
 
-    def reset(self):
+    def reset(self) -> None:
         """
         reset is called to start from scratch in a process.  It may be called on first boot or
         after a detected fork.
@@ -87,7 +97,7 @@ class TheMachine(object):
         logger.debug("State machine being reset.  Will start a new announce cycle.")
         self.fsm.lookup()
 
-    def lookup_agent_host(self, e):
+    def lookup_agent_host(self, e: Any) -> bool:
         host = self.agent.options.agent_host
         port = self.agent.options.agent_port
 
@@ -105,39 +115,43 @@ class TheMachine(object):
                     return True
 
         if self.warnedPeriodic is False:
-            logger.info("Instana Host Agent couldn't be found. Will retry periodically...")
+            logger.info(
+                "Instana Host Agent couldn't be found. Will retry periodically..."
+            )
             self.warnedPeriodic = True
 
-        self.schedule_retry(self.lookup_agent_host, e, self.THREAD_NAME + ": agent_lookup")
+        self.schedule_retry(
+            self.lookup_agent_host, e, f"{self.THREAD_NAME}: agent_lookup"
+        )
         return False
 
-    def announce_sensor(self, e):
-        logger.debug("Attempting to make an announcement to the agent on %s:%d",
-                     self.agent.options.agent_host, self.agent.options.agent_port)
+    def announce_sensor(self, e: Any) -> bool:
+        logger.debug(
+            f"Attempting to make an announcement to the agent on {self.agent.options.agent_host}:{self.agent.options.agent_port}"
+        )
         pid = os.getpid()
 
         try:
             if os.path.isfile("/proc/self/cmdline"):
                 with open("/proc/self/cmdline") as cmd:
                     cmdinfo = cmd.read()
-                cmdline = cmdinfo.split('\x00')
+                cmdline = cmdinfo.split("\x00")
             else:
                 # Python doesn't provide a reliable method to determine what
                 # the OS process command line may be.  Here we are forced to
                 # rely on ps rather than adding a dependency on something like
                 # psutil which requires dev packages, gcc etc...
-                proc = subprocess.Popen(["ps", "-p", str(pid), "-o", "command"],
-                                        stdout=subprocess.PIPE)
+                proc = subprocess.Popen(
+                    ["ps", "-p", str(pid), "-o", "command"], stdout=subprocess.PIPE
+                )
                 (out, _) = proc.communicate()
-                parts = out.split(b'\n')
+                parts = out.split(b"\n")
                 cmdline = [parts[1].decode("utf-8")]
         except Exception:
             cmdline = sys.argv
             logger.debug("announce_sensor", exc_info=True)
 
-        d = Discovery(pid=self.__get_real_pid(),
-                      name=cmdline[0],
-                      args=cmdline[1:])
+        d = Discovery(pid=self.__get_real_pid(), name=cmdline[0], args=cmdline[1:])
 
         # If we're on a system with a procfs
         if os.path.exists("/proc/"):
@@ -146,47 +160,56 @@ class TheMachine(object):
                 # PermissionError: [Errno 13] Permission denied: '/proc/6/fd/8'
                 # Use a try/except as a safety
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                sock.connect((self.agent.options.agent_host, self.agent.options.agent_port))
-                path = "/proc/%d/fd/%d" % (pid, sock.fileno())
+                sock.connect(
+                    (self.agent.options.agent_host, self.agent.options.agent_port)
+                )
+                path = f"/proc/{pid}/fd/{sock.fileno()}"
                 d.fd = sock.fileno()
                 d.inode = os.readlink(path)
-            except:
+            except:  # noqa: E722
                 logger.debug("Error generating file descriptor: ", exc_info=True)
 
         payload = self.agent.announce(d)
 
         if not payload:
             logger.debug("Cannot announce sensor. Scheduling retry.")
-            self.schedule_retry(self.announce_sensor, e, self.THREAD_NAME + ": announce")
+            self.schedule_retry(
+                self.announce_sensor, e, f"{self.THREAD_NAME}: announce"
+            )
             return False
-        
+
         self.agent.set_from(payload)
         self.fsm.pending()
-        logger.debug("Announced pid: %s (true pid: %s).  Waiting for Agent Ready...",
-                     str(pid), str(self.agent.announce_data.pid))
+        logger.debug(
+            f"Announced PID: {pid} (true PID: {self.agent.announce_data.pid}).  Waiting for Agent Ready..."
+        )
         return True
 
-    def schedule_retry(self, fun, e, name):
+    def schedule_retry(self, fun: Callable, e: Any, name: str) -> None:
         self.timer = threading.Timer(self.RETRY_PERIOD, fun, [e])
         self.timer.daemon = True
         self.timer.name = name
         self.timer.start()
 
-    def on_ready(self, _):
+    def on_ready(self, _: Any) -> None:
         self.agent.start()
 
         ns_pid = str(os.getpid())
         true_pid = str(self.agent.announce_data.pid)
 
-        logger.info("Instana host agent available. We're in business. Announced PID: %s (true pid: %s)", ns_pid, true_pid)
+        logger.info(
+            f"Instana host agent available. We're in business. Announced PID: {ns_pid} (true PID: {true_pid})"
+        )
 
-    def on_good2go(self, _):
+    def on_good2go(self, _: Any) -> None:
         ns_pid = str(os.getpid())
         true_pid = str(self.agent.announce_data.pid)
 
-        self.agent.log_message_to_host_agent("Instana Python Package %s: PID %s (true pid: %s) is now online and reporting" % (VERSION, ns_pid, true_pid))
+        self.agent.log_message_to_host_agent(
+            f"Instana Python Package {VERSION}: PID {ns_pid} (true PID: {true_pid}) is now online and reporting"
+        )
 
-    def __get_real_pid(self):
+    def __get_real_pid(self) -> int:
         """
         Attempts to determine the true process ID by querying the
         /proc/<pid>/sched file.  This works on systems with a proc filesystem.
@@ -195,14 +218,14 @@ class TheMachine(object):
         pid = None
 
         if os.path.exists("/proc/"):
-            sched_file = "/proc/%d/sched" % os.getpid()
+            sched_file = f"/proc/{os.getpid()}/sched"
 
             if os.path.isfile(sched_file):
                 try:
                     file = open(sched_file)
                     line = file.readline()
-                    g = re.search(r'\((\d+),', line)
-                    if len(g.groups()) == 1:
+                    g = re.search(r"\((\d+),", line)
+                    if g and len(g.groups()) == 1:
                         pid = int(g.groups()[0])
                 except Exception:
                     logger.debug("parsing sched file failed", exc_info=True)
@@ -211,3 +234,6 @@ class TheMachine(object):
             pid = os.getpid()
 
         return pid
+
+
+# Made with Bob

--- a/src/instana/util/process_discovery.py
+++ b/src/instana/util/process_discovery.py
@@ -1,0 +1,13 @@
+# (c) Copyright IBM Corp. 2025
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class Discovery:
+    pid: int = 0  # the PID of this process
+    name: Optional[str] = None  # the name of the executable
+    args: Optional[List[str]] = None  # the command line arguments
+    fd: int = -1  # the file descriptor of the socket associated with the connection to the agent for this HTTP request
+    inode: str = ""  # the inode of the socket associated with the connection to the agent for this HTTP request

--- a/tests/agent/test_host.py
+++ b/tests/agent/test_host.py
@@ -14,12 +14,13 @@ from mock import MagicMock, patch
 
 from instana.agent.host import AnnounceData, HostAgent
 from instana.collector.host import HostCollector
-from instana.fsm import Discovery, TheMachine
+from instana.fsm import TheMachine
 from instana.options import StandardOptions
 from instana.recorder import StanRecorder
 from instana.singletons import get_agent
 from instana.span.span import InstanaSpan
 from instana.span_context import SpanContext
+from instana.util.process_discovery import Discovery
 from instana.util.runtime import is_windows
 
 
@@ -714,4 +715,5 @@ class TestHostAgent:
         assert not self.agent._HostAgent__is_endpoint_ignored("service2", "method2")
 
         # don't ignore other services
+        assert not self.agent._HostAgent__is_endpoint_ignored("service3")
         assert not self.agent._HostAgent__is_endpoint_ignored("service3")


### PR DESCRIPTION
This PR:

1. Format the `TheMachine` and `Discovery` classes by adding type annotations to the `fsm.py` file and using `ruff`.
2. Refactor the `Discovery` class by changing it to a `DataClass`, and move it out of the fsm.py file.
3. Add support to announce Windows processes. The implementation gracefully handles platform differences, ensuring consistent process information on both Unix and Windows environments:
- Created a new `_get_cmdline()` function to return the command line of the current monitored process independently of the running platform.
- Created the `_get_cmdline_windows()` function to return the command line on Windows machines.
- Created `_get_cmdline_unix()` that returns the command line in Unix machines. It decides how to collect the information by running either the ` _get_cmdline_linux_proc()` or the `_get_cmdline_unix_ps()`.
- Refactored the `_setup_socket_connection()` function.

Signed-off-by: Paulo Vital <paulo.vital@ibm.com>