### PR TITLE
fix: do not create spans when confluent-kafka.poll() response is empty

### DIFF
--- a/src/instana/instrumentation/kafka/confluent_kafka_python.py
+++ b/src/instana/instrumentation/kafka/confluent_kafka_python.py
@@ -251,7 +251,8 @@ try:
 
         try:
             res = wrapped(*args, **kwargs)
-            create_span("poll", res.topic(), res.headers())
+            if res:
+                create_span("poll", res.topic(), res.headers())
             return res
         except Exception as exc:
             exception = exc


### PR DESCRIPTION
This PR solves the confluent-kafka bug below:
``` python
Traceback (most recent call last):
  File "/opt/instana/instrumentation/python/instana/instrumentation/kafka/confluent_kafka_python.py", line 254, in trace_kafka_poll
    create_span("poll", res.topic(), res.headers())
                        ^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'topic'
```

Note: This issue doesn't happen in the Kafka-Python package since the poll function there works differently.