### PR TITLE
fix: Logging stacklevel for Python >= 3.14.0.

### DIFF
--- a/src/instana/instrumentation/logging.py
+++ b/src/instana/instrumentation/logging.py
@@ -31,7 +31,7 @@ def log_with_instana(
     stacklevel_in = kwargs.pop(
         "stacklevel", 1 if get_runtime_env_info()[0] not in ["ppc64le", "s390x"] else 2
     )
-    stacklevel = stacklevel_in + 1 + (sys.version_info >= (3, 14))
+    stacklevel = stacklevel_in + 1
 
     try:
         # Only needed if we're tracing and serious log and logging spans are not disabled


### PR DESCRIPTION
Reverting commit e57ab45 as closing the final release of Python 3.14.0.

Signed-off-by: Paulo Vital <paulo.vital@ibm.com>