### PR TITLE
fix: Adapt psycopg2 to Python >= 3.13.11 (trixie)

### DIFF
--- a/src/instana/instrumentation/psycopg2.py
+++ b/src/instana/instrumentation/psycopg2.py
@@ -41,8 +41,13 @@ try:
         args: Tuple[Any, ...],
         kwargs: Dict[str, Any],
     ) -> Callable[..., object]:
+        args_list = list(args)
+
         if "conn_or_curs" in kwargs and hasattr(kwargs["conn_or_curs"], "__wrapped__"):
             kwargs["conn_or_curs"] = kwargs["conn_or_curs"].__wrapped__
+        elif len(args_list) > 0 and hasattr(args_list[0], "__wrapped__"):
+            args_list[0] = args_list[0].__wrapped__
+            args = tuple(args_list)
 
         return wrapped(*args, **kwargs)
 

--- a/tests/clients/test_psycopg2.py
+++ b/tests/clients/test_psycopg2.py
@@ -8,9 +8,10 @@ from typing import Generator
 import psycopg2
 import psycopg2.extensions as ext
 import psycopg2.extras
+import psycopg2._json
 import pytest
 
-from instana.instrumentation.psycopg2 import register_json_with_instana
+
 from instana.singletons import agent, get_tracer
 from tests.helpers import testenv
 
@@ -65,7 +66,7 @@ class TestPsycoPG2:
         agent.options.allow_exit_as_root = False
 
     def test_register_json(self) -> None:
-        resp = register_json_with_instana(conn_or_curs=self.db)
+        resp = psycopg2._json.register_json(conn_or_curs=self.db)
         assert resp[0].values[0] == 114
         assert resp[1].values[0] == 199
 


### PR DESCRIPTION
Adapt psycopg2 instrumentation to the latest update of Python 3.13.11 (trixie)

Solved issues:
- FAILED tests/clients/test_psycopg2.py::TestPsycoPG2::test_register_json - TypeError: register_json_with_instana() got an unexpected keyword argument 'conn_or_curs'
