### PR TITLE
fix: Added exception re-raise in httpx method overwrites

### DIFF
--- a/src/instana/instrumentation/httpx.py
+++ b/src/instana/instrumentation/httpx.py
@@ -89,6 +89,7 @@ try:
                 _set_response_span_attributes(span, response)
             except Exception as e:
                 span.record_exception(e)
+                raise
             else:
                 return response
 
@@ -118,6 +119,7 @@ try:
                 _set_response_span_attributes(span, response)
             except Exception as e:
                 span.record_exception(e)
+                raise
             else:
                 return response
 

--- a/src/instana/instrumentation/httpx.py
+++ b/src/instana/instrumentation/httpx.py
@@ -82,10 +82,12 @@ try:
         ) as span:
             try:
                 request = args[0]
-                _set_request_span_attributes(span, request)
+                _set_request_span_attributes(span, request)  # Has its own try-except
                 tracer.inject(span.context, Format.HTTP_HEADERS, request.headers)
             except Exception:
-                logger.exception("httpx handle_request_with_instana pre-request:")
+                logger.exception(
+                    "httpx handle_request_with_instana pre-request:", exc_info=True
+                )
 
             try:
                 response = wrapped(*args, **kwargs)
@@ -93,10 +95,7 @@ try:
                 span.record_exception(e)
                 raise
 
-            try:
-                _set_response_span_attributes(span, response)
-            except Exception:
-                logger.exception("httpx handle_request_with_instana post-request:")
+            _set_response_span_attributes(span, response)  # Has its own try-except
 
             return response
 
@@ -119,10 +118,13 @@ try:
         ) as span:
             try:
                 request = args[0]
-                _set_request_span_attributes(span, request)
+                _set_request_span_attributes(span, request)  # Has its own try-except
                 tracer.inject(span.context, Format.HTTP_HEADERS, request.headers)
             except Exception:
-                logger.exception("httpx handle_request_with_instana pre-request:")
+                logger.exception(
+                    "httpx handle_async_request_with_instana pre-request:",
+                    exc_info=True,
+                )
 
             try:
                 response = await wrapped(*args, **kwargs)
@@ -130,10 +132,7 @@ try:
                 span.record_exception(e)
                 raise
 
-            try:
-                _set_response_span_attributes(span, response)
-            except Exception:
-                logger.exception("httpx handle_request_with_instana post-request:")
+            _set_response_span_attributes(span, response)  # Has its own try-except
 
             return response
 

--- a/src/instana/instrumentation/httpx.py
+++ b/src/instana/instrumentation/httpx.py
@@ -84,14 +84,21 @@ try:
                 request = args[0]
                 _set_request_span_attributes(span, request)
                 tracer.inject(span.context, Format.HTTP_HEADERS, request.headers)
+            except Exception:
+                logger.exception("httpx handle_request_with_instana pre-request:")
 
+            try:
                 response = wrapped(*args, **kwargs)
-                _set_response_span_attributes(span, response)
             except Exception as e:
                 span.record_exception(e)
                 raise
-            else:
-                return response
+
+            try:
+                _set_response_span_attributes(span, response)
+            except Exception:
+                logger.exception("httpx handle_request_with_instana post-request:")
+
+            return response
 
     @wrapt.patch_function_wrapper("httpx", "AsyncHTTPTransport.handle_async_request")
     async def handle_async_request_with_instana(
@@ -114,14 +121,21 @@ try:
                 request = args[0]
                 _set_request_span_attributes(span, request)
                 tracer.inject(span.context, Format.HTTP_HEADERS, request.headers)
+            except Exception:
+                logger.exception("httpx handle_request_with_instana pre-request:")
 
+            try:
                 response = await wrapped(*args, **kwargs)
-                _set_response_span_attributes(span, response)
             except Exception as e:
                 span.record_exception(e)
                 raise
-            else:
-                return response
+
+            try:
+                _set_response_span_attributes(span, response)
+            except Exception:
+                logger.exception("httpx handle_request_with_instana post-request:")
+
+            return response
 
     logger.debug("Instrumenting httpx")
 

--- a/src/instana/instrumentation/httpx.py
+++ b/src/instana/instrumentation/httpx.py
@@ -86,7 +86,7 @@ try:
                 tracer.inject(span.context, Format.HTTP_HEADERS, request.headers)
             except Exception:
                 logger.exception(
-                    "httpx handle_request_with_instana pre-request:", exc_info=True
+                    "httpx handle_request_with_instana:", exc_info=True
                 )
 
             try:
@@ -96,7 +96,6 @@ try:
                 raise
 
             _set_response_span_attributes(span, response)  # Has its own try-except
-
             return response
 
     @wrapt.patch_function_wrapper("httpx", "AsyncHTTPTransport.handle_async_request")
@@ -122,7 +121,7 @@ try:
                 tracer.inject(span.context, Format.HTTP_HEADERS, request.headers)
             except Exception:
                 logger.exception(
-                    "httpx handle_async_request_with_instana pre-request:",
+                    "httpx handle_async_request_with_instana:",
                     exc_info=True,
                 )
 
@@ -133,7 +132,6 @@ try:
                 raise
 
             _set_response_span_attributes(span, response)  # Has its own try-except
-
             return response
 
     logger.debug("Instrumenting httpx")


### PR DESCRIPTION
Fixes #866.

Added exception re-raise after exception has been recorded.
Previously `pylance` showed the following warning:
```
Function with declared return type "Response" must return value on all code paths
  "None" is not assignable to "Response"
```
Currently this warning isn't visible anymore.