### PR TITLE
Remove Python 3.8 from the project dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,7 @@ workflows:
       - python3x:
           matrix:
             parameters:
-              py-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+              py-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       - python314
       - py39cassandra
       - py39gevent_starlette

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -26,8 +26,6 @@ spec:
         params:
           - name: imageDigest
             value:
-              # public.ecr.aws/docker/library/python:3.8.20-bookworm
-              - "sha256:7aa279fb41dad2962d3c915aa6f6615134baa412ab5aafa9d4384dcaaa0af15d"
               # public.ecr.aws/docker/library/python:3.9.22-bookworm
               - "sha256:a847112640804ed2d03bb774d46bb1619bd37862fb2b7e48eebe425a168c153b"
               # public.ecr.aws/docker/library/python:3.10.17-bookworm

--- a/.tekton/python-tracer-prepuller.yaml
+++ b/.tekton/python-tracer-prepuller.yaml
@@ -49,10 +49,6 @@ spec:
           # public.ecr.aws/bitnami/kafka:3.9.0
           image: public.ecr.aws/docker/library/kafka@sha256:d2890d68f96b36da3c8413fa94294f018b2f95d87cf108cbf71eab510572d9be
           command: ["sh", "-c", "'true'"]
-        - name: prepuller-38
-          # public.ecr.aws/docker/library/python:3.8.20-bookworm
-          image: public.ecr.aws/docker/library/python@
-          command: ["sh", "-c", "'true'"]
         - name: prepuller-39
           # public.ecr.aws/docker/library/python:3.9.22-bookworm
           image: public.ecr.aws/docker/library/python@sha256:a847112640804ed2d03bb774d46bb1619bd37862fb2b7e48eebe425a168c153b

--- a/bin/aws-lambda/build_and_publish_lambda_layer.py
+++ b/bin/aws-lambda/build_and_publish_lambda_layer.py
@@ -170,7 +170,6 @@ for region in target_regions:
             "--zip-file",
             aws_zip_filename,
             "--compatible-runtimes",
-            "python3.8",
             "python3.9",
             "python3.10",
             "python3.11",

--- a/example/asyncio/README.md
+++ b/example/asyncio/README.md
@@ -4,7 +4,7 @@ This directory includes an example asyncio application and client with aiohttp a
 
 # Requirements
 
