### PR TITLE
Ensure locally executable UT

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,17 @@
+ARG PYTHON_VERSION=3.12
+FROM public.ecr.aws/docker/library/python:${PYTHON_VERSION}-slim
+
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    make \
+    git \
+    pkg-config \
+    default-libmysqlclient-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir --upgrade pip
+
+CMD ["echo", "Container ready..."]

--- a/README.md
+++ b/README.md
@@ -55,9 +55,29 @@ You can find more documentation covering supported components and minimum versio
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/instana/python-sensor.
 
-## More
+## Run Tests with Docker
+Docker compose file currently supports up to Python version 3.14.
 
-Want to instrument other languages?  See our [Node.js], [Go], [Ruby] instrumentation or many other [supported technologies].
+Run tests for all Python versions:
+- `docker compose --profile infra-general --profile tests-general up --build --abort-on-container-exit | grep python-sensor-test`
+
+To run tests for a specific Python version using Docker, 3.12 for example:
+- `docker compose --profile infra-general --profile py312 up --build --abort-on-container-exit | grep python-sensor-test`
+
+Cassandra Tests:
+- `docker compose --profile infra-cassandra --profile tests-cassandra up --build --abort-on-container-exit | grep python-sensor-test`
+
+Kafka Tests:
+- `docker compose --profile infra-kafka --profile tests-kafka up --build --abort-on-container-exit | grep python-sensor-test`
+
+Gevent Tests:
+- `docker compose --profile tests-gevent up --build --abort-on-container-exit | grep python-sensor-test`
+
+AWS Tests:
+- `docker compose --profile tests-aws up --build --abort-on-container-exit | grep python-sensor-test`
+
+## More
+Want to instrument other languages? See our [Node.js], [Go], [Ruby] instrumentation or many other [supported technologies].
 
 <!-- Reference links -->
 [Instana]: https://www.instana.com/ "IBM Instana Observability"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,65 @@
+x-common-env: &common-env
+  PYTHONUNBUFFERED: "1"
+  REDIS_HOST: redis
+  MYSQL_HOST: mariadb
+  MONGO_HOST: mongodb
+  POSTGRES_HOST: postgres
+  RABBITMQ_HOST: rabbitmq
+  PUBSUB_EMULATOR_HOST: pubsub:8681
+
+x-general-deps: &general-deps
+  redis: { condition: service_healthy }
+  mariadb: { condition: service_healthy }
+  mongodb: { condition: service_healthy }
+  postgres: { condition: service_healthy }
+  rabbitmq: { condition: service_healthy }
+  pubsub: { condition: service_started }
+
+x-cassandra-deps: &cassandra-deps
+  cassandra: { condition: service_healthy }
+
+x-kafka-deps: &kafka-deps
+  kafka: { condition: service_healthy }
+
+x-test-template: &test-template
+  build:
+    context: .
+    dockerfile: Dockerfile.test
+  environment:
+    <<: *common-env
+  networks:
+    - default
+
+x-standard-test-command: &standard-test-command >
+  /bin/bash -c "
+  pip install --upgrade pip setuptools wheel &&
+  pip install wrapt --upgrade --force-reinstall &&
+  pip install -r requirements.txt &&
+  pip install -r tests/requirements.txt &&
+
+  coverage run --source=instana -m pytest -v --junitxml=test-results/junit.xml tests &&
+  coverage report -m
+  "
+
 services:
+
   redis:
     image: public.ecr.aws/docker/library/redis
+    profiles: ["infra-general", "all-infra"]
     volumes:
       - ./tests/conf/redis.conf:/usr/local/etc/redis/redis.conf:Z
     command: redis-server /usr/local/etc/redis/redis.conf
