### PR TITLE
[INSTA-47091] fix: Improved getting active tracer and current span mechanism

### DIFF
--- a/src/instana/instrumentation/aio_pika.py
+++ b/src/instana/instrumentation/aio_pika.py
@@ -15,7 +15,7 @@ try:
 
     from instana.log import logger
     from instana.propagators.format import Format
-    from instana.util.traceutils import get_tracer_tuple, tracing_is_off
+    from instana.util.traceutils import get_tracer_tuple
     from instana.singletons import get_tracer
 
     if TYPE_CHECKING:
@@ -41,10 +41,10 @@ try:
         args: Tuple[object],
         kwargs: Dict[str, Any],
     ) -> Optional["ConfirmationFrameType"]:
-        if tracing_is_off():
+        tracer, parent_span, _ = get_tracer_tuple()
+        if not tracer:
             return await wrapped(*args, **kwargs)
 
-        tracer, parent_span, _ = get_tracer_tuple()
         parent_context = parent_span.get_span_context() if parent_span else None
 
         def _bind_args(

--- a/src/instana/instrumentation/aiohttp/client.py
+++ b/src/instana/instrumentation/aiohttp/client.py
@@ -12,7 +12,7 @@ from instana.log import logger
 from instana.propagators.format import Format
 from instana.singletons import agent
 from instana.util.secrets import strip_secrets_from_query
-from instana.util.traceutils import get_tracer_tuple, tracing_is_off, extract_custom_headers
+from instana.util.traceutils import get_tracer_tuple, extract_custom_headers
 
 try:
     import aiohttp
@@ -21,17 +21,16 @@ try:
         from aiohttp.client import ClientSession
         from instana.span.span import InstanaSpan
 
-
     async def stan_request_start(
         session: "ClientSession", trace_config_ctx: SimpleNamespace, params
     ) -> Awaitable[None]:
         try:
+            tracer, parent_span, _ = get_tracer_tuple()
             # If we're not tracing, just return
-            if tracing_is_off():
+            if not tracer:
                 trace_config_ctx.span_context = None
                 return
 
-            tracer, parent_span, _ = get_tracer_tuple()
             parent_context = parent_span.get_span_context() if parent_span else None
 
             span = tracer.start_span("aiohttp-client", span_context=parent_context)

--- a/src/instana/instrumentation/aws/s3.py
+++ b/src/instana/instrumentation/aws/s3.py
@@ -15,7 +15,6 @@ try:
     from instana.singletons import get_tracer
     from instana.util.traceutils import (
         get_tracer_tuple,
-        tracing_is_off,
     )
 
     operations = {
@@ -48,11 +47,10 @@ try:
         args: Sequence[object],
         kwargs: Dict[str, Any],
     ) -> Callable[..., object]:
-        # If we're not tracing, just return
-        if tracing_is_off():
-            return wrapped(*args, **kwargs)
-
         tracer, parent_span, _ = get_tracer_tuple()
+        # If we're not tracing, just return
+        if not tracer:
+            return wrapped(*args, **kwargs)
 
         parent_context = parent_span.get_span_context() if parent_span else None
 

--- a/src/instana/instrumentation/cassandra.py
+++ b/src/instana/instrumentation/cassandra.py
@@ -14,7 +14,7 @@ try:
     import wrapt
 
     from instana.log import logger
-    from instana.util.traceutils import get_tracer_tuple, tracing_is_off
+    from instana.util.traceutils import get_tracer_tuple
 
     if TYPE_CHECKING:
         from cassandra.cluster import ResponseFuture, Session
@@ -73,10 +73,10 @@ try:
         fn: "ResponseFuture",
     ) -> None:
         tracer, parent_span, _ = get_tracer_tuple()
-        parent_context = parent_span.get_span_context() if parent_span else None
-
-        if tracing_is_off():
+        if not tracer:
             return
