### PR TITLE
fix: uWSGI app crashes with `AUTOWRAPT_BOOTSTRAP=True` in `Python >= 3.12`

### DIFF
--- a/src/instana/hooks/hook_uwsgi.py
+++ b/src/instana/hooks/hook_uwsgi.py
@@ -44,8 +44,11 @@ try:
         logger.debug(
             f"uWSGI --master={opt_master} --lazy-apps={opt_lazy_apps}: postfork hooks not applied"
         )
+
 except ImportError:
     logger.debug(
         "uwsgi hooks: decorators not available: likely not running under uWSGI"
     )
-    pass
+
+except AttributeError:
+    logger.debug("uwsgi hooks: Running under uWSGI but decorators not available")

--- a/src/instana/util/runtime.py
+++ b/src/instana/util/runtime.py
@@ -135,7 +135,7 @@ def determine_service_name() -> str:
                     uwsgi_type = "uWSGI worker%s"
 
                 app_name = uwsgi_type % app_name
-            except ImportError:
+            except (ImportError, AttributeError):
                 pass
     except Exception:
         logger.debug("non-fatal get_application_name: ", exc_info=True)


### PR DESCRIPTION
### Before changes
App crashes with error

``` shell
% AUTOWRAPT_BOOTSTRAP=instana uwsgi --http 127.0.0.1:5000 --module app:app
*** Starting uWSGI 2.0.28 (64bit) on [Thu Apr 10 12:50:17 2025] ***
compiled with version: Apple LLVM 16.0.0 (clang-1600.0.26.6) on 08 April 2025 09:12:51
os: Darwin-24.3.0 Darwin Kernel Version 24.3.0: Thu Jan  2 20:24:24 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6030
nodename: Varshas-MacBook-Pro.local
machine: arm64
clock source: unix
pcre jit disabled
detected number of CPU cores: 12
current working directory: /Users/varsha/Documents/GitHub/tracer-repos/python-sensor-example-flask/src
detected binary path: /Users/varsha/Documents/GitHub/tracer-repos/python-sensor-example-flask/venv-3.12.0/bin/uwsgi
*** WARNING: you are running uWSGI without its master process manager ***
your processes number limit is 6000
your memory page size is 16384 bytes
detected max file descriptor number: 1048575
lock engine: OSX spinlocks
thunder lock: disabled (you can enable it with --thunder-lock)
uWSGI http bound on 127.0.0.1:5000 fd 4
spawned uWSGI http 1 (pid: 50378)
uwsgi socket 0 bound to TCP address 127.0.0.1:49205 (port auto-assigned) fd 3
Python version: 3.12.0 (main, Apr  7 2025, 12:28:29) [Clang 16.0.0 (clang-1600.0.26.6)]
2025-04-10 12:50:17,914: 50377 DEBUG instana: non-fatal get_application_name: 
Traceback (most recent call last):
  File "/Users/varsha/Documents/GitHub/tracer-repos/python-sensor-example-flask/venv-3.12.0/lib/python3.12/site-packages/instana/util/runtime.py", line 105, in determine_service_name
    if os.getpid() == uwsgi.masterpid():
                      ^^^^^^^^^^^^^^^
AttributeError: module 'uwsgi' has no attribute 'masterpid'
Fatal Python error: init_import_site: Failed to import the site module
Python runtime state: initialized
Traceback (most recent call last):
  File "<frozen importlib._bootstrap>", line 1354, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1325, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 929, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1170, in exec_module
  File "<frozen site>", line 614, in <module>
  File "<frozen site>", line 607, in main
  File "/Users/varsha/Documents/GitHub/tracer-repos/python-sensor-example-flask/venv-3.12.0/lib/python3.12/site-packages/autowrapt/bootstrap.py", line 41, in _execsitecustomize
    return wrapped(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/varsha/Documents/GitHub/tracer-repos/python-sensor-example-flask/venv-3.12.0/lib/python3.12/site-packages/autowrapt/bootstrap.py", line 47, in _execsitecustomize
    _register_bootstrap_functions()
  File "/Users/varsha/Documents/GitHub/tracer-repos/python-sensor-example-flask/venv-3.12.0/lib/python3.12/site-packages/autowrapt/bootstrap.py", line 36, in _register_bootstrap_functions
    discover_post_import_hooks(name)
  File "/Users/varsha/Documents/GitHub/tracer-repos/python-sensor-example-flask/venv-3.12.0/lib/python3.12/site-packages/wrapt/importer.py", line 105, in discover_post_import_hooks
    register_post_import_hook(callback, entrypoint.name)
  File "/Users/varsha/Documents/GitHub/tracer-repos/python-sensor-example-flask/venv-3.12.0/lib/python3.12/site-packages/wrapt/importer.py", line 81, in register_post_import_hook
    hook(module)
  File "/Users/varsha/Documents/GitHub/tracer-repos/python-sensor-example-flask/venv-3.12.0/lib/python3.12/site-packages/wrapt/importer.py", line 87, in import_hook
    __import__(entrypoint.module_name)
  File "/Users/varsha/Documents/GitHub/tracer-repos/python-sensor-example-flask/venv-3.12.0/lib/python3.12/site-packages/instana/__init__.py", line 255, in <module>
    boot_agent()
  File "/Users/varsha/Documents/GitHub/tracer-repos/python-sensor-example-flask/venv-3.12.0/lib/python3.12/site-packages/instana/__init__.py", line 220, in boot_agent
    from instana.hooks import (
  File "/Users/varsha/Documents/GitHub/tracer-repos/python-sensor-example-flask/venv-3.12.0/lib/python3.12/site-packages/instana/hooks/hook_uwsgi.py", line 17, in <module>
    f"uWSGI options: {uwsgi.opt}",
                      ^^^^^^^^^
AttributeError: module 'uwsgi' has no attribute 'opt'
```

