### PR TITLE
feat: Add IBM i support

### DIFF
--- a/src/instana/fsm.py
+++ b/src/instana/fsm.py
@@ -119,7 +119,7 @@ class TheMachine:
                 # rely on ps rather than adding a dependency on something like
                 # psutil which requires dev packages, gcc etc...
                 proc = subprocess.Popen(
-                    ["ps", "-p", str(pid), "-o", "command"], stdout=subprocess.PIPE
+                    ["ps", "-p", str(pid), "-o", "args"], stdout=subprocess.PIPE
                 )
                 (out, _) = proc.communicate()
                 parts = out.split(b"\n")


### PR DESCRIPTION
### Error in Agent logs:
> 2025-10-07T00:44:34.743-05:00 | DEBUG | instana-executor-thread-4-12     | aultAnnounceUtil | com.instana.agent-process-handling - 1.0.29 | Announcement request root namespace PID match discarded due to name/argument mismatch: PythonProcess [pid=570881, name=python, arguments=[], fd=-1, inode=] is not SigarProcessImpl [pid=570881, parentPid=570282, startTime=0, name=python, directory=<lazy>, executable=<lazy>, arguments=[simple_flask_app.py], userName=<lazy>, groupName=<lazy>, procCred=null, environmentVariables={}, stable=false].

### Inference:
`DefaultAnnounceUtil` says the `PythonProcess` with pid `570881` does not share the same arguments `(arguments=[])` as the `SigarProcessImpl` which has `arguments=[simple_flask_app.py]` and therefore they are marked as NOT the same.

### What's happening?
When the sensor announces itself, it's sending incomplete information - specifically, it's sending empty command line arguments `(arguments=[])`.

Meanwhile, the Instana agent already knows about this process through its system monitoring (Sigar) and has the correct command line arguments `(arguments=[simple_flask_app.py])`.

The agent is trying to match these two pieces of information (the announcement from the Python sensor and what it knows from system monitoring), but because the arguments don't match, it rejects the announcement.

### Root cause:
Looks like in legacy systems like IBM i, `ps -p <PID> -o command` doesn't provide the full command with arguments, the other command should work for all kinds of OS

```
$ps -p 572882 -o command
COMMAND
python

$ps -p 572882 -o args
COMMAND
python simple_flask_app.py
```