+
+        parent_context = parent_span.get_span_context() if parent_span else None
 
         attributes = {}
         if isinstance(fn.query, cassandra.query.SimpleStatement):

--- a/src/instana/instrumentation/couchbase.py
+++ b/src/instana/instrumentation/couchbase.py
@@ -25,7 +25,7 @@ try:
     import wrapt
 
     from instana.span.span import InstanaSpan
-    from instana.util.traceutils import get_tracer_tuple, tracing_is_off
+    from instana.util.traceutils import get_tracer_tuple
 
     # List of operations to instrument
     # incr, incr_multi, decr, decr_multi, retrieve_in are wrappers around operations above
@@ -94,11 +94,11 @@ try:
             kwargs: Dict[str, Any],
         ) -> object:
             tracer, parent_span, _ = get_tracer_tuple()
-            parent_context = parent_span.get_span_context() if parent_span else None
-
             # If we're not tracing, just return
-            if tracing_is_off():
+            if not tracer:
                 return wrapped(*args, **kwargs)
+
+            parent_context = parent_span.get_span_context() if parent_span else None
 
             with tracer.start_as_current_span(
                 "couchbase", span_context=parent_context
@@ -120,11 +120,11 @@ try:
         kwargs: Dict[str, Any],
     ) -> object:
         tracer, parent_span, _ = get_tracer_tuple()
-        parent_context = parent_span.get_span_context() if parent_span else None
-
         # If we're not tracing, just return
-        if tracing_is_off():
+        if not tracer:
             return wrapped(*args, **kwargs)
+
+        parent_context = parent_span.get_span_context() if parent_span else None
 
         with tracer.start_as_current_span(
             "couchbase", span_context=parent_context

--- a/src/instana/instrumentation/google/cloud/pubsub.py
+++ b/src/instana/instrumentation/google/cloud/pubsub.py
@@ -9,7 +9,7 @@ import wrapt
 from instana.log import logger
 from instana.propagators.format import Format
 from instana.singletons import get_tracer
-from instana.util.traceutils import get_tracer_tuple, tracing_is_off
+from instana.util.traceutils import get_tracer_tuple
 
 if TYPE_CHECKING:
     from instana.span.span import InstanaSpan
@@ -49,11 +49,11 @@ try:
         """References:
         - PublisherClient.publish(topic_path, messages, metadata)
         """
+        tracer, parent_span, _ = get_tracer_tuple()
         # return early if we're not tracing
-        if tracing_is_off():
+        if not tracer:
             return wrapped(*args, **kwargs)
 
-        tracer, parent_span, _ = get_tracer_tuple()
         parent_context = parent_span.get_span_context() if parent_span else None
 
         with tracer.start_as_current_span(

--- a/src/instana/instrumentation/google/cloud/storage.py
+++ b/src/instana/instrumentation/google/cloud/storage.py
@@ -8,7 +8,7 @@ import re
 from typing import Any, Callable, Dict, Tuple, Union
 from instana.log import logger
 from instana.instrumentation.google.cloud.collectors import _storage_api
-from instana.util.traceutils import get_tracer_tuple, tracing_is_off
+from instana.util.traceutils import get_tracer_tuple
 
 try:
     from google.cloud import storage
@@ -60,12 +60,13 @@ try:
         args: Tuple[object, ...],
         kwargs: Dict[str, Any],
     ) -> object:
+        tracer, parent_span, _ = get_tracer_tuple()
+
         # batch requests are traced with finish_batch_with_instana()
         # also return early if we're not tracing
-        if isinstance(instance, storage.Batch) or tracing_is_off():
+        if isinstance(instance, storage.Batch) or not tracer:
             return wrapped(*args, **kwargs)
 
-        tracer, parent_span, _ = get_tracer_tuple()
         parent_context = parent_span.get_span_context() if parent_span else None
 
         with tracer.start_as_current_span("gcs", span_context=parent_context) as span:
@@ -91,11 +92,11 @@ try:
         args: Tuple[object, ...],
         kwargs: Dict[str, Any],
     ) -> object:
