### PR TITLE
fix: Currency report generation

### DIFF
--- a/.tekton/.currency/scripts/generate_report.py
+++ b/.tekton/.currency/scripts/generate_report.py
@@ -23,7 +23,7 @@ SPEC_MAP = {
 
 
 def estimate_days_behind(release_date):
-    return datetime.today() - datetime.strptime(release_date, "%Y-%m-%d")
+    return (datetime.today().date() - datetime.strptime(release_date, "%Y-%m-%d").date()).days
 
 
 def get_upstream_version(dependency, last_supported_version):


### PR DESCRIPTION
- Fix Successful taskrun filter condition. Current condition doesn't return successful taskruns.

```yaml
conditions:
  - lastTransitionTime: "2019-08-12T18:22:57Z"
    message: All Steps have completed executing
    reason: Succeeded
    status: "True"
    type: Succeeded
```

`type`: "Succeeded", `status`: "False"  → failed (e.g., "step-unittest" exited with code 1)
`type`: "Succeeded", `status`: "True"  → succeeded (e.g., All Steps have completed executing)


- Return days behind in `int` instead of `timedelta`

| Package name         | Support Policy   | Beta version   | Last Supported Version   | Latest version   | Up-to-date   | Release date   | Latest Version Published At   | Days behind                     | Cloud Native   |
|:---------------------|:-----------------|:---------------|:-------------------------|:-----------------|:-------------|:---------------|:------------------------------|:--------------------------------|:---------------|
| FastAPI              | 45-days          | No             | 0.124.2                  | 0.124.4          | No           | 2025-12-12     | 2025-12-10                    | 5 days, 17:26:54.833221 day/s   | No          
| Urllib3              | 45-days          | No             | 2.6.1                    | 2.6.2            | No           | 2025-12-11     | 2025-12-08                    | 7 days, 17:26:56.997257 day/s   | No             