### PR TITLE
Remove `setuptools` from project dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dependencies = [
     "opentelemetry-semantic-conventions>=0.48b0",
     "typing_extensions>=4.12.2",
     "pyyaml>=6.0.2",
-    "setuptools>=69.0.0; python_version >= \"3.12\"",
     "psutil>=5.9.0; sys_platform == \"win32\"",
 ]
 


### PR DESCRIPTION
Remove `setuptools` from project dependency

### Why?
Dependency on `pkg_resources` gone after `wrapt-2.0.0`