+        tracer, parent_span, _ = get_tracer_tuple()
         # return early if we're not tracing
-        if tracing_is_off():
+        if not tracer:
             return wrapped(*args, **kwargs)
 
-        tracer, parent_span, _ = get_tracer_tuple()
         parent_context = parent_span.get_span_context() if parent_span else None
 
         with tracer.start_as_current_span("gcs", span_context=parent_context) as span:
@@ -127,11 +128,11 @@ try:
         args: Tuple[object, ...],
         kwargs: Dict[str, Any],
     ) -> object:
+        tracer, parent_span, _ = get_tracer_tuple()
         # return early if we're not tracing
-        if tracing_is_off():
+        if not tracer:
             return wrapped(*args, **kwargs)
 
-        tracer, parent_span, _ = get_tracer_tuple()
         parent_context = parent_span.get_span_context() if parent_span else None
 
         with tracer.start_as_current_span("gcs", span_context=parent_context) as span:
@@ -152,11 +153,11 @@ try:
         args: Tuple[object, ...],
         kwargs: Dict[str, Any],
     ) -> object:
+        tracer, parent_span, _ = get_tracer_tuple()
         # return early if we're not tracing
-        if tracing_is_off():
+        if not tracer:
             return wrapped(*args, **kwargs)
 
-        tracer, parent_span, _ = get_tracer_tuple()
         parent_context = parent_span.get_span_context() if parent_span else None
 
         with tracer.start_as_current_span("gcs", span_context=parent_context) as span:

--- a/src/instana/instrumentation/httpx.py
+++ b/src/instana/instrumentation/httpx.py
@@ -14,7 +14,6 @@ try:
     from instana.util.traceutils import (
         extract_custom_headers,
         get_tracer_tuple,
-        tracing_is_off,
     )
 
     if TYPE_CHECKING:
@@ -72,11 +71,11 @@ try:
         args: Tuple[int, str, Tuple[Any, ...]],
         kwargs: Dict[str, Any],
     ) -> httpx.Response:
+        tracer, parent_span, _ = get_tracer_tuple()
         # If we're not tracing, just return
-        if tracing_is_off():
+        if not tracer:
             return wrapped(*args, **kwargs)
 
-        tracer, parent_span, _ = get_tracer_tuple()
         parent_context = parent_span.get_span_context() if parent_span else None
 
         with tracer.start_as_current_span(
@@ -101,11 +100,11 @@ try:
         args: Tuple[int, str, Tuple[Any, ...]],
         kwargs: Dict[str, Any],
     ) -> httpx.Response:
+        tracer, parent_span, _ = get_tracer_tuple()
         # If we're not tracing, just return
-        if tracing_is_off():
+        if not tracer:
             return await wrapped(*args, **kwargs)
 
-        tracer, parent_span, _ = get_tracer_tuple()
         parent_context = parent_span.get_span_context() if parent_span else None
 
         with tracer.start_as_current_span(

--- a/src/instana/instrumentation/kafka/confluent_kafka_python.py
+++ b/src/instana/instrumentation/kafka/confluent_kafka_python.py
@@ -15,7 +15,7 @@ try:
     from instana.propagators.format import Format
     from instana.singletons import get_tracer
     from instana.span.span import InstanaSpan
-    from instana.util.traceutils import get_tracer_tuple, tracing_is_off
+    from instana.util.traceutils import get_tracer_tuple
 
     consumer_token = None
     consumer_span = contextvars.ContextVar("confluent_kafka_consumer_span")
@@ -61,10 +61,10 @@ try:
         args: Tuple[int, str, Tuple[Any, ...]],
         kwargs: Dict[str, Any],
     ) -> None:
-        if tracing_is_off():
+        tracer, parent_span, _ = get_tracer_tuple()
+        if not tracer:
             return wrapped(*args, **kwargs)
 