-* Python 3.8 or greater
+* Python 3.9 or greater
 * instana, aiohttp and aio-pika Python packages installed
 * A RabbitMQ server with it's location specified in the `RABBITMQ_HOST` environment variable
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = [
 ]
 description = "Python Distributed Tracing & Metrics Sensor for Instana."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "MIT"
 keywords = [
     "performance",
@@ -31,7 +31,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -50,7 +49,7 @@ dependencies = [
     "urllib3>=1.26.5",
     "opentelemetry-api>=1.27.0",
     "opentelemetry-semantic-conventions>=0.48b0",
-    "typing_extensions>=4.12.2",
+    "typing_extensions>=4.12.2; python_version < \"3.11\"",
     "pyyaml>=6.0.2",
     "setuptools>=69.0.0; python_version >= \"3.12\"",
     "psutil>=5.9.0; sys_platform == \"win32\"",

--- a/src/instana/autoprofile/profiler.py
+++ b/src/instana/autoprofile/profiler.py
@@ -52,8 +52,8 @@ class Profiler(object):
             return
 
         try:
-            if not min_version(3, 8):
-                raise Exception("Supported Python versions 3.8 or higher.")
+            if not min_version(3, 9):
+                raise Exception("Supported Python versions: 3.9 or higher.")
 
             if platform.python_implementation() != "CPython":
                 raise Exception("Supported Python interpreter is CPython.")

--- a/src/instana/instrumentation/pep0249.py
+++ b/src/instana/instrumentation/pep0249.py
@@ -4,10 +4,13 @@
 # This is a wrapper for PEP-0249: Python Database API Specification v2.0
 import wrapt
 from typing import TYPE_CHECKING, Dict, Any, List, Tuple, Union, Callable, Optional
-from typing_extensions import Self
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 from opentelemetry.semconv.trace import SpanAttributes
-from opentelemetry.trace import SpanKind
 
 from instana.log import logger
 from instana.util.traceutils import get_tracer_tuple, tracing_is_off

--- a/tests/apps/aiohttp_app/__init__.py
+++ b/tests/apps/aiohttp_app/__init__.py
@@ -2,13 +2,10 @@
 # (c) Copyright Instana Inc. 2020
 
 import os
-import sys
 from .app import aiohttp_server as server
 from ..utils import launch_background_thread
 
 APP_THREAD = None
 
-if not any((os.environ.get('GEVENT_STARLETTE_TEST'),
-            os.environ.get('CASSANDRA_TEST'),
-            sys.version_info < (3, 5, 3))):
+if not any((os.environ.get("GEVENT_STARLETTE_TEST"), os.environ.get("CASSANDRA_TEST"))):
     APP_THREAD = launch_background_thread(server, "AIOHTTP")

--- a/tests/apps/aiohttp_app2/__init__.py
+++ b/tests/apps/aiohttp_app2/__init__.py
@@ -1,13 +1,10 @@
 # (c) Copyright IBM Corp. 2024
 
 import os
-import sys
 from tests.apps.aiohttp_app2.app import aiohttp_server as server
 from tests.apps.utils import launch_background_thread
 
 APP_THREAD = None
 
-if not any((os.environ.get('GEVENT_STARLETTE_TEST'),
-            os.environ.get('CASSANDRA_TEST'),
-            sys.version_info < (3, 5, 3))):
+if not any((os.environ.get("GEVENT_STARLETTE_TEST"), os.environ.get("CASSANDRA_TEST"))):
     APP_THREAD = launch_background_thread(server, "AIOHTTP")

--- a/tests/apps/grpc_server/__init__.py
+++ b/tests/apps/grpc_server/__init__.py
@@ -2,19 +2,17 @@
 # (c) Copyright Instana Inc. 2019
 
 import os
-import sys
 import time
 import threading
 
-if not any((os.environ.get('GEVENT_STARLETTE_TEST'),
-            os.environ.get('CASSANDRA_TEST'),
-            sys.version_info < (3, 5, 3))):
+if not any((os.environ.get("GEVENT_STARLETTE_TEST"), os.environ.get("CASSANDRA_TEST"))):
     # Background RPC application
     #
     # Spawn the background RPC app that the tests will throw
     # requests at.
     import tests.apps.grpc_server
     from .stan_server import StanServicer
+
     stan_servicer = StanServicer()
     rpc_server_thread = threading.Thread(target=stan_servicer.start_server)
     rpc_server_thread.daemon = True

--- a/tests/apps/grpc_server/stan_server.py
+++ b/tests/apps/grpc_server/stan_server.py
@@ -92,8 +92,4 @@ Invention, my dear friends, is 93% perspiration, 6% electricity, \
 
 if __name__ == "__main__":
     print ("Booting foreground GRPC application...")
-
-    if sys.version_info >= (3, 5, 3):
-        StanServicer().start_server()
-    else:
-        print("Python v3.5.3 or higher only")
+    StanServicer().start_server()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,16 +62,6 @@ if not os.environ.get("GEVENT_STARLETTE_TEST"):
 if not os.environ.get("KAFKA_TEST"):
     collect_ignore_glob.append("*kafka/test*")
 
-# Currently asyncio and tornado_server depends on aiohttp and
-# since aiohttp versions < 3.12.14 have vulnerability we skip the tests below
-if sys.version_info < (3, 9):
-    collect_ignore_glob.extend(
-        [
-            "*test_aiohttp*",
-            "*test_asyncio*",
-            "*test_tornado_server*",
-        ]
-    )
 
 if sys.version_info >= (3, 12):
     # Currently Spyne does not support python > 3.12

--- a/tests_aws/01_lambda/conftest.py
+++ b/tests_aws/01_lambda/conftest.py
@@ -10,10 +10,6 @@ os.environ["AWS_EXECUTION_ENV"] = "AWS_Lambda_python_3.10"
 
 from instana.collector.base import BaseCollector
 
-if sys.version_info <= (3, 8):
-    print("Python runtime version not supported by AWS Lambda.")
-    exit(1)
-
 
 @pytest.fixture
 def trace_id() -> int:


### PR DESCRIPTION
Remove Python 3.8 from the project dependencies
- install `typing_extensions` only for Python < 3.11