-    ports:
-      - "0.0.0.0:6379:6379"
-
-  cassandra:
-    image: public.ecr.aws/docker/library/cassandra
-    ports:
-      - 9042:9042
-
-  couchbase:
-    image: public.ecr.aws/docker/library/couchbase:community
-    ports:
-      - 8091-8094:8091-8094
-      - 11210:11210
+    ports: ["6379:6379"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
   mariadb:
     image: public.ecr.aws/docker/library/mariadb
-    ports:
-      - 3306:3306
+    profiles: ["infra-general", "all-infra"]
+    ports: ["3306:3306"]
     environment:
       MYSQL_DATABASE: 'instana_test_db'
       MYSQL_USER: 'root'
@@ -29,55 +67,86 @@ services:
       MYSQL_ROOT_HOST: '%'
     volumes:
       - ./tests/config/database/mysql/conf.d/mysql.cnf:/etc/mysql/conf.d/mysql.cnf:Z
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
 
   mongodb:
     image: public.ecr.aws/docker/library/mongo
-    ports:
-      - '27017:27017'
+    profiles: ["infra-general", "all-infra"]
+    ports: ["27017:27017"]
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
   postgres:
     image: public.ecr.aws/docker/library/postgres
-    ports:
-      - 5432:5432
+    profiles: ["infra-general", "all-infra"]
+    ports: ["5432:5432"]
     environment:
       POSTGRES_USER: root
       POSTGRES_PASSWORD: passw0rd
       POSTGRES_DB: instana_test_db
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U root -d instana_test_db"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
   rabbitmq:
     image: public.ecr.aws/docker/library/rabbitmq
+    profiles: ["infra-general", "all-infra"]
     environment:
       - RABBITMQ_NODENAME=rabbit@localhost
-    ports:
-      - 5671:5671
-      - 5672:5672
+    ports: ["5671:5671", "5672:5672"]
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "check_port_connectivity"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 30s
 
   pubsub:
     image: quay.io/thekevjames/gcloud-pubsub-emulator:latest
+    profiles: ["infra-general", "all-infra"]
     environment:
       - PUBSUB_EMULATOR_HOST=0.0.0.0:8681
       - PUBSUB_PROJECT1=test-project,test-topic
-    ports:
-      - "8681:8681"
-      - "8682:8682"
+    ports: ["8681:8681", "8682:8682"]
 
-  # Sidecar container for Kafka
+  cassandra:
+    image: public.ecr.aws/docker/library/cassandra
+    profiles: ["infra-cassandra", "all-infra"]
+    ports: ["9042:9042"]
+    environment:
+      MAX_HEAP_SIZE: 2048m
+      HEAP_NEWSIZE: 512m
+    healthcheck:
+      test: ["CMD-SHELL", "cqlsh -e 'describe cluster'"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+
   zookeeper:
     image: public.ecr.aws/ubuntu/zookeeper:3.1-22.04_edge
+    profiles: ["infra-kafka", "all-infra"]
     ports: ["2181:2181"]
     environment: [ "TZ=UTC" ]
 
   kafka:
     image: public.ecr.aws/ubuntu/kafka:3.1-22.04_edge
+    profiles: ["infra-kafka", "all-infra"]
     depends_on: [zookeeper]
-    ports: 
-      - "9094:9094"
-      - "9093:9093"
+    ports: ["9094:9094", "9093:9093"]
     environment:
       - TZ=UTC
       - ZOOKEEPER_HOST=zookeeper
       - ZOOKEEPER_PORT=2181
-    command: 
+    command:
       - /opt/kafka/config/server.properties
       - --override
       - listeners=INTERNAL://0.0.0.0:9093,EXTERNAL://0.0.0.0:9094
@@ -97,3 +166,201 @@ services:
       - transaction.state.log.min.isr=1
       - --override
       - auto.create.topics.enable=true
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-broker-api-versions.sh --bootstrap-server localhost:9093 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+
+  # ================================================================
+  # GENERAL TEST MATRIX
+  # ================================================================
+
+  test-py39:
+    <<: *test-template
+    image: python-sensor-test:3.9
+    container_name: python-sensor-test-py39
+    profiles: ["tests-general", "py39"]
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+      args:
+        PYTHON_VERSION: "3.9"
+    depends_on: *general-deps
+    volumes: [".:/app", "test-results-py39:/app/test-results"]
+    command: *standard-test-command
+
+  test-py310:
+    <<: *test-template
+    image: python-sensor-test:3.10
+    container_name: python-sensor-test-py310
+    profiles: ["tests-general", "py310"]
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+      args:
+        PYTHON_VERSION: "3.10"
+    depends_on: *general-deps
+    volumes: [".:/app", "test-results-py310:/app/test-results"]
+    command: *standard-test-command
+
+  test-py311:
+    <<: *test-template
+    image: python-sensor-test:3.11
+    container_name: python-sensor-test-py311
+    profiles: ["tests-general", "py311"]
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+      args:
+        PYTHON_VERSION: "3.11"
+    depends_on: *general-deps
+    volumes: [".:/app", "test-results-py311:/app/test-results"]
+    command: *standard-test-command
+
+  test-py312:
+    <<: *test-template
+    image: python-sensor-test:3.12
+    container_name: python-sensor-test-py312
+    profiles: ["tests-general", "py312"]
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+      args:
+        PYTHON_VERSION: "3.12"
+    depends_on: *general-deps
+    volumes: [".:/app", "test-results-py312:/app/test-results"]
+    command: *standard-test-command
+
+  test-py313:
+    <<: *test-template
+    image: python-sensor-test:3.13
+    container_name: python-sensor-test-py313
+    profiles: ["tests-general", "py313"]
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+      args:
+        PYTHON_VERSION: "3.13"
+    depends_on: *general-deps
+    volumes: [".:/app", "test-results-py313:/app/test-results"]
+    command: *standard-test-command
+
+  # ================================================================
+  # SPECIALIZED TESTS
+  # ================================================================
+
+  test-cassandra:
+    <<: *test-template
+    image: python-sensor-test:3.9
+    container_name: python-sensor-test-cassandra
+    profiles: ["tests-cassandra"]
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+      args:
+        PYTHON_VERSION: "3.9"
+    depends_on: *cassandra-deps
+    volumes: [".:/app", "test-results-cassandra:/app/test-results"]
+    environment:
+      <<: *common-env
+      CASSANDRA_HOST: cassandra
+      CASSANDRA_TEST: "true"
+    command: >
+      /bin/bash -c "
+      pip install --upgrade pip setuptools wheel &&
+      pip install wrapt --upgrade --force-reinstall &&
+      pip install -r requirements.txt &&
+      pip install -r tests/requirements-cassandra.txt &&
+      
+      coverage run --source=instana -m pytest -v --junitxml=test-results/junit.xml tests/clients/test_cassandra-driver.py &&
+      coverage report -m
+      "
+
+  test-kafka:
+    <<: *test-template
+    image: python-sensor-test:3.13
+    container_name: python-sensor-test-kafka
+    profiles: ["tests-kafka"]
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+      args:
+        PYTHON_VERSION: "3.13"
+    depends_on: *kafka-deps
+    volumes: [".:/app", "test-results-kafka:/app/test-results"]
+    environment:
+      <<: *common-env
+      KAFKA_HOST: kafka
+      KAFKA_PORT: "9093"
+      KAFKA_TEST: "true"
+    command: >
+      /bin/bash -c "
+      pip install --upgrade pip setuptools wheel &&
+      pip install wrapt --upgrade --force-reinstall &&
+      pip install -r requirements.txt &&
+      pip install -r tests/requirements-kafka.txt &&
+      
+      coverage run --source=instana -m pytest -v --junitxml=test-results/junit.xml tests/clients/kafka/test*.py &&
+      coverage report -m
+      "
+
+  test-gevent:
+    <<: *test-template
+    image: python-sensor-test:3.9
+    container_name: python-sensor-test-gevent
+    profiles: ["tests-gevent"]
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+      args:
+        PYTHON_VERSION: "3.9"
+    volumes: [".:/app", "test-results-gevent:/app/test-results"]
+    environment:
+      <<: *common-env
+      GEVENT_TEST: "true"
+    command: >
+      /bin/bash -c "
+      pip install --upgrade pip setuptools wheel &&
+      pip install wrapt --upgrade --force-reinstall &&
+      pip install -r requirements.txt &&
+      pip install -r tests/requirements-gevent-starlette.txt &&
+      
+      coverage run --source=instana -m pytest -v --junitxml=test-results/junit.xml tests/frameworks/test_gevent.py &&
+      coverage report -m
+      "
+
+  test-aws:
+    <<: *test-template
+    image: python-sensor-test:3.12
+    container_name: python-sensor-test-aws
+    profiles: ["tests-aws"]
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+      args:
+        PYTHON_VERSION: "3.12"
+    volumes: [".:/app", "test-results-aws:/app/test-results"]
+    # AWS test uses common env, no extra vars needed, so we rely on template
+    command: >
+      /bin/bash -c "
+      pip install --upgrade pip setuptools wheel &&
+      pip install wrapt --upgrade --force-reinstall &&
+      pip install -r requirements.txt &&
+      pip install -r tests/requirements-aws.txt &&
+      
+      coverage run --source=instana -m pytest -v --junitxml=test-results/junit.xml tests_aws &&
+      coverage report -m
+      "
+
+volumes:
+  test-results-py39:
+  test-results-py310:
+  test-results-py311:
+  test-results-py312:
+  test-results-py313:
+  test-results-general:
+  test-results-cassandra:
+  test-results-kafka:
+  test-results-gevent:
+  test-results-aws:

--- a/tests/clients/test_aio_pika.py
+++ b/tests/clients/test_aio_pika.py
@@ -6,6 +6,7 @@ import asyncio
 from aio_pika import Message, connect, connect_robust
 
 from instana.singletons import agent, get_tracer
+from tests.helpers import testenv
 
 if TYPE_CHECKING:
     from instana.span.readable_span import ReadableSpan
@@ -33,7 +34,9 @@ class TestAioPika:
 
     async def publish_message(self, params_combination: str = "both_args") -> None:
         # Perform connection
-        connection = await connect()
+        connection = await connect(
+            host=testenv["rabbitmq_host"], port=testenv["rabbitmq_port"]
+        )
 
         async with connection:
             # Creating a channel
@@ -68,14 +71,18 @@ class TestAioPika:
             await exchange.publish(*args, **kwargs)
 
     async def delete_queue(self) -> None:
-        connection = await connect()
+        connection = await connect(
+            host=testenv["rabbitmq_host"], port=testenv["rabbitmq_port"]
+        )
 
         async with connection:
             channel = await connection.channel()
             await channel.queue_delete(self.queue_name)
 
     async def consume_message(self, connect_method) -> None:
-        connection = await connect_method()
+        connection = await connect_method(
+            host=testenv["rabbitmq_host"], port=testenv["rabbitmq_port"]
+        )
 
         async with connection:
             # Creating channel
@@ -91,7 +98,9 @@ class TestAioPika:
                             break
 
     async def consume_with_exception(self, connect_method) -> None:
-        connection = await connect_method()
+        connection = await connect_method(
+            host=testenv["rabbitmq_host"], port=testenv["rabbitmq_port"]
+        )
 
         async def on_message(msg):
             raise RuntimeError("Simulated Exception")

--- a/tests/clients/test_google-cloud-pubsub.py
+++ b/tests/clients/test_google-cloud-pubsub.py
@@ -17,8 +17,8 @@ from instana.singletons import agent, get_tracer
 from instana.span.span import get_current_span
 from tests.test_utils import _TraceContextMixin
 
-# Use PubSub Emulator exposed at :8085
-os.environ["PUBSUB_EMULATOR_HOST"] = "localhost:8681"
+# Use PubSub Emulator exposed at :8681
+os.environ["PUBSUB_EMULATOR_HOST"] = os.getenv("PUBSUB_EMULATOR_HOST", "localhost:8681")
 
 
 class TestPubSubPublish(_TraceContextMixin):

--- a/tests/clients/test_pep0249.py
+++ b/tests/clients/test_pep0249.py
@@ -93,12 +93,12 @@ class TestCursorWrapper:
         # Test Connection
         assert (
             self.test_conn.dsn
-            == "user=root password=xxx dbname=instana_test_db host=127.0.0.1 port=5432"
+            == f'user=root password=xxx dbname=instana_test_db host={testenv["postgresql_host"]} port=5432'
         )
         assert not self.test_conn.autocommit
         assert self.test_conn.status == 1
         assert self.test_conn.info.dbname == "instana_test_db"
-        assert self.test_conn.info.host == "127.0.0.1"
+        assert self.test_conn.info.host == testenv["postgresql_host"]
         assert self.test_conn.info.user == "root"
         assert self.test_conn.info.port == 5432
 
@@ -122,7 +122,7 @@ class TestCursorWrapper:
             assert span.attributes["db.name"] == "instana_test_db"
             assert span.attributes["db.statement"] == sample_sql
             assert span.attributes["db.user"] == "root"
-            assert span.attributes["host"] == "127.0.0.1"
+            assert span.attributes["host"] == testenv["postgresql_host"]
             assert span.attributes["port"] == 5432
 
     def test_collect_kvs_error(self, caplog: LogCaptureFixture) -> None:
@@ -260,11 +260,11 @@ class TestConnectionWrapper:
         self.connect_params = [
             "db",
             {
-                "db": "instana_test_db",
-                "host": "localhost",
-                "port": "5432",
-                "user": "root",
-                "password": "passw0rd",
+                "db": testenv["postgresql_db"],
+                "host": testenv["postgresql_host"],
+                "port": testenv["postgresql_port"],
+                "user": testenv["postgresql_user"],
+                "password": testenv["postgresql_pw"],
             },
         ]
         self.test_conn = psycopg2.connect(
@@ -319,7 +319,7 @@ class TestConnectionFactory:
 
     def test_call(self) -> None:
         response = self.conn_fact(
-            dsn="user=root password=passw0rd dbname=instana_test_db host=localhost port=5432"
+            dsn=f'user=root password=passw0rd dbname=instana_test_db host={testenv["postgresql_host"]} port=5432'
         )
         assert isinstance(self.conn_fact._wrapper_ctor, ConnectionWrapper.__class__)
         assert self.conn_fact._connect_func == self.test_conn_func

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,10 +91,11 @@ if sys.version_info >= (3, 14):
 
 @pytest.fixture(scope="session")
 def celery_config():
+    redis_host = os.environ.get("REDIS_HOST", "localhost")
     return {
         "broker_connection_retry_on_startup": True,
-        "broker_url": "redis://localhost:6379",
-        "result_backend": "redis://localhost:6379",
+        "broker_url": f"redis://{redis_host}:6379",
+        "result_backend": f"redis://{redis_host}:6379",
     }
 
 

--- a/tests/frameworks/test_celery.py
+++ b/tests/frameworks/test_celery.py
@@ -2,6 +2,7 @@
 # (c) Copyright Instana Inc. 2020
 
 
+import os
 import time
 from typing import Generator, List
 
@@ -52,6 +53,7 @@ class TestCelery:
         self.tracer = get_tracer()
         self.recorder = self.tracer.span_processor
         self.recorder.clear_spans()
+        self.redis_host = os.environ.get("REDIS_HOST", "localhost")
         yield
 
     def test_apply_async(
@@ -92,7 +94,7 @@ class TestCelery:
 
         assert client_span.data["celery"]["task"] == "tests.frameworks.test_celery.add"
         assert client_span.data["celery"]["scheme"] == "redis"
-        assert client_span.data["celery"]["host"] == "localhost"
+        assert client_span.data["celery"]["host"] == self.redis_host
         assert client_span.data["celery"]["port"] == "6379"
         assert client_span.data["celery"]["task_id"]
         assert not client_span.data["celery"]["error"]
@@ -100,7 +102,7 @@ class TestCelery:
 
         assert worker_span.data["celery"]["task"] == "tests.frameworks.test_celery.add"
         assert worker_span.data["celery"]["scheme"] == "redis"
-        assert worker_span.data["celery"]["host"] == "localhost"
+        assert worker_span.data["celery"]["host"] == self.redis_host
         assert worker_span.data["celery"]["port"] == "6379"
         assert worker_span.data["celery"]["task_id"]
         assert not worker_span.data["celery"]["error"]
@@ -145,7 +147,7 @@ class TestCelery:
 
         assert client_span.data["celery"]["task"] == "tests.frameworks.test_celery.add"
         assert client_span.data["celery"]["scheme"] == "redis"
-        assert client_span.data["celery"]["host"] == "localhost"
+        assert client_span.data["celery"]["host"] == self.redis_host
         assert client_span.data["celery"]["port"] == "6379"
         assert client_span.data["celery"]["task_id"]
         assert not client_span.data["celery"]["error"]
@@ -153,7 +155,7 @@ class TestCelery:
 
         assert worker_span.data["celery"]["task"] == "tests.frameworks.test_celery.add"
         assert worker_span.data["celery"]["scheme"] == "redis"
-        assert worker_span.data["celery"]["host"] == "localhost"
+        assert worker_span.data["celery"]["host"] == self.redis_host
         assert worker_span.data["celery"]["port"] == "6379"
         assert worker_span.data["celery"]["task_id"]
         assert not worker_span.data["celery"]["error"]
@@ -198,7 +200,7 @@ class TestCelery:
 
         assert client_span.data["celery"]["task"] == "tests.frameworks.test_celery.add"
         assert client_span.data["celery"]["scheme"] == "redis"
-        assert client_span.data["celery"]["host"] == "localhost"
+        assert client_span.data["celery"]["host"] == self.redis_host
         assert client_span.data["celery"]["port"] == "6379"
         assert client_span.data["celery"]["task_id"]
         assert not client_span.data["celery"]["error"]
@@ -206,7 +208,7 @@ class TestCelery:
 
         assert worker_span.data["celery"]["task"] == "tests.frameworks.test_celery.add"
         assert worker_span.data["celery"]["scheme"] == "redis"
-        assert worker_span.data["celery"]["host"] == "localhost"
+        assert worker_span.data["celery"]["host"] == self.redis_host
         assert worker_span.data["celery"]["port"] == "6379"
         assert worker_span.data["celery"]["task_id"]
         assert not worker_span.data["celery"]["error"]
@@ -264,7 +266,7 @@ class TestCelery:
             == "tests.frameworks.test_celery.will_raise_error"
         )
         assert client_span.data["celery"]["scheme"] == "redis"
-        assert client_span.data["celery"]["host"] == "localhost"
+        assert client_span.data["celery"]["host"] == self.redis_host
         assert client_span.data["celery"]["port"] == "6379"
         assert client_span.data["celery"]["task_id"]
         assert not client_span.data["celery"]["error"]
@@ -275,7 +277,7 @@ class TestCelery:
             == "tests.frameworks.test_celery.will_raise_error"
         )
         assert worker_span.data["celery"]["scheme"] == "redis"
-        assert worker_span.data["celery"]["host"] == "localhost"
+        assert worker_span.data["celery"]["host"] == self.redis_host
         assert worker_span.data["celery"]["port"] == "6379"
         assert worker_span.data["celery"]["task_id"]
         assert worker_span.data["celery"]["error"] == "This is a simulated error"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -25,11 +25,7 @@ testenv["couchdb_password"] = os.environ.get("COUCHDB_PASSWORD", "password")
 """
 MySQL Environment
 """
-if "MYSQL_HOST" in os.environ:
-    testenv["mysql_host"] = os.environ["MYSQL_HOST"]
-else:
-    testenv["mysql_host"] = "127.0.0.1"
-
+testenv["mysql_host"] = os.environ.get("MYSQL_HOST", "127.0.0.1")
 testenv["mysql_port"] = int(os.environ.get("MYSQL_PORT", "3306"))
 testenv["mysql_db"] = os.environ.get("MYSQL_DATABASE", "instana_test_db")
 testenv["mysql_user"] = os.environ.get("MYSQL_USER", "root")
@@ -62,7 +58,7 @@ testenv["mongodb_pw"] = os.environ.get("MONGO_PW", None)
 RabbitMQ Environment
 """
 testenv["rabbitmq_host"] = os.environ.get("RABBITMQ_HOST", "127.0.0.1")
-testenv["rabbitmq_port"] = os.environ.get("RABBITMQ_PORT", 5672)
+testenv["rabbitmq_port"] = int(os.environ.get("RABBITMQ_PORT", "5672"))
 
 
 """


### PR DESCRIPTION
You can run infra as before using this command:
- `docker compose --profile infra-general up -d`

Unittests in the docker-compose file currently supports up to Python version 3.14.

Run tests for all Python versions:
- `docker compose --profile infra-general --profile tests-general up --build --abort-on-container-exit | grep python-sensor-test`

To run tests for a specific Python version using Docker, 3.12 for example:
- `docker compose --profile infra-general --profile py312 up --build --abort-on-container-exit | grep python-sensor-test`

Cassandra Tests:
- `docker compose --profile infra-cassandra --profile tests-cassandra up --build --abort-on-container-exit | grep python-sensor-test`

Kafka Tests:
- `docker compose --profile infra-kafka --profile tests-kafka up --build --abort-on-container-exit | grep python-sensor-test`

Gevent Tests:
- `docker compose --profile tests-gevent up --build --abort-on-container-exit | grep python-sensor-test`

AWS Tests:
- `docker compose --profile tests-aws up --build --abort-on-container-exit | grep python-sensor-test`