-        tracer, parent_span, _ = get_tracer_tuple()
         parent_context = parent_span.get_span_context() if parent_span else None
 
         # Get the topic from either args or kwargs

--- a/src/instana/instrumentation/kafka/kafka_python.py
+++ b/src/instana/instrumentation/kafka/kafka_python.py
@@ -15,7 +15,7 @@ try:
     from instana.propagators.format import Format
     from instana.singletons import get_tracer
     from instana.span.span import InstanaSpan
-    from instana.util.traceutils import get_tracer_tuple, tracing_is_off
+    from instana.util.traceutils import get_tracer_tuple
 
     if TYPE_CHECKING:
         from kafka.producer.future import FutureRecordMetadata
@@ -30,10 +30,11 @@ try:
         args: Tuple[int, str, Tuple[Any, ...]],
         kwargs: Dict[str, Any],
     ) -> "FutureRecordMetadata":
-        if tracing_is_off():
+        tracer, parent_span, _ = get_tracer_tuple()
+
+        if not tracer:
             return wrapped(*args, **kwargs)
 
-        tracer, parent_span, _ = get_tracer_tuple()
         parent_context = parent_span.get_span_context() if parent_span else None
 
         # Get the topic from either args or kwargs

--- a/src/instana/instrumentation/logging.py
+++ b/src/instana/instrumentation/logging.py
@@ -12,7 +12,7 @@ import wrapt
 from instana.log import logger
 from instana.singletons import agent
 from instana.util.runtime import get_runtime_env_info
-from instana.util.traceutils import get_tracer_tuple, tracing_is_off
+from instana.util.traceutils import get_tracer_tuple
 
 
 @wrapt.patch_function_wrapper("logging", "Logger._log")
