### PR TITLE
fix: tracing fastapi app

### DIFF
--- a/src/instana/instrumentation/fastapi.py
+++ b/src/instana/instrumentation/fastapi.py
@@ -71,6 +71,10 @@ try:
             kwargs["middleware"] = [Middleware(InstanaASGIMiddleware)]
         elif isinstance(middleware, list):
             middleware.append(Middleware(InstanaASGIMiddleware))
+        elif isinstance(middleware, tuple):
+            kwargs["middleware"] =  (*middleware, Middleware(InstanaASGIMiddleware))
+        else:
+            logger.warning("Unsupported FastAPI middleware sequence type.")
 
         exception_handlers = kwargs.get("exception_handlers")
         if exception_handlers is None:


### PR DESCRIPTION
close #804 

Here, FastAPI accepts `Sequence` and the current implementation of `InstanaASGIMiddleware` insert does not cover tuple
https://github.com/fastapi/fastapi/blob/450a334253b1426aab08b4dea17b16ba8b4c098c/fastapi/applications.py#L472

Are there any document that describes how to run tests? This is super small change tho