### PR TITLE
[aio-pika] Enable consumer callback tracing

### DIFF
--- a/src/instana/instrumentation/aio_pika.py
+++ b/src/instana/instrumentation/aio_pika.py
@@ -100,12 +100,12 @@ try:
                 _extract_span_attributes(
                     span, connection, "consume", message.routing_key, message.exchange
                 )
-            try:
-                response = await wrapped(*args, **kwargs)
-            except Exception as exc:
-                span.record_exception(exc)
-            else:
-                return response
+                try:
+                    response = await wrapped(*args, **kwargs)
+                except Exception as exc:
+                    span.record_exception(exc)
+                else:
+                    return response
 
         wrapped_callback = callback_wrapper(callback)
         if kwargs.get("callback"):


### PR DESCRIPTION
Addresses #794.

The following changes were made:
- Move the execution of the consumer callback in the `aio-pika´ consume wrapper into the `with` statement that constitutes the consumer span. This enables tracing of further calls made in the consumer callback function.
- Add a test to check if exceptions thrown in the consumer callback function are recorded by Instana. This fails against the current `main` branch and passes with the changes in this PR.