@@ -34,15 +34,14 @@ def log_with_instana(
     stacklevel = stacklevel_in + 1
 
     try:
+        tracer, parent_span, _ = get_tracer_tuple()
         # Only needed if we're tracing and serious log and logging spans are not disabled
         if (
-            tracing_is_off()
+            not tracer
             or argv[0] < logging.WARN
             or agent.options.is_span_disabled(category="logging")
         ):
             return wrapped(*argv, **kwargs, stacklevel=stacklevel)
-
-        tracer, parent_span, _ = get_tracer_tuple()
 
         msg = str(argv[1])
         args = argv[2]

--- a/src/instana/instrumentation/pep0249.py
+++ b/src/instana/instrumentation/pep0249.py
@@ -7,10 +7,9 @@ from typing import TYPE_CHECKING, Dict, Any, List, Tuple, Union, Callable, Optio
 from typing_extensions import Self
 
 from opentelemetry.semconv.trace import SpanAttributes
-from opentelemetry.trace import SpanKind
 
 from instana.log import logger
-from instana.util.traceutils import get_tracer_tuple, tracing_is_off
+from instana.util.traceutils import get_tracer_tuple
 from instana.util.sql import sql_sanitizer
 
 if TYPE_CHECKING:
@@ -70,7 +69,7 @@ class CursorWrapper(wrapt.ObjectProxy):
         tracer, parent_span, operation_name = get_tracer_tuple()
 
         # If not tracing or we're being called from sqlalchemy, just pass through
-        if tracing_is_off() or (operation_name == "sqlalchemy"):
+        if not tracer or (operation_name == "sqlalchemy"):
             return self.__wrapped__.execute(sql, params)
 
         parent_context = parent_span.get_span_context() if parent_span else None
@@ -95,7 +94,7 @@ class CursorWrapper(wrapt.ObjectProxy):
         tracer, parent_span, operation_name = get_tracer_tuple()
 
         # If not tracing or we're being called from sqlalchemy, just pass through
-        if tracing_is_off() or (operation_name == "sqlalchemy"):
+        if not tracer or (operation_name == "sqlalchemy"):
             return self.__wrapped__.executemany(sql, seq_of_parameters)
 
         parent_context = parent_span.get_span_context() if parent_span else None
@@ -120,7 +119,7 @@ class CursorWrapper(wrapt.ObjectProxy):
         tracer, parent_span, operation_name = get_tracer_tuple()
 
         # If not tracing or we're being called from sqlalchemy, just pass through
-        if tracing_is_off() or (operation_name == "sqlalchemy"):
+        if not tracer or (operation_name == "sqlalchemy"):
             return self.__wrapped__.execute(proc_name, params)
 
         parent_context = parent_span.get_span_context() if parent_span else None

--- a/src/instana/instrumentation/pymongo.py
+++ b/src/instana/instrumentation/pymongo.py
@@ -4,7 +4,7 @@
 
 from instana.span.span import InstanaSpan
 from instana.log import logger
-from instana.util.traceutils import get_tracer_tuple, tracing_is_off
+from instana.util.traceutils import get_tracer_tuple
 
 try:
     import pymongo
@@ -18,7 +18,7 @@ try:
         def started(self, event: pymongo.monitoring.CommandStartedEvent) -> None:
             tracer, parent_span, _ = get_tracer_tuple()
             # return early if we're not tracing
-            if tracing_is_off():
+            if not tracer:
                 return
             parent_context = parent_span.get_span_context() if parent_span else None
 

--- a/src/instana/instrumentation/redis.py
+++ b/src/instana/instrumentation/redis.py
@@ -2,15 +2,15 @@
 # (c) Copyright Instana Inc. 2018
 
 
-from typing import Any, Callable, Dict, Tuple
-import wrapt
-
-from instana.log import logger
-from instana.span.span import InstanaSpan
-from instana.util.traceutils import get_tracer_tuple, tracing_is_off
-
 try:
+    from typing import Any, Callable, Dict, Tuple
+
     import redis
+    import wrapt
+
+    from instana.log import logger
+    from instana.span.span import InstanaSpan
+    from instana.util.traceutils import get_tracer_tuple
 
     EXCLUDED_PARENT_SPANS = ["redis", "celery-client", "celery-worker"]
 
@@ -44,11 +44,12 @@ try:
         kwargs: Dict[str, Any],
     ) -> object:
         tracer, parent_span, operation_name = get_tracer_tuple()
-        parent_context = parent_span.get_span_context() if parent_span else None
 
         # If we're not tracing, just return
-        if tracing_is_off() or (operation_name in EXCLUDED_PARENT_SPANS):
+        if not tracer or (operation_name in EXCLUDED_PARENT_SPANS):
             return wrapped(*args, **kwargs)
+
+        parent_context = parent_span.get_span_context() if parent_span else None
 
         with tracer.start_as_current_span("redis", span_context=parent_context) as span:
             try:
@@ -70,11 +71,12 @@ try:
         kwargs: Dict[str, Any],
     ) -> object:
         tracer, parent_span, operation_name = get_tracer_tuple()
-        parent_context = parent_span.get_span_context() if parent_span else None
 
         # If we're not tracing, just return
-        if tracing_is_off() or (operation_name in EXCLUDED_PARENT_SPANS):
+        if not tracer or (operation_name in EXCLUDED_PARENT_SPANS):
             return wrapped(*args, **kwargs)
+
+        parent_context = parent_span.get_span_context() if parent_span else None
 
         with tracer.start_as_current_span("redis", span_context=parent_context) as span:
             try:

--- a/src/instana/instrumentation/urllib3.py
+++ b/src/instana/instrumentation/urllib3.py
@@ -13,7 +13,6 @@ from instana.singletons import agent
 from instana.util.secrets import strip_secrets_from_query
 from instana.util.traceutils import (
     get_tracer_tuple,
-    tracing_is_off,
     extract_custom_headers,
 )
 
