### PR TITLE
Fix TypeError in agent announcement process when payload is boolean

### DIFF
--- a/src/instana/agent/host.py
+++ b/src/instana/agent/host.py
@@ -138,10 +138,15 @@ class HostAgent(BaseAgent):
         @return: None
         """
         self.options.set_from(res_data)
-        self.announce_data = AnnounceData(
-            pid=res_data["pid"],
-            agentUuid=res_data["agentUuid"],
-        )
+
+        # Ensure required keys are present
+        if "pid" in res_data and "agentUuid" in res_data:
+            self.announce_data = AnnounceData(
+                pid=res_data["pid"],
+                agentUuid=res_data["agentUuid"],
+            )
+        else:
+            logger.debug(f"Missing required keys in announce response: {res_data}")
 
     def get_from_structure(self) -> Dict[str, str]:
         """

--- a/src/instana/fsm.py
+++ b/src/instana/fsm.py
@@ -148,7 +148,7 @@ class TheMachine:
 
         payload = self.agent.announce(d)
 
-        if not payload:
+        if not payload or not isinstance(payload, dict):
             logger.debug("Cannot announce sensor. Scheduling retry.")
             self.schedule_retry(
                 self.announce_sensor, e, f"{self.THREAD_NAME}: announce"


### PR DESCRIPTION
# Summary

Add error handling for missing keys in announce response and improve payload validation in the FSM announcement flow.

# Files Changed

📄 `src/instana/agent/host.py`

Enhanced error handling in the `HostAgent` class's `set_from` method to safely handle missing required keys in the response data. The update adds a check to ensure that both "pid" and "agentUuid" keys are present in the response data before creating an `AnnounceData` object, preventing potential KeyError exceptions. If the required keys are missing, the code logs a debug message with the incomplete response data.

📄 `src/instana/fsm.py`

Improved payload validation in the `TheMachine.announce_sensor` method by checking not only if the payload exists but also if it's a dictionary. This prevents potential issues when the announcement response is not in the expected format, ensuring more robust behavior when scheduling retries for sensor announcements.