### PR TITLE
Release new version only on `3.x` tags that does not contain `post`

### DIFF
--- a/.github/workflows/pkg_release.yml
+++ b/.github/workflows/pkg_release.yml
@@ -11,13 +11,13 @@ name: Release new version
 on:
   push:
     tags:
-      - v3.*
+      - 'v3.*'
+      - '!v3.*post*'
 
 jobs:
   build:
     name: Build package
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref_name, 'v3') }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION

This change is based on the official documentation on `GitHub Actions`: [link](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-including-and-excluding-branches-and-tags)

- Do not release new version for `fedramp` specific code
- Remove redundant check for `v3` tags

Signed-off-by: Varsha GS <varsha.gs@ibm.com>