@@ -107,7 +106,7 @@ try:
         host = getattr(instance, "host", "") or ""
 
         if (
-            tracing_is_off()
+            not tracer
             or span_name == "boto3"
             or "com.instana" in request_url_or_path
             or "com.instana" in host

--- a/tests/clients/test_google-cloud-storage.py
+++ b/tests/clients/test_google-cloud-storage.py
@@ -1073,13 +1073,13 @@ class TestGoogleCloudStorage(_TraceContextMixin):
                 pass
             assert isinstance(buckets, page_iterator.HTTPIterator)
 
-    def test_execute_with_instana_tracing_is_off(self) -> None:
+    def test_execute_with_instana_is_tracing_off(self) -> None:
         client = self._client(
             credentials=AnonymousCredentials(), project="test-project"
         )
         with self.tracer.start_as_current_span("test"), patch(
-            "instana.instrumentation.google.cloud.storage.tracing_is_off",
-            return_value=True,
+            "instana.instrumentation.google.cloud.storage.get_tracer_tuple",
+            return_value=(None, None, None),
         ):
             response = client.list_buckets()
             assert isinstance(response.client, storage.Client)
@@ -1089,7 +1089,7 @@ class TestGoogleCloudStorage(_TraceContextMixin):
         reason='Avoiding "Fatal Python error: Segmentation fault"',
     )
     @patch("requests.Session.request")
-    def test_download_with_instana_tracing_is_off(self, mock_requests: Mock) -> None:
+    def test_download_with_instana_is_tracing_off(self, mock_requests: Mock) -> None:
         mock_requests.return_value = self._mock_response(
             content=b"CONTENT", status_code=http_client.OK
         )
