### PR TITLE
ci: Add Ruff linter as GitHub Action.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,15 @@
+name: Ruff
+on: [ push, pull_request ]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+            args: check --output-format=github
+            src: >-
+                ./src
+                ./tests
+                ./tests_autowrapt
+                ./tests_aws

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,14 +5,15 @@ free to scratch it.
 
 To contribute with code, please submit a [pull request].
 
-A good way to familiarize yourself with the codebase and contribution process is
-to look for and tackle low-hanging fruit in the [issue tracker].
+A good way to familiarize yourself with the codebase and contribution process 
+is to look for and tackle low-hanging fruit in the [issue tracker].
 
-<!--Before embarking on a more ambitious contribution, please quickly [get in touch](#communication) with us.-->
+<!--Before embarking on a more ambitious contribution, please quickly [get in 
+touch](#communication) with us.-->
 
 **Note: We appreciate your effort, and want to avoid a situation where a 
-contribution requires extensive rework (by you or by us), sits in backlog for a 
-long time, or cannot be accepted at all!**
+contribution requires extensive rework (by you or by us), sits in backlog for 
+a long time, or cannot be accepted at all!**
 
 ## Proposing new features
 
@@ -33,8 +34,8 @@ Do not forget to add the label `bug` to your issue.
 ## Merge approval
 
 The project maintainers use `LGTM` (Looks Good To Me) in comments on the code
-review to indicate acceptance. A pull request requires LGTMs from, at least, one
-of the maintainers of each component affected.
+review to indicate acceptance. A pull request requires LGTMs from, at least, 
+one of the maintainers of each component affected.
 
 For a list of the maintainers, see the [MAINTAINERS.md](MAINTAINERS.md) page.
 
@@ -42,9 +43,9 @@ For a list of the maintainers, see the [MAINTAINERS.md](MAINTAINERS.md) page.
 
 ### Copyright
 
-Each source file must include a Copyright header to IBM. When submitting a pull 
-request for review which contains new source code files, the developer must 
-include the following content in the beginning of the file.
+Each source file must include a Copyright header to IBM. When submitting a 
+pull request for review which contains new source code files, the developer 
+must include the following content in the beginning of the file.
 
 ```
 # (c) Copyright IBM Corp. <YEAR>
@@ -56,7 +57,8 @@ include the following content in the beginning of the file.
 We have tried to make it as easy as possible to make contributions. This
 applies to how we handle the legal aspects of contribution. 
 
-We use the same approach - the [Developer's Certificate of Origin 1.1 (DCO)] - that the [Linux® Kernel community] uses to manage code contributions.
+We use the same approach - the [Developer's Certificate of Origin 1.1 (DCO)] -
+that the [Linux® Kernel community] uses to manage code contributions.
 
 We simply ask that when submitting a pull request for review, the developer
 must include a sign-off statement in the commit message.
@@ -75,22 +77,57 @@ local git repository using the following command:
 git commit -s
 ```
 
-<!--
-## Communication
-**FIXME** Please feel free to connect with us on our [Slack channel](link).
-
 ## Setup
-**FIXME** Please add any special setup instructions for your project to help the developer
-become productive quickly.
 
-## Testing
-**FIXME** Please provide information that helps the developer test any changes they make
-before submitting.
+1. **Clone the repository and install dependencies:**
+   ```shell
+   git clone https://github.com/instana/python-sensor.git
+   cd python-sensor
+   pip install -e ".[dev]"
+   ```
+   
+   This installs the package in editable mode with development dependencies
+   (pytest, ruff, pre-commit, etc.)
 
-## Coding style guidelines
-**FIXME** Optional, but recommended: please share any specific style guidelines you might
-have for your project.
--->
+2. **Set up pre-commit hooks:**
+   ```shell
+   pre-commit install
+   ```
+   
+   This automatically runs Ruff linter and formatter before each commit.
+
+## Testing and Code Quality
+
+Before submitting a pull request:
+
+1. **Run tests:**
+   ```shell
+   pytest
+   ```
+
+2. **Check code style:**
+   ```shell
+   ruff check ./src ./tests ./tests_autowrapt ./tests_aws
+   ```
+   
+   Or run all pre-commit checks:
+   ```shell
+   pre-commit run --all-files
+   ```
+
+**Note:** All pull requests to `main` must pass GitHub Actions checks (Ruff 
+linter + test suite).
+
+## Coding Style
+
+- Python 3.9+ compatible code
+- Follow PEP 8 style guidelines (enforced by Ruff)
+- Include copyright headers in new files (see [Legal](#legal) section)
+- Use type hints where appropriate
+- Ruff automatically formats code on commit via pre-commit hooks
+
+Configuration is defined in [`pyproject.toml`](pyproject.toml). For advanced 
+Ruff usage, see [Ruff documentation](https://docs.astral.sh/ruff/).
 
 <!-- Reference links -->
 
@@ -99,3 +136,4 @@ have for your project.
 [raise an issue]: https://github.com/instana/python-sensor/issues "Raise an issue"
 [Developer's Certificate of Origin 1.1 (DCO)]: https://github.com/hyperledger/fabric/blob/master/docs/source/DCO1.1.txt "DCO1.1"
 [Linux® Kernel community]: https://elinux.org/Developer_Certificate_Of_Origin  "Linux Kernel DCO"
+[Ruff Documentation]: https://docs.astral.sh/ruff/ "Ruff Documentation"


### PR DESCRIPTION
Reopening [an old PR](https://github.com/instana/python-sensor/pull/711) closed some time ago.

@pvital - Executes Ruff as a linter tool to check code patterns.
@CagriYonca - Adds information about pre-commit to the CONTRIBUTING.md

Ruff linter has been tested [here](https://github.com/instana/python-sensor/actions/runs/24397262909).