### PR TITLE
fix: check span attributes

### DIFF
--- a/src/instana/span/base_span.py
+++ b/src/instana/span/base_span.py
@@ -56,6 +56,10 @@ class BaseSpan(object):
         :return: dict - a filtered set of attributes
         """
         filtered_attributes = DictionaryOfStan()
+
+        if attributes is None:
+            return filtered_attributes
+
         for key in attributes.keys():
             validated_key, validated_value = self._validate_attribute(
                 key, attributes[key]


### PR DESCRIPTION
This PR is related to the issue [842](https://github.com/instana/python-sensor/issues/842) and it fixes the case a span was created without attributes.