@@ -1097,8 +1097,8 @@ class TestGoogleCloudStorage(_TraceContextMixin):
             credentials=AnonymousCredentials(), project="test-project"
         )
         with self.tracer.start_as_current_span("test"), patch(
-            "instana.instrumentation.google.cloud.storage.tracing_is_off",
-            return_value=True,
+            "instana.instrumentation.google.cloud.storage.get_tracer_tuple",
+            return_value=(None, None, None),
         ):
             response = (
                 client.bucket("test bucket")
@@ -1111,7 +1111,7 @@ class TestGoogleCloudStorage(_TraceContextMixin):
             assert not response
 
     @patch("requests.Session.request")
-    def test_upload_with_instana_tracing_is_off(self, mock_requests: Mock) -> None:
+    def test_upload_with_instana_is_tracing_off(self, mock_requests: Mock) -> None:
         mock_requests.return_value = self._mock_response(
             json_content={"kind": "storage#object"}, status_code=http_client.OK
         )
@@ -1121,8 +1121,8 @@ class TestGoogleCloudStorage(_TraceContextMixin):
         )
 
         with self.tracer.start_as_current_span("test"), patch(
-            "instana.instrumentation.google.cloud.storage.tracing_is_off",
-            return_value=True,
+            "instana.instrumentation.google.cloud.storage.get_tracer_tuple",
+            return_value=(None, None, None),
         ):
             response = (
                 client.bucket("test bucket")
@@ -1132,7 +1132,7 @@ class TestGoogleCloudStorage(_TraceContextMixin):
             assert not response
 
     @patch("requests.Session.request")
-    def test_finish_batch_operation_tracing_is_off(self, mock_requests: Mock) -> None:
+    def test_finish_batch_operation_is_tracing_off(self, mock_requests: Mock) -> None:
         mock_requests.return_value = self._mock_response(
             _TWO_PART_BATCH_RESPONSE,
             status_code=http_client.OK,
@@ -1145,8 +1145,8 @@ class TestGoogleCloudStorage(_TraceContextMixin):
         bucket = client.bucket("test-bucket")
 
         with self.tracer.start_as_current_span("test"), patch(
-            "instana.instrumentation.google.cloud.storage.tracing_is_off",
-            return_value=True,
+            "instana.instrumentation.google.cloud.storage.get_tracer_tuple",
+            return_value=(None, None, None),
         ):
             with client.batch() as batch_response:
                 for obj in ["obj1", "obj2"]:

--- a/tests/clients/test_pika.py
+++ b/tests/clients/test_pika.py
@@ -467,8 +467,8 @@ class TestPikaChannel(_TestPika):
     @mock.patch("pika.channel.Channel._send_method")
     def test_basic_publish_tracing_off(self, send_method, _unused, mocker) -> None:
         mocker.patch(
-            "instana.instrumentation.pika.tracing_is_off",
-            return_value=True,
+            "instana.instrumentation.pika.get_tracer_tuple",
+            return_value=(None, None, None),
         )
 
         self.obj._set_state(self.obj.OPEN)

--- a/tests/frameworks/test_aiohttp_client.py
+++ b/tests/frameworks/test_aiohttp_client.py
@@ -476,8 +476,8 @@ class TestAiohttpClient:
 
     def test_client_get_tracing_off(self, mocker) -> None:
         mocker.patch(
-            "instana.instrumentation.aiohttp.client.tracing_is_off",
-            return_value=True,
+            "instana.instrumentation.aiohttp.client.get_tracer_tuple",
+            return_value=(None, None, None),
         )
 
         async def test():

--- a/tests/frameworks/test_sanic.py
+++ b/tests/frameworks/test_sanic.py
@@ -37,7 +37,6 @@ class TestSanic(_TraceContextMixin):
         """Setup and Teardown"""
         # setup
         # Clear all spans before a test run
-        self.tracer = get_tracer()
         self.recorder = self.tracer.span_processor
         self.recorder.clear_spans()
 

--- a/tests/util/test_traceutils.py
+++ b/tests/util/test_traceutils.py
@@ -5,12 +5,9 @@ from typing import Generator
 import pytest
 
 from instana.singletons import agent, get_tracer
-from instana.tracer import InstanaTracer
 from instana.util.traceutils import (
     extract_custom_headers,
-    get_active_tracer,
     get_tracer_tuple,
-    tracing_is_off,
 )
 
 
@@ -66,21 +63,7 @@ class TestTraceutils:
         assert span.attributes["http.header.X-Capture-This-Too"] == "this too"
         assert span.attributes["http.header.X-Capture-That-Too"] == "that too"
 
-    def test_get_activate_tracer(self, mocker) -> None:
-        assert not get_active_tracer()
-
-        with self.tracer.start_as_current_span("test"):
-            response = get_active_tracer()
-            assert isinstance(response, InstanaTracer)
-            assert response == self.tracer
-            with mocker.patch(
-                "instana.span.span.InstanaSpan.is_recording", return_value=False
-            ):
-                assert not get_active_tracer()
-
-    def test_get_tracer_tuple(
-        self,
-    ) -> None:
+    def test_get_tracer_tuple(self) -> None:
         response = get_tracer_tuple()
         assert response == (None, None, None)
 
@@ -92,15 +75,3 @@ class TestTraceutils:
         with self.tracer.start_as_current_span("test") as span:
             response = get_tracer_tuple()
             assert response == (self.tracer, span, span.name)
-
-    def test_tracing_is_off(self) -> None:
-        response = tracing_is_off()
-        assert response
-        with self.tracer.start_as_current_span("test"):
-            response = tracing_is_off()
-            assert not response
-
-        agent.options.allow_exit_as_root = True
-        response = tracing_is_off()
-        assert not response
-        agent.options.allow_exit_as_root = False


### PR DESCRIPTION
`tracing_is_off` function is also widely used in almost every instrumentation and it only returns whether the tracer is ready to record a new span or not. As I already explained above, we already have this information in the tracer, so that by combining these two functions into get_tracer_tuple function, we're getting rid of 1 get_current_span call and functionality of `tracing_is_off` function since we can directly check if the tracer in the instrumentation is False or not.

- `get_active_tracer` and `tracing_is_off` functions has been removed
- adapted instrumentations to the new get_tracer_tuple function