### PR TITLE
chore: pin setup tools <= 81.0.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -40,3 +40,4 @@ tracerite<=1.1.1; python_version < "3.9"
 uvicorn>=0.13.4
 urllib3>=1.26.5
 httpx>=0.27.0
+setuptools<=81.0.0 # This change is temporary and will remain in place until Pyramid resolves the failures caused by the pkg_resources deprecation.


### PR DESCRIPTION
Summary
Pyramid depends on setuptools, and recent setuptools releases have deprecated the pkg_resources module. This deprecation causes runtime failures in Pyramid.
Changes

Pin setuptools to versions < V81.0.0 to avoid pkg_resources related failures.

Notes

This is a temporary workaround.
The version pinning should be removed once Pyramid updates its dependencies to address this issue.

Reference-https://setuptools.pypa.io/en/stable/history.html#v82-0-0