### After changes

``` shell
% AUTOWRAPT_BOOTSTRAP=instana INSTANA_DEBUG=true uwsgi --http 127.0.0.1:5000 --module app:app                  
*** Starting uWSGI 2.0.28 (64bit) on [Mon Aug 11 15:23:41 2025] ***
compiled with version: Apple LLVM 16.0.0 (clang-1600.0.26.6) on 08 April 2025 09:12:51
os: Darwin-24.5.0 Darwin Kernel Version 24.5.0: Tue Apr 22 19:54:29 PDT 2025; root:xnu-11417.121.6~2/RELEASE_ARM64_T6030
nodename: Varshas-MacBook-Pro.local
machine: arm64
clock source: unix
pcre jit disabled
detected number of CPU cores: 12
current working directory: /Users/varsha/Documents/GitHub/tracer-repos/python-sensor-example-flask/src
detected binary path: /Users/varsha/Documents/GitHub/tracer-repos/python-sensor-example-flask/venv-3.12.0/bin/uwsgi
*** WARNING: you are running uWSGI without its master process manager ***
your processes number limit is 6000
your memory page size is 16384 bytes
detected max file descriptor number: 1048575
lock engine: OSX spinlocks
thunder lock: disabled (you can enable it with --thunder-lock)
uWSGI http bound on 127.0.0.1:5000 fd 4
spawned uWSGI http 1 (pid: 24368)
uwsgi socket 0 bound to TCP address 127.0.0.1:60550 (port auto-assigned) fd 3
Python version: 3.12.0 (main, Apr  7 2025, 12:28:29) [Clang 16.0.0 (clang-1600.0.26.6)]
2025-08-11 15:23:41,583: 24367 INFO instana: Stan is on the scene.  Starting Instana instrumentation version: 3.7.0
2025-08-11 15:23:41,583: 24367 DEBUG instana: Runtime environment: Machine: arm64, System: Darwin, Python version: 3.12.0
2025-08-11 15:23:41,583: 24367 DEBUG instana: Loading Host Collector
2025-08-11 15:23:41,588: 24367 DEBUG instana: Initializing host agent state machine
2025-08-11 15:23:41,594: 24367 DEBUG instana: Instrumenting asyncio
2025-08-11 15:23:41,663: 24367 DEBUG instana: Instrumenting flask (with blinker support)
2025-08-11 15:23:41,667: 24367 DEBUG instana: Instrumenting logging
2025-08-11 15:23:41,683: 24367 DEBUG instana: Instrumenting urllib3
2025-08-11 15:23:41,687: 24367 DEBUG instana: Instrumenting DynamoDB
2025-08-11 15:23:41,706: 24367 DEBUG instana: gunicorn hooks: decorators not available: likely not running under gunicorn
2025-08-11 15:23:41,707: 24367 DEBUG instana: uwsgi hooks: Running under uWSGI but decorators not available
Python main interpreter initialized at 0x103864478
python threads support enabled
your server socket listen backlog is limited to 100 connections
your mercy for graceful operations on workers is 60 seconds
mapped 72896 bytes (71 KB) for 1 cores
*** Operational MODE: single process ***
WSGI app 0 (mountpoint='') ready in 0 seconds on interpreter 0x103864478 pid: 24367 (default app)
*** uWSGI is running in multiple interpreter mode ***
spawned uWSGI worker 1 (and the only) (pid: 24367, cores: 1)
2025-08-11 15:23:42,609: 24367 DEBUG instana: Instana host agent found on localhost:42699
2025-08-11 15:23:42,609: 24367 DEBUG instana: Attempting to make an announcement to the agent on localhost:42699
2025-08-11 15:23:42,631: 24367 DEBUG instana: Starting Host Collector
2025-08-11 15:23:42,631: 24367 DEBUG instana: BaseCollector.start: launching collection thread
2025-08-11 15:23:42,632: 24367 INFO instana: Instana host agent available. We're in business. Announced PID: 24367 (true pid: 24367)
2025-08-11 15:23:42,632: 24367 DEBUG instana: Announced pid: 24367 (true pid: 24367).  Waiting for Agent Ready...
2025-08-11 15:23:43,644: 24367 DEBUG instana: Agent is ready.  Getting to work.
2025-08-11 15:24:02,577: 24367 DEBUG instana: Flask(blinker): Applying flask before/after instrumentation funcs
[pid: 24367|app: 0|req: 1/1] 127.0.0.1 () {28 vars in 306 bytes} [Mon Aug 11 15:24:02 2025] GET / => generated 39 bytes in 3 msecs (HTTP/1.1 200) 8 headers in 313 bytes (2 switches on core 0)
2025-08-11 15:24:02,843: 24367 DEBUG instana: Reporting 1 spans
```

### Reason
`uwsgi` module is available at runtime, confirming that the app is running under uWSGI but decorators are not available.