### PR TITLE
Disabling log collection at the tracer level

### DIFF
--- a/src/instana/__init__.py
+++ b/src/instana/__init__.py
@@ -20,6 +20,7 @@ from instana.collector.helpers.runtime import (
     is_autowrapt_instrumented,
     is_webhook_instrumented,
 )
+from instana.util.config import is_truthy
 from instana.version import VERSION
 
 __author__ = "Instana Inc."
@@ -225,7 +226,9 @@ def _start_profiler() -> None:
         profiler.start()
 
 
-if "INSTANA_DISABLE" not in os.environ:
+if "INSTANA_DISABLE" not in os.environ and not is_truthy(
+    os.environ.get("INSTANA_TRACING_DISABLE", None)
+):
     # There are cases when sys.argv may not be defined at load time.  Seems to happen in embedded Python,
     # and some Pipenv installs.  If this is the case, it's best effort.
     if (

--- a/src/instana/__init__.py
+++ b/src/instana/__init__.py
@@ -11,9 +11,9 @@ Source Code: https://github.com/instana/python-sensor
 """
 
 import importlib
-import importlib.util
 import os
 import sys
+from importlib import util as importlib_util
 from typing import Tuple
 
 from instana.collector.helpers.runtime import (
@@ -226,9 +226,15 @@ def _start_profiler() -> None:
         profiler.start()
 
 
-if "INSTANA_DISABLE" not in os.environ and not is_truthy(
-    os.environ.get("INSTANA_TRACING_DISABLE", None)
-):
+if "INSTANA_DISABLE" in os.environ:  # pragma: no cover
+    import warnings
+
+    message = "Instana: The INSTANA_DISABLE environment variable is deprecated. Please use INSTANA_TRACING_DISABLE=True instead."
+    warnings.simplefilter("always")
+    warnings.warn(message, DeprecationWarning)
+
+
+if not is_truthy(os.environ.get("INSTANA_TRACING_DISABLE", None)):
     # There are cases when sys.argv may not be defined at load time.  Seems to happen in embedded Python,
     # and some Pipenv installs.  If this is the case, it's best effort.
     if (
@@ -246,7 +252,7 @@ if "INSTANA_DISABLE" not in os.environ and not is_truthy(
         if (
             (is_autowrapt_instrumented() or is_webhook_instrumented())
             and "INSTANA_DISABLE_AUTO_INSTR" not in os.environ
-            and importlib.util.find_spec("gevent")
+            and importlib_util.find_spec("gevent")
         ):
             apply_gevent_monkey_patch()
 

--- a/src/instana/util/config_reader.py
+++ b/src/instana/util/config_reader.py
@@ -1,15 +1,18 @@
 # (c) Copyright IBM Corp. 2025
 
-from typing import Union
-from instana.log import logger
 import yaml
+
+from instana.log import logger
 
 
 class ConfigReader:
-    def __init__(self, file_path: Union[str]) -> None:
+    def __init__(self, file_path: str) -> None:
         self.file_path = file_path
-        self.data = None
-        self.load_file()
+        self.data = {}
+        if file_path:
+            self.load_file()
+        else:
+            logger.warning("ConfigReader: No configuration file specified")
 
     def load_file(self) -> None:
         """Loads and parses the YAML file"""
@@ -17,6 +20,8 @@ class ConfigReader:
             with open(self.file_path, "r") as file:
                 self.data = yaml.safe_load(file)
         except FileNotFoundError:
-            logger.error(f"Configuration file has not found: {self.file_path}")
+            logger.error(
+                f"ConfigReader: Configuration file has not found: {self.file_path}"
+            )
         except yaml.YAMLError as e:
-            logger.error(f"Error parsing YAML file: {e}")
+            logger.error(f"ConfigReader: Error parsing YAML file: {e}")

--- a/tests/test_span_disabling.py
+++ b/tests/test_span_disabling.py
@@ -1,0 +1,79 @@
+# (c) Copyright IBM Corp. 2025
+
+import pytest
+
+from instana.options import BaseOptions, StandardOptions
+from instana.singletons import agent
+
+
+class TestSpanDisabling:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        # Save original options
+        self.original_options = agent.options
+        yield
+        # Restore original options
+        agent.options = self.original_options
+
+    def test_is_span_disabled_default(self):
+        options = BaseOptions()
+        assert not options.is_span_disabled(category="logging")
+        assert not options.is_span_disabled(category="databases")
+        assert not options.is_span_disabled(span_type="redis")
+
+    def test_disable_category(self):
+        options = BaseOptions()
+        options.disabled_spans = ["logging"]
+        assert options.is_span_disabled(category="logging")
+        assert not options.is_span_disabled(category="databases")
+
+    def test_disable_type(self):
+        options = BaseOptions()
+        options.disabled_spans = ["redis"]
+        assert options.is_span_disabled(span_type="redis")
+        assert not options.is_span_disabled(span_type="mysql")
+
+    def test_type_category_relationship(self):
+        options = BaseOptions()
+        options.disabled_spans = ["databases"]
+        assert options.is_span_disabled(span_type="redis")
+        assert options.is_span_disabled(span_type="mysql")
+
+    def test_precedence_rules(self):
+        options = BaseOptions()
+        options.disabled_spans = ["databases"]
+        options.enabled_spans = ["redis"]
+        assert options.is_span_disabled(category="databases")
+        assert options.is_span_disabled(span_type="mysql")
+        assert not options.is_span_disabled(span_type="redis")
+
+    @pytest.mark.parametrize("value", ["True", "true", "1"])
+    def test_env_var_disable_all(self, value, monkeypatch):
+        monkeypatch.setenv("INSTANA_TRACING_DISABLE", value)
+        options = BaseOptions()
+        assert options.is_span_disabled(category="logging") is True
+        assert options.is_span_disabled(category="databases") is True
+        assert options.is_span_disabled(category="messaging") is True
+        assert options.is_span_disabled(category="protocols") is True
+
+    def test_env_var_disable_specific(self, monkeypatch):
+        monkeypatch.setenv("INSTANA_TRACING_DISABLE", "logging, redis")
+        options = BaseOptions()
+        assert options.is_span_disabled(category="logging") is True
+        assert options.is_span_disabled(category="databases") is False
+        assert options.is_span_disabled(span_type="redis") is True
+        assert options.is_span_disabled(span_type="mysql") is False
+
+    def test_yaml_config(self):
+        options = StandardOptions()
+        tracing_config = {
+            "disable": [{"logging": True}, {"redis": False}, {"databases": True}]
+        }
+        options.set_tracing(tracing_config)
+        assert options.is_span_disabled(category="logging")
+        assert options.is_span_disabled(category="databases")
+        assert options.is_span_disabled(span_type="mysql")
+        assert not options.is_span_disabled(span_type="redis")
+
+
+# Made with Bob

--- a/tests/util/test_config_reader.py
+++ b/tests/util/test_config_reader.py
@@ -2,19 +2,77 @@
 
 import logging
 import os
+from typing import TYPE_CHECKING, Generator
 
 import pytest
+from yaml import YAMLError
 
 from instana.util.config import (
     get_disable_trace_configurations_from_yaml,
     parse_ignored_endpoints_from_yaml,
 )
+from instana.util.config_reader import ConfigReader
+
+if TYPE_CHECKING:
+    from pytest import LogCaptureFixture
+    from pytest_mock import MockerFixture
 
 
 class TestConfigReader:
-    def test_load_configuration_with_tracing(
-        self, caplog: pytest.LogCaptureFixture
+    @pytest.fixture(autouse=True)
+    def _resource(
+        self,
+        caplog: "LogCaptureFixture",
+    ) -> Generator[None, None, None]:
+        yield
+        caplog.clear()
+        if "INSTANA_CONFIG_PATH" in os.environ:
+            os.environ.pop("INSTANA_CONFIG_PATH")
+
+    def test_config_reader_null(self, caplog: "LogCaptureFixture") -> None:
+        config_reader = ConfigReader(os.environ.get("INSTANA_CONFIG_PATH", ""))
+        assert config_reader.file_path == ""
+        assert config_reader.data == {}
+        assert "ConfigReader: No configuration file specified" in caplog.messages
+
+    def test_config_reader_default(self) -> None:
+        filename = "tests/util/test_configuration-1.yaml"
+        os.environ["INSTANA_CONFIG_PATH"] = filename
+        config_reader = ConfigReader(os.environ.get("INSTANA_CONFIG_PATH", ""))
+        assert config_reader.file_path == filename
+        assert "tracing" in config_reader.data
+        assert len(config_reader.data["tracing"]) == 2
+
+    def test_config_reader_file_not_found_error(
+        self, caplog: "LogCaptureFixture"
     ) -> None:
+        filename = "tests/util/test_configuration-3.yaml"
+        os.environ["INSTANA_CONFIG_PATH"] = filename
+        config_reader = ConfigReader(os.environ.get("INSTANA_CONFIG_PATH", ""))
+        assert config_reader.file_path == filename
+        assert config_reader.data == {}
+        assert (
+            f"ConfigReader: Configuration file has not found: {filename}"
+            in caplog.messages
+        )
+
+    def test_config_reader_yaml_error(
+        self, caplog: "LogCaptureFixture", mocker: "MockerFixture"
+    ) -> None:
+        filename = "tests/util/test_configuration-1.yaml"
+        exception_message = "BLAH"
+        mocker.patch(
+            "instana.util.config_reader.yaml.safe_load",
+            side_effect=YAMLError(exception_message),
+        )
+
+        config_reader = ConfigReader(filename)  # noqa: F841
+        assert (
+            f"ConfigReader: Error parsing YAML file: {exception_message}"
+            in caplog.messages
+        )
+
+    def test_load_configuration_with_tracing(self, caplog: "LogCaptureFixture") -> None:
         caplog.set_level(logging.DEBUG, logger="instana")
 
         ignore_endpoints = parse_ignored_endpoints_from_yaml(
@@ -49,7 +107,7 @@ class TestConfigReader:
             not in caplog.messages
         )
 
-    def test_load_configuration_legacy(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_load_configuration_legacy(self, caplog: "LogCaptureFixture") -> None:
         caplog.set_level(logging.DEBUG, logger="instana")
 
         ignore_endpoints = parse_ignored_endpoints_from_yaml(

--- a/tests/util/test_config_reader.py
+++ b/tests/util/test_config_reader.py
@@ -1,10 +1,14 @@
 # (c) Copyright IBM Corp. 2025
 
 import logging
+import os
 
 import pytest
 
-from instana.util.config import parse_ignored_endpoints_from_yaml
+from instana.util.config import (
+    get_disable_trace_configurations_from_yaml,
+    parse_ignored_endpoints_from_yaml,
+)
 
 
 class TestConfigReader:
@@ -32,6 +36,14 @@ class TestConfigReader:
             "kafka.*.topic4",
         ]
 
+        os.environ["INSTANA_CONFIG_PATH"] = "tests/util/test_configuration-1.yaml"
+        disabled_spans, enabled_spans = get_disable_trace_configurations_from_yaml()
+        # Check disabled_spans list
+        assert "logging" in disabled_spans
+        assert "databases" in disabled_spans
+        assert "redis" not in disabled_spans
+        assert "redis" in enabled_spans
+
         assert (
             'Please use "tracing" instead of "com.instana.tracing" for local configuration file.'
             not in caplog.messages
@@ -58,6 +70,15 @@ class TestConfigReader:
             "kafka.*.span-topic",
             "kafka.*.topic4",
         ]
+
+        os.environ["INSTANA_CONFIG_PATH"] = "tests/util/test_configuration-2.yaml"
+        disabled_spans, enabled_spans = get_disable_trace_configurations_from_yaml()
+        # Check disabled_spans list
+        assert "logging" in disabled_spans
+        assert "databases" in disabled_spans
+        assert "redis" not in disabled_spans
+        assert "redis" in enabled_spans
+
         assert (
             'Please use "tracing" instead of "com.instana.tracing" for local configuration file.'
             in caplog.messages

--- a/tests/util/test_configuration-1.yaml
+++ b/tests/util/test_configuration-1.yaml
@@ -17,3 +17,8 @@ tracing:
         endpoints: ["span-topic", "topic4"]
       # - methods: ["consume", "send"]
       #   endpoints: ["*"] # Applied to all topics
+  disable:
+    - "logging": true
+    - "databases": true
+    - "redis": false
+    

--- a/tests/util/test_configuration-2.yaml
+++ b/tests/util/test_configuration-2.yaml
@@ -18,3 +18,7 @@ com.instana.tracing:
         endpoints: ["span-topic", "topic4"]
       # - methods: ["consume", "send"]
       #   endpoints: ["*"] # Applied to all topics
+  disable:
+    - "logging": true
+    - "databases": true
+    - "redis": false


### PR DESCRIPTION
We need to disable log collection at the tracer level to prevent duplication in the backend when both the application tracer and an OpenTelemetry collector are running on the same system.

This PR adds support for the Span Disabling feature, which allows the exclusion of specific traces or calls from tracing based on the category (technology) or type (frameworks, libraries, instrumentations) supported by the traces.

In addition, it refactors the initialization of the Instana module and the ConfigReader class.