### PR TITLE
feat(runtime): Update pollrate behavior and add tests for it

### DIFF
--- a/src/instana/agent/host.py
+++ b/src/instana/agent/host.py
@@ -99,13 +99,31 @@ class HostAgent(BaseAgent):
 
     def is_timed_out(self) -> bool:
         """
-        If we haven't heard from the Instana host agent in 60 seconds, this
-        method will return True.
-        @return: Boolean
+        If we haven't heard from the Instana host agent within the timeout
+        window, this method will return True.  The window is the larger of
+        60 seconds or twice the configured poll_rate so that high poll_rate
+        values (e.g. 120 s) do not cause spurious resets.
+
+        Note: We intentionally read the FSM state directly instead of calling
+        can_send(), because can_send() has a fork-detection side-effect that
+        triggers handle_fork() → reset() and would cause a spurious restart
+        loop on frameworks (e.g. Twisted) that spawn threads with different
+        perceived PIDs.  total_seconds() is used instead of .seconds to
+        correctly handle gaps longer than 24 hours.
+
+        Both "wait4init" and "good2go" states are checked: in wait4init last_seen
+        is typically None so the condition is harmless, but the check is kept
+        symmetric so that any edge case where last_seen is set before full
+        announce is also caught.
+
+        Returns:
+            bool: True if the agent has not been heard from within the timeout window.
         """
-        if self.last_seen and self.can_send:
+        if self.last_seen and self.machine.fsm.current in ["wait4init", "good2go"]:
+            poll_rate = getattr(getattr(self, "options", None), "poll_rate", 1)
+            timeout_threshold = max(60, poll_rate * 2)
             diff = datetime.now() - self.last_seen
-            if diff.seconds > 60:
+            if diff.total_seconds() > timeout_threshold:
                 return True
         return False
 
@@ -276,31 +294,40 @@ class HostAgent(BaseAgent):
     ) -> Optional[Response]:
         """
         Used to report collection payload to the host agent.  This can be metrics, spans and snapshot data.
+        When there is nothing to send (no spans, profiles, or metrics), a lightweight HEAD heartbeat
+        is sent instead so that the host-agent timeout detection continues to work correctly even
+        when poll_rate is larger than the 60-second timeout window.
         """
         response = None
+        data_was_sent = False
         try:
             # Report spans (if any)
             response = self.report_spans(payload)
-
             if response is not None and 200 <= response.status_code <= 204:
                 self.last_seen = datetime.now()
+                data_was_sent = True
 
             # Report profiles (if any)
             response = self.report_profiles(payload)
-
             if response is not None and 200 <= response.status_code <= 204:
                 self.last_seen = datetime.now()
+                data_was_sent = True
 
             # Report metrics
             response = self.report_metrics(payload)
-
             if response is not None and 200 <= response.status_code <= 204:
                 self.last_seen = datetime.now()
+                data_was_sent = True
 
                 if response.status_code == 200 and len(response.content) > 2:
-                    # The host agent returned something indicating that is has a request for us that we
-                    # need to process.
+                    # The host agent returned something indicating that it has a request for us
+                    # that we need to process.
                     self.handle_agent_tasks(json.loads(response.content)[0])
+
+            # Nothing was sent this cycle — send a heartbeat HEAD request so that
+            # is_timed_out() keeps working correctly at high poll_rate values.
+            if not data_was_sent:
+                self._send_heartbeat()
         except requests.exceptions.ConnectionError:
             pass
         except urllib3.exceptions.MaxRetryError:
@@ -311,6 +338,34 @@ class HostAgent(BaseAgent):
                 exc_info=True,
             )
         return response
+
+    def _send_heartbeat(self) -> None:
+        """
+        Updates last_seen via a HEAD request when no payload was sent this cycle.
+
+        Critical when metric collection is disabled (INSTANA_DISABLE_METRICS_COLLECTION)
+        and no spans arrive — last_seen would never be updated, causing is_timed_out()
+        to fire spuriously. Only runs in "good2go" state; wait4init already polls via
+        is_agent_ready().
+        """
+        try:
+            announce_data = self.announce_data  # local copy — avoids race with reset()
+            if announce_data is None:
+                return
+            if self.machine.fsm.current != "good2go":
+                return
+            response = self.client.head(self.__data_url(), timeout=0.8)
+            if response is not None and 200 <= response.status_code <= 204:
+                self.last_seen = datetime.now()
+        except requests.exceptions.ConnectionError:
+            pass
+        except urllib3.exceptions.MaxRetryError:
+            pass
+        except Exception as exc:
+            logger.debug(
+                f"_send_heartbeat: connection error ({type(exc)})",
+                exc_info=True,
+            )
 
     def report_metrics(self, payload: dict[str, Any]) -> Optional[Response]:
         metrics = payload.get("metrics", [])

--- a/src/instana/agent/host.py
+++ b/src/instana/agent/host.py
@@ -99,13 +99,24 @@ class HostAgent(BaseAgent):
 
     def is_timed_out(self) -> bool:
         """
-        If we haven't heard from the Instana host agent in 60 seconds, this
-        method will return True.
+        If we haven't heard from the Instana host agent within the timeout
+        window, this method will return True.  The window is the larger of
+        60 seconds or twice the configured poll_rate so that high poll_rate
+        values (e.g. 120 s) do not cause spurious resets.
+
+        Note: We intentionally read the FSM state directly instead of calling
+        can_send(), because can_send() has a fork-detection side-effect that
+        triggers handle_fork() → reset() and would cause a spurious restart
+        loop on frameworks (e.g. Twisted) that spawn threads with different
+        perceived PIDs.  total_seconds() is used instead of .seconds to
+        correctly handle gaps longer than 24 hours.
         @return: Boolean
         """
-        if self.last_seen and self.can_send:
+        if self.last_seen and self.machine.fsm.current in ["wait4init", "good2go"]:
+            poll_rate = getattr(getattr(self, "options", None), "poll_rate", 1)
+            timeout_threshold = max(60, poll_rate * 2)
             diff = datetime.now() - self.last_seen
-            if diff.seconds > 60:
+            if diff.total_seconds() > timeout_threshold:
                 return True
         return False
 
@@ -276,31 +287,40 @@ class HostAgent(BaseAgent):
     ) -> Optional[Response]:
         """
         Used to report collection payload to the host agent.  This can be metrics, spans and snapshot data.
+        When there is nothing to send (no spans, profiles, or metrics), a lightweight HEAD heartbeat
+        is sent instead so that the host-agent timeout detection continues to work correctly even
+        when poll_rate is larger than the 60-second timeout window.
         """
         response = None
+        data_was_sent = False
         try:
             # Report spans (if any)
             response = self.report_spans(payload)
-
             if response is not None and 200 <= response.status_code <= 204:
                 self.last_seen = datetime.now()
+                data_was_sent = True
 
             # Report profiles (if any)
             response = self.report_profiles(payload)
-
             if response is not None and 200 <= response.status_code <= 204:
                 self.last_seen = datetime.now()
+                data_was_sent = True
 
             # Report metrics
             response = self.report_metrics(payload)
-
             if response is not None and 200 <= response.status_code <= 204:
                 self.last_seen = datetime.now()
+                data_was_sent = True
 
                 if response.status_code == 200 and len(response.content) > 2:
-                    # The host agent returned something indicating that is has a request for us that we
-                    # need to process.
+                    # The host agent returned something indicating that it has a request for us
+                    # that we need to process.
                     self.handle_agent_tasks(json.loads(response.content)[0])
+
+            # Nothing was sent this cycle — send a heartbeat HEAD request so that
+            # is_timed_out() keeps working correctly at high poll_rate values.
+            if not data_was_sent:
+                self._send_heartbeat()
         except requests.exceptions.ConnectionError:
             pass
         except urllib3.exceptions.MaxRetryError:
@@ -311,6 +331,34 @@ class HostAgent(BaseAgent):
                 exc_info=True,
             )
         return response
+
+    def _send_heartbeat(self) -> None:
+        """
+        Updates last_seen via a HEAD request when no payload was sent this cycle.
+
+        Critical when metric collection is disabled (INSTANA_DISABLE_METRICS_COLLECTION)
+        and no spans arrive — last_seen would never be updated, causing is_timed_out()
+        to fire spuriously. Only runs in "good2go" state; wait4init already polls via
+        is_agent_ready().
+        """
+        try:
+            announce_data = self.announce_data  # local copy — avoids race with reset()
+            if announce_data is None:
+                return
+            if self.machine.fsm.current != "good2go":
+                return
+            response = self.client.head(self.__data_url(), timeout=0.8)
+            if response is not None and 200 <= response.status_code <= 204:
+                self.last_seen = datetime.now()
+        except requests.exceptions.ConnectionError:
+            pass
+        except urllib3.exceptions.MaxRetryError:
+            pass
+        except Exception as exc:
+            logger.debug(
+                f"_send_heartbeat: connection error ({type(exc)})",
+                exc_info=True,
+            )
 
     def report_metrics(self, payload: dict[str, Any]) -> Optional[Response]:
         metrics = payload.get("metrics", [])

--- a/src/instana/collector/helpers/runtime.py
+++ b/src/instana/collector/helpers/runtime.py
@@ -44,10 +44,11 @@ class RuntimeHelper(BaseHelper):
         self.previous = DictionaryOfStan()
         self.previous_rusage = get_resource_usage()
 
-        if gc.isenabled():
-            self.previous_gc_count = gc.get_count()
-        else:
-            self.previous_gc_count = None
+        # Initialise to None so the first collect_metrics call establishes the
+        # baseline snapshot and reports all-zero deltas.  Any GC activity that
+        # occurs between process start and the first collection is intentionally
+        # excluded — we only report incremental deltas from the first poll onward.
+        self.previous_gc_stats = None
 
     def collect_metrics(self, **kwargs: Dict[str, Any]) -> List[Dict[str, Any]]:
         plugin_data = dict()
@@ -82,6 +83,7 @@ class RuntimeHelper(BaseHelper):
             return
 
         """ Collect up and return the runtime metrics """
+        rusage = self.previous_rusage
         try:
             rusage = get_resource_usage()
             if gc.isenabled():
@@ -232,52 +234,27 @@ class RuntimeHelper(BaseHelper):
 
     def _collect_gc_metrics(self, plugin_data, with_snapshot):
         try:
-            gc_count = gc.get_count()
-            gc_threshold = gc.get_threshold()
+            gc_stats = gc.get_stats()
+            if self.previous_gc_stats is None:
+                # First call: establish baseline, report all-zero deltas so the
+                # snapshot payload carries zeros rather than the cumulative counts
+                # that accumulated since process start (which are not meaningful
+                # as deltas).
+                self.previous_gc_stats = gc_stats
+                return
 
-            self.apply_delta(
-                gc_count[0],
-                self.previous["data"]["metrics"]["gc"],
-                plugin_data["data"]["metrics"]["gc"],
-                "collect0",
-                with_snapshot,
-            )
-            self.apply_delta(
-                gc_count[1],
-                self.previous["data"]["metrics"]["gc"],
-                plugin_data["data"]["metrics"]["gc"],
-                "collect1",
-                with_snapshot,
-            )
-            self.apply_delta(
-                gc_count[2],
-                self.previous["data"]["metrics"]["gc"],
-                plugin_data["data"]["metrics"]["gc"],
-                "collect2",
-                with_snapshot,
-            )
-
-            self.apply_delta(
-                gc_threshold[0],
-                self.previous["data"]["metrics"]["gc"],
-                plugin_data["data"]["metrics"]["gc"],
-                "threshold0",
-                with_snapshot,
-            )
-            self.apply_delta(
-                gc_threshold[1],
-                self.previous["data"]["metrics"]["gc"],
-                plugin_data["data"]["metrics"]["gc"],
-                "threshold1",
-                with_snapshot,
-            )
-            self.apply_delta(
-                gc_threshold[2],
-                self.previous["data"]["metrics"]["gc"],
-                plugin_data["data"]["metrics"]["gc"],
-                "threshold2",
-                with_snapshot,
-            )
+            # Use a plain dict as the staging target so that accessing it never
+            # auto-creates keys in plugin_data (DictionaryOfStan creates keys on
+            # read, which would leave an empty "gc": {} even when nothing changed).
+            staging = {}
+            prev_gc = self.previous["data"]["metrics"]["gc"]
+            for i, (stat, prev_stat) in enumerate(zip(gc_stats, self.previous_gc_stats)):
+                for key in ("collections", "collected", "uncollectable"):
+                    delta = stat[key] - prev_stat.get(key, 0)
+                    self.apply_delta(delta, prev_gc, staging, f"{key}{i}", with_snapshot)
+            if staging:
+                plugin_data["data"]["metrics"]["gc"].update(staging)
+            self.previous_gc_stats = gc_stats
         except Exception:
             logger.debug("_collect_gc_metrics", exc_info=True)
 

--- a/src/instana/collector/helpers/runtime.py
+++ b/src/instana/collector/helpers/runtime.py
@@ -44,10 +44,11 @@ class RuntimeHelper(BaseHelper):
         self.previous = DictionaryOfStan()
         self.previous_rusage = get_resource_usage()
 
-        if gc.isenabled():
-            self.previous_gc_count = gc.get_count()
-        else:
-            self.previous_gc_count = None
+        # Initialise to None so the first collect_metrics call establishes the
+        # baseline snapshot and reports all-zero deltas.  Any GC activity that
+        # occurs between process start and the first collection is intentionally
+        # excluded — we only report incremental deltas from the first poll onward.
+        self.previous_gc_stats = None
 
     def collect_metrics(self, **kwargs: Dict[str, Any]) -> List[Dict[str, Any]]:
         plugin_data = dict()
@@ -67,6 +68,15 @@ class RuntimeHelper(BaseHelper):
             with_snapshot = kwargs.get("with_snapshot", False)
             self._collect_runtime_metrics(plugin_data, with_snapshot)
 
+            # Send pollRate on every payload so that filler learns the configured
+            # rate immediately (not just every 5 min when with_snapshot=True).
+            # Backend reads this via PollRateUtil.regularPollRateFromPayload()
+            # which does a flat lookup for "pollRate" in the data map.
+            opts = getattr(getattr(self.collector, "agent", None), "options", None)
+            plugin_data["data"]["pollRate"] = (
+                getattr(opts, "poll_rate", 1) if opts is not None else 1
+            )
+
             if with_snapshot:
                 self._collect_runtime_snapshot(plugin_data)
         except Exception:
@@ -82,6 +92,7 @@ class RuntimeHelper(BaseHelper):
             return
 
         """ Collect up and return the runtime metrics """
+        rusage = self.previous_rusage
         try:
             rusage = get_resource_usage()
             if gc.isenabled():
@@ -230,54 +241,36 @@ class RuntimeHelper(BaseHelper):
         finally:
             self.previous_rusage = rusage
 
-    def _collect_gc_metrics(self, plugin_data, with_snapshot):
+    def _collect_gc_metrics(self, plugin_data: Dict[str, Any], with_snapshot: bool) -> None:
         try:
-            gc_count = gc.get_count()
-            gc_threshold = gc.get_threshold()
+            gc_stats = gc.get_stats()
+            if self.previous_gc_stats is None:
+                # First call: establish baseline, report all-zero deltas so the
+                # snapshot payload carries zeros rather than the cumulative counts
+                # that accumulated since process start (which are not meaningful
+                # as deltas).
+                self.previous_gc_stats = gc_stats
+                return
 
-            self.apply_delta(
-                gc_count[0],
-                self.previous["data"]["metrics"]["gc"],
-                plugin_data["data"]["metrics"]["gc"],
-                "collect0",
-                with_snapshot,
-            )
-            self.apply_delta(
-                gc_count[1],
-                self.previous["data"]["metrics"]["gc"],
-                plugin_data["data"]["metrics"]["gc"],
-                "collect1",
-                with_snapshot,
-            )
-            self.apply_delta(
-                gc_count[2],
-                self.previous["data"]["metrics"]["gc"],
-                plugin_data["data"]["metrics"]["gc"],
-                "collect2",
-                with_snapshot,
-            )
-
-            self.apply_delta(
-                gc_threshold[0],
-                self.previous["data"]["metrics"]["gc"],
-                plugin_data["data"]["metrics"]["gc"],
-                "threshold0",
-                with_snapshot,
-            )
-            self.apply_delta(
-                gc_threshold[1],
-                self.previous["data"]["metrics"]["gc"],
-                plugin_data["data"]["metrics"]["gc"],
-                "threshold1",
-                with_snapshot,
-            )
-            self.apply_delta(
-                gc_threshold[2],
-                self.previous["data"]["metrics"]["gc"],
-                plugin_data["data"]["metrics"]["gc"],
-                "threshold2",
-                with_snapshot,
-            )
+            # Use a plain dict as the staging target so that accessing it never
+            # auto-creates keys in plugin_data (DictionaryOfStan creates keys on
+            # read, which would leave an empty "gc": {} even when nothing changed).
+            #
+            # apply_delta is intentionally NOT used here: it is designed for
+            # cumulative values and stores the last-seen value in `previous` so
+            # it can skip unchanged payloads.  These values are already deltas
+            # (stat[key] - prev_stat[key]), so the only meaningful "no-change"
+            # signal is delta == 0 — which we check directly.
+            #
+            # delta=0 values are always included so that filler receives a signal
+            # every poll and does not fall back to zero-fill on inactive GC periods.
+            staging = {}
+            for i, (stat, prev_stat) in enumerate(zip(gc_stats, self.previous_gc_stats)):
+                for key in ("collections", "collected", "uncollectable"):
+                    delta = stat[key] - prev_stat[key]
+                    staging[f"{key}{i}"] = delta
+            plugin_data["data"]["metrics"]["gc"].update(staging)
+            self.previous_gc_stats = gc_stats
         except Exception:
             logger.debug("_collect_gc_metrics", exc_info=True)
 
@@ -332,13 +325,6 @@ class RuntimeHelper(BaseHelper):
             snapshot_payload["a"] = platform.architecture()[0]  # architecture
             snapshot_payload["versions"] = self.gather_python_packages()
             snapshot_payload["iv"] = VERSION
-
-            # Inform filler of the configured poll_rate so that entity expiry is
-            # scaled correctly (presenceExpirySeconds = 20 * poll_rate).
-            # The backend reads this via SnapshotExtracting.describePollRateSnapshot()
-            # which looks for the top-level "pollRate" key in the payload.
-            opts = getattr(getattr(self.collector, "agent", None), "options", None)
-            plugin_data["data"]["pollRate"] = getattr(opts, "poll_rate", 1) if opts is not None else 1
 
             if is_autowrapt_instrumented():
                 snapshot_payload["m"] = "Autowrapt"

--- a/src/instana/collector/helpers/runtime.py
+++ b/src/instana/collector/helpers/runtime.py
@@ -333,6 +333,13 @@ class RuntimeHelper(BaseHelper):
             snapshot_payload["versions"] = self.gather_python_packages()
             snapshot_payload["iv"] = VERSION
 
+            # Inform filler of the configured poll_rate so that entity expiry is
+            # scaled correctly (presenceExpirySeconds = 20 * poll_rate).
+            # The backend reads this via SnapshotExtracting.describePollRateSnapshot()
+            # which looks for the top-level "pollRate" key in the payload.
+            opts = getattr(getattr(self.collector, "agent", None), "options", None)
+            plugin_data["data"]["pollRate"] = getattr(opts, "poll_rate", 1) if opts is not None else 1
+
             if is_autowrapt_instrumented():
                 snapshot_payload["m"] = "Autowrapt"
             elif is_webhook_instrumented():

--- a/src/instana/options.py
+++ b/src/instana/options.py
@@ -360,7 +360,7 @@ class StandardOptions(BaseOptions):
     AGENT_DEFAULT_HOST = "localhost"
     AGENT_DEFAULT_PORT = 42699
     DEFAULT_POLL_RATE = 1
-    MAX_POLL_RATE = 5
+    VALID_POLL_RATES = [1, 5, 10, 20, 30, 60, 120, 180, 240, 300, 360, 420, 480, 540, 600]
 
     def __init__(self, **kwds: dict[str, Any]) -> None:
         super(StandardOptions, self).__init__()
@@ -543,7 +543,11 @@ class StandardOptions(BaseOptions):
             self.enabled_spans.extend(enabled_spans)
 
     def set_poll_rate(self, plugin_config: dict[str, Any]) -> None:
-        """Set poll rate from agent plugin configuration."""
+        """Set poll rate from agent plugin configuration.
+
+        Normalizes the received value to the nearest valid poll rate in
+        VALID_POLL_RATES, matching the behaviour of Java PollRateUtil.
+        """
         poll_rate_value = plugin_config.get("poll_rate")
         if poll_rate_value is None:
             return
@@ -557,18 +561,17 @@ class StandardOptions(BaseOptions):
             self.poll_rate = self.DEFAULT_POLL_RATE
             return
 
-        if poll_rate in (self.DEFAULT_POLL_RATE, self.MAX_POLL_RATE):
-            self.poll_rate = poll_rate
-            logger.debug(
-                f"Poll rate set to {self.poll_rate} seconds from agent configuration"
+        if poll_rate <= 0:
+            self.poll_rate = self.DEFAULT_POLL_RATE
+            logger.warning(
+                f"Invalid poll_rate value {poll_rate}, defaulting to {self.DEFAULT_POLL_RATE}"
             )
             return
 
+        self.poll_rate = min(self.VALID_POLL_RATES, key=lambda x: abs(x - poll_rate))
         logger.debug(
-            f"Invalid poll_rate value {poll_rate}, defaulting to "
-            f"{self.DEFAULT_POLL_RATE}"
+            f"Poll rate set to {self.poll_rate} seconds from agent configuration"
         )
-        self.poll_rate = self.DEFAULT_POLL_RATE
 
     def set_from(self, res_data: dict[str, Any]) -> None:
         """

--- a/tests/agent/test_host.py
+++ b/tests/agent/test_host.py
@@ -334,8 +334,8 @@ class TestHostAgent:
         assert not agent.is_timed_out()
 
         agent.last_seen = datetime.datetime.now() - datetime.timedelta(minutes=5)
-        agent.can_send = True
-        assert agent.is_timed_out()
+        with patch.object(agent.machine.fsm, "current", "good2go"):
+            assert agent.is_timed_out()
 
     def test_can_send_test_env(
         self,

--- a/tests/collector/helpers/test_collector_runtime.py
+++ b/tests/collector/helpers/test_collector_runtime.py
@@ -1,6 +1,6 @@
 # (c) Copyright IBM Corp. 2024
 
-from typing import Generator
+from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
@@ -27,7 +27,7 @@ class TestRuntimeHelper:
 
         gc.disable()
         helper = RuntimeHelper(collector=HostCollector(HostAgent()))
-        assert helper.previous_gc_count is None
+        assert helper.previous_gc_stats is None
 
     def test_collect_metrics(self) -> None:
         response = self.helper.collect_metrics()
@@ -68,8 +68,71 @@ class TestRuntimeHelper:
     def test_collect_gc_metrics(self) -> None:
         plugin_data = self.helper.collect_metrics()
 
+        # First call establishes the baseline (previous_gc_stats was None); no
+        # data is written yet.
         self.helper._collect_gc_metrics(plugin_data[0], True)
-        assert len(self.helper.previous["data"]["metrics"]["gc"]) == 6
+        assert self.helper.previous_gc_stats is not None
+
+        # Second call computes deltas from the baseline and writes them.
+        self.helper._collect_gc_metrics(plugin_data[0], True)
+        gc_metrics = self.helper.previous["data"]["metrics"]["gc"]
+        for i in range(3):
+            for key in ("collections", "collected", "uncollectable"):
+                assert f"{key}{i}" in gc_metrics
+
+    def test_collect_gc_metrics_reports_delta_between_polls(self) -> None:
+        """GC metrics must be deltas between successive polls, not kumulatif values."""
+        # Simulate first poll: previous_gc_stats set to known baseline
+        baseline = [
+            {"collections": 100, "collected": 200, "uncollectable": 0},
+            {"collections": 10, "collected": 50, "uncollectable": 0},
+            {"collections": 1, "collected": 5, "uncollectable": 0},
+        ]
+        self.helper.previous_gc_stats = baseline
+
+        # Simulate gc.get_stats() returning incremented counts
+        after = [
+            {"collections": 103, "collected": 206, "uncollectable": 0},
+            {"collections": 11, "collected": 53, "uncollectable": 0},
+            {"collections": 1, "collected": 5, "uncollectable": 0},
+        ]
+
+        plugin_data = [{"data": {"metrics": {"gc": {}}}}]
+
+        with patch("gc.get_stats", return_value=after):
+            self.helper._collect_gc_metrics(plugin_data[0], True)
+
+        gc_metrics = plugin_data[0]["data"]["metrics"]["gc"]
+        # Gen 0: collections delta = 3, collected delta = 6
+        assert gc_metrics["collections0"] == 3
+        assert gc_metrics["collected0"] == 6
+        assert gc_metrics["uncollectable0"] == 0
+        # Gen 1: collections delta = 1, collected delta = 3
+        assert gc_metrics["collections1"] == 1
+        assert gc_metrics["collected1"] == 3
+        # Gen 2: no change — delta = 0, still reported because with_snapshot=True
+        assert gc_metrics["collections2"] == 0
+        assert gc_metrics["collected2"] == 0
+
+        # previous_gc_stats must be updated to the latest snapshot
+        assert self.helper.previous_gc_stats == after
+
+    def test_collect_gc_metrics_no_change_not_sent_without_snapshot(self) -> None:
+        """When nothing changed and with_snapshot=False, gc metrics must be empty."""
+        same = [
+            {"collections": 50, "collected": 100, "uncollectable": 0},
+            {"collections": 5, "collected": 20, "uncollectable": 0},
+            {"collections": 0, "collected": 0, "uncollectable": 0},
+        ]
+        self.helper.previous_gc_stats = same
+
+        plugin_data = [{"data": {"metrics": {"gc": {}}}}]
+
+        with patch("gc.get_stats", return_value=same):
+            self.helper._collect_gc_metrics(plugin_data[0], False)
+
+        # All deltas are 0 and with_snapshot=False → nothing written
+        assert plugin_data[0]["data"]["metrics"]["gc"] == {}
 
     def test_collect_runtime_metrics(self) -> None:
         """Test that _collect_runtime_metrics properly collects metrics"""

--- a/tests/collector/helpers/test_collector_runtime.py
+++ b/tests/collector/helpers/test_collector_runtime.py
@@ -38,7 +38,8 @@ class TestRuntimeHelper:
         self.helper._collect_runtime_snapshot(plugin_data[0])
         assert plugin_data[0]["name"] == "com.instana.plugin.python"
         assert plugin_data[0]["data"]["snapshot"]["m"] == "Manual"
-        assert len(plugin_data[0]["data"]) == 3
+        # data contains: pid, metrics, pollRate, snapshot
+        assert len(plugin_data[0]["data"]) == 4
 
     def test_collect_runtime_snapshot_autowrapt(self) -> None:
         with patch(
@@ -49,7 +50,8 @@ class TestRuntimeHelper:
             self.helper._collect_runtime_snapshot(plugin_data[0])
             assert plugin_data[0]["name"] == "com.instana.plugin.python"
             assert plugin_data[0]["data"]["snapshot"]["m"] == "Autowrapt"
-            assert len(plugin_data[0]["data"]) == 3
+            # data contains: pid, metrics, pollRate, snapshot
+            assert len(plugin_data[0]["data"]) == 4
 
     def test_collect_runtime_snapshot_webhook(self) -> None:
         with patch(
@@ -60,7 +62,8 @@ class TestRuntimeHelper:
             self.helper._collect_runtime_snapshot(plugin_data[0])
             assert plugin_data[0]["name"] == "com.instana.plugin.python"
             assert plugin_data[0]["data"]["snapshot"]["m"] == "AutoTrace"
-            assert len(plugin_data[0]["data"]) == 3
+            # data contains: pid, metrics, pollRate, snapshot
+            assert len(plugin_data[0]["data"]) == 4
 
     def test_collect_gc_metrics(self) -> None:
         plugin_data = self.helper.collect_metrics()
@@ -173,6 +176,44 @@ class TestRuntimeHelper:
 
         # Verify the previous_rusage was updated
         assert self.helper.previous_rusage == new_resource
+
+    def test_collect_runtime_snapshot_poll_rate_default(self) -> None:
+        """pollRate defaults to 1 when agent has no options configured."""
+        plugin_data = self.helper.collect_metrics()
+        self.helper._collect_runtime_snapshot(plugin_data[0])
+        assert plugin_data[0]["data"]["pollRate"] == 1
+
+    def test_collect_runtime_snapshot_poll_rate_from_agent_options(self) -> None:
+        """pollRate is read from agent.options.poll_rate and written to data top-level."""
+        self.helper.collector.agent.options.poll_rate = 60
+        plugin_data = self.helper.collect_metrics()
+        self.helper._collect_runtime_snapshot(plugin_data[0])
+        assert plugin_data[0]["data"]["pollRate"] == 60
+
+    def test_collect_runtime_snapshot_poll_rate_no_options(self) -> None:
+        """pollRate defaults to 1 when agent has no options attribute."""
+        self.helper.collector.agent.options = None
+        plugin_data = self.helper.collect_metrics()
+        self.helper._collect_runtime_snapshot(plugin_data[0])
+        assert plugin_data[0]["data"]["pollRate"] == 1
+
+    def test_collect_runtime_snapshot_poll_rate_no_agent(self) -> None:
+        """pollRate defaults to 1 when collector has no agent attribute."""
+        self.helper.collector.agent = None
+        plugin_data = self.helper.collect_metrics()
+        self.helper._collect_runtime_snapshot(plugin_data[0])
+        assert plugin_data[0]["data"]["pollRate"] == 1
+
+    def test_collect_runtime_snapshot_poll_rate_at_top_level_not_in_snapshot(self) -> None:
+        """pollRate must be at data top-level, not nested inside snapshot.
+        Backend's PollRateUtil.regularPollRateFromPayload() reads payload.getByPath("pollRate")
+        which is a flat lookup on the data map — it cannot find a nested key.
+        """
+        self.helper.collector.agent.options.poll_rate = 30
+        plugin_data = self.helper.collect_metrics()
+        self.helper._collect_runtime_snapshot(plugin_data[0])
+        assert plugin_data[0]["data"]["pollRate"] == 30
+        assert "pollRate" not in plugin_data[0]["data"].get("snapshot", {})
 
     @patch("os.environ")
     def test_collect_runtime_metrics_disabled(self, mock_environ):

--- a/tests/collector/helpers/test_collector_runtime.py
+++ b/tests/collector/helpers/test_collector_runtime.py
@@ -1,6 +1,6 @@
 # (c) Copyright IBM Corp. 2024
 
-from typing import Generator
+from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
@@ -27,7 +27,7 @@ class TestRuntimeHelper:
 
         gc.disable()
         helper = RuntimeHelper(collector=HostCollector(HostAgent()))
-        assert helper.previous_gc_count is None
+        assert helper.previous_gc_stats is None
 
     def test_collect_metrics(self) -> None:
         response = self.helper.collect_metrics()
@@ -39,6 +39,7 @@ class TestRuntimeHelper:
         assert plugin_data[0]["name"] == "com.instana.plugin.python"
         assert plugin_data[0]["data"]["snapshot"]["m"] == "Manual"
         # data contains: pid, metrics, pollRate, snapshot
+        # pollRate is now written by collect_metrics() on every poll, not by _collect_runtime_snapshot()
         assert len(plugin_data[0]["data"]) == 4
 
     def test_collect_runtime_snapshot_autowrapt(self) -> None:
@@ -51,6 +52,7 @@ class TestRuntimeHelper:
             assert plugin_data[0]["name"] == "com.instana.plugin.python"
             assert plugin_data[0]["data"]["snapshot"]["m"] == "Autowrapt"
             # data contains: pid, metrics, pollRate, snapshot
+            # pollRate is now written by collect_metrics() on every poll
             assert len(plugin_data[0]["data"]) == 4
 
     def test_collect_runtime_snapshot_webhook(self) -> None:
@@ -63,13 +65,93 @@ class TestRuntimeHelper:
             assert plugin_data[0]["name"] == "com.instana.plugin.python"
             assert plugin_data[0]["data"]["snapshot"]["m"] == "AutoTrace"
             # data contains: pid, metrics, pollRate, snapshot
+            # pollRate is now written by collect_metrics() on every poll
             assert len(plugin_data[0]["data"]) == 4
 
     def test_collect_gc_metrics(self) -> None:
         plugin_data = self.helper.collect_metrics()
 
+        # First call establishes the baseline (previous_gc_stats was None); no
+        # data is written yet.
         self.helper._collect_gc_metrics(plugin_data[0], True)
-        assert len(self.helper.previous["data"]["metrics"]["gc"]) == 6
+        assert self.helper.previous_gc_stats is not None
+
+        # Second call computes deltas from the baseline and writes them into plugin_data.
+        # All 9 keys (collections/collected/uncollectable × gen0/1/2) are always written
+        # so that filler receives a signal every poll and does not zero-fill on quiet periods.
+        self.helper._collect_gc_metrics(plugin_data[0], True)
+        gc_metrics = plugin_data[0]["data"]["metrics"]["gc"]
+        expected_keys = [
+            f"{k}{i}"
+            for k in ("collections", "collected", "uncollectable")
+            for i in range(3)
+        ]
+        for key in expected_keys:
+            assert key in gc_metrics, f"{key} must always be present in GC metrics"
+
+    def test_collect_gc_metrics_reports_delta_between_polls(self) -> None:
+        """GC metrics must be deltas between successive polls, not kumulatif values."""
+        # Simulate first poll: previous_gc_stats set to known baseline
+        baseline = [
+            {"collections": 100, "collected": 200, "uncollectable": 0},
+            {"collections": 10, "collected": 50, "uncollectable": 0},
+            {"collections": 1, "collected": 5, "uncollectable": 0},
+        ]
+        self.helper.previous_gc_stats = baseline
+
+        # Simulate gc.get_stats() returning incremented counts
+        after = [
+            {"collections": 103, "collected": 206, "uncollectable": 0},
+            {"collections": 11, "collected": 53, "uncollectable": 0},
+            {"collections": 1, "collected": 5, "uncollectable": 0},
+        ]
+
+        plugin_data = [{"data": {"metrics": {"gc": {}}}}]
+
+        with patch("gc.get_stats", return_value=after):
+            self.helper._collect_gc_metrics(plugin_data[0], True)
+
+        gc_metrics = plugin_data[0]["data"]["metrics"]["gc"]
+        # Gen 0: collections delta = 3, collected delta = 6, uncollectable delta = 0
+        assert gc_metrics["collections0"] == 3
+        assert gc_metrics["collected0"] == 6
+        assert gc_metrics["uncollectable0"] == 0   # delta=0 is now always sent
+        # Gen 1: collections delta = 1, collected delta = 3, uncollectable delta = 0
+        assert gc_metrics["collections1"] == 1
+        assert gc_metrics["collected1"] == 3
+        assert gc_metrics["uncollectable1"] == 0   # delta=0 is now always sent
+        # Gen 2: no change — all deltas = 0, but still sent
+        assert gc_metrics["collections2"] == 0
+        assert gc_metrics["collected2"] == 0
+        assert gc_metrics["uncollectable2"] == 0
+
+        # previous_gc_stats must be updated to the latest snapshot
+        assert self.helper.previous_gc_stats == after
+
+    def test_collect_gc_metrics_zero_delta_always_sent(self) -> None:
+        """delta=0 must always be sent so filler does not zero-fill on quiet GC periods."""
+        same = [
+            {"collections": 50, "collected": 100, "uncollectable": 0},
+            {"collections": 5, "collected": 20, "uncollectable": 0},
+            {"collections": 0, "collected": 0, "uncollectable": 0},
+        ]
+        self.helper.previous_gc_stats = same
+
+        plugin_data = [{"data": {"metrics": {"gc": {}}}}]
+
+        with patch("gc.get_stats", return_value=same):
+            self.helper._collect_gc_metrics(plugin_data[0], False)
+
+        gc_metrics = plugin_data[0]["data"]["metrics"]["gc"]
+        # All 9 keys must be present, all with value 0
+        expected_keys = [
+            f"{k}{i}"
+            for k in ("collections", "collected", "uncollectable")
+            for i in range(3)
+        ]
+        for key in expected_keys:
+            assert key in gc_metrics, f"{key} must be present even with delta=0"
+            assert gc_metrics[key] == 0, f"{key} delta must be 0"
 
     def test_collect_runtime_metrics(self) -> None:
         """Test that _collect_runtime_metrics properly collects metrics"""
@@ -177,34 +259,33 @@ class TestRuntimeHelper:
         # Verify the previous_rusage was updated
         assert self.helper.previous_rusage == new_resource
 
-    def test_collect_runtime_snapshot_poll_rate_default(self) -> None:
-        """pollRate defaults to 1 when agent has no options configured."""
+    def test_collect_metrics_poll_rate_default(self) -> None:
+        """pollRate defaults to 1 when agent has no options configured.
+        pollRate is now written by collect_metrics() on every poll so that
+        filler learns the rate immediately, not just every 5 min via snapshot.
+        """
         plugin_data = self.helper.collect_metrics()
-        self.helper._collect_runtime_snapshot(plugin_data[0])
         assert plugin_data[0]["data"]["pollRate"] == 1
 
-    def test_collect_runtime_snapshot_poll_rate_from_agent_options(self) -> None:
-        """pollRate is read from agent.options.poll_rate and written to data top-level."""
+    def test_collect_metrics_poll_rate_from_agent_options(self) -> None:
+        """pollRate is read from agent.options.poll_rate on every collect_metrics() call."""
         self.helper.collector.agent.options.poll_rate = 60
         plugin_data = self.helper.collect_metrics()
-        self.helper._collect_runtime_snapshot(plugin_data[0])
         assert plugin_data[0]["data"]["pollRate"] == 60
 
-    def test_collect_runtime_snapshot_poll_rate_no_options(self) -> None:
+    def test_collect_metrics_poll_rate_no_options(self) -> None:
         """pollRate defaults to 1 when agent has no options attribute."""
         self.helper.collector.agent.options = None
         plugin_data = self.helper.collect_metrics()
-        self.helper._collect_runtime_snapshot(plugin_data[0])
         assert plugin_data[0]["data"]["pollRate"] == 1
 
-    def test_collect_runtime_snapshot_poll_rate_no_agent(self) -> None:
+    def test_collect_metrics_poll_rate_no_agent(self) -> None:
         """pollRate defaults to 1 when collector has no agent attribute."""
         self.helper.collector.agent = None
         plugin_data = self.helper.collect_metrics()
-        self.helper._collect_runtime_snapshot(plugin_data[0])
         assert plugin_data[0]["data"]["pollRate"] == 1
 
-    def test_collect_runtime_snapshot_poll_rate_at_top_level_not_in_snapshot(self) -> None:
+    def test_collect_metrics_poll_rate_at_top_level_not_in_snapshot(self) -> None:
         """pollRate must be at data top-level, not nested inside snapshot.
         Backend's PollRateUtil.regularPollRateFromPayload() reads payload.getByPath("pollRate")
         which is a flat lookup on the data map — it cannot find a nested key.

--- a/tests/collector/test_host_collector.py
+++ b/tests/collector/test_host_collector.py
@@ -6,17 +6,18 @@ import logging
 import os
 import sys
 import threading
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
+from mock import patch
+from pytest import LogCaptureFixture
+
 from instana.collector.helpers.runtime import (
     PATH_OF_AUTOTRACE_WEBHOOK_SITEDIR,
 )
 from instana.collector.host import HostCollector
 from instana.singletons import get_agent, get_tracer
 from instana.version import VERSION
-from mock import patch
-from pytest import LogCaptureFixture
 
 
 class TestHostCollector:
@@ -101,6 +102,7 @@ class TestHostCollector:
     def test_should_send_metrics_with_custom_poll_rate(self) -> None:
         """Test that metrics respect custom poll_rate from agent options"""
         from time import time
+
         from instana.options import StandardOptions
 
         # Set custom poll_rate of 5 seconds
@@ -146,6 +148,7 @@ class TestHostCollector:
     def test_prepare_payload_respects_poll_rate(self) -> None:
         """Test that prepare_payload only collects metrics based on poll_rate"""
         from time import time
+
         from instana.options import StandardOptions
 
         # Set poll_rate to 5 seconds
@@ -179,6 +182,7 @@ class TestHostCollector:
     def test_metrics_data_last_sent_updated(self) -> None:
         """Test that metrics_data_last_sent timestamp is updated after collecting metrics"""
         from time import time
+
         from instana.options import StandardOptions
 
         self.agent.options = StandardOptions()
@@ -200,10 +204,10 @@ class TestHostCollector:
     def test_prepare_payload_spans_always_collected(self) -> None:
         """Test that spans are always collected regardless of poll_rate"""
         from instana.options import StandardOptions
-        from instana.span.span import InstanaSpan
-        from instana.span.registered_span import RegisteredSpan
-        from instana.span_context import SpanContext
         from instana.recorder import StanRecorder
+        from instana.span.registered_span import RegisteredSpan
+        from instana.span.span import InstanaSpan
+        from instana.span_context import SpanContext
 
         # Set high poll_rate
         self.agent.options = StandardOptions()
@@ -239,6 +243,7 @@ class TestHostCollector:
 
     def test_prepare_payload_basics(self) -> None:
         with patch.object(gc, "isenabled", return_value=True):
+            # First call establishes the GC baseline; no gc metrics in payload yet.
             self.payload = self.agent.collector.prepare_payload()
             assert self.payload
 
@@ -309,38 +314,22 @@ class TestHostCollector:
                 int,
             ]
 
+            # Second call: GC baseline is now set, so deltas are reported.
+            # Reset both timestamps so metrics AND snapshot are collected.
+            self.agent.collector.metrics_data_last_sent = 0
+            self.agent.collector.snapshot_data_last_sent = 0
+            self.payload = self.agent.collector.prepare_payload()
+            python_plugin = self.payload["metrics"]["plugins"][0]
             assert "gc" in python_plugin["data"]["metrics"]
             assert isinstance(python_plugin["data"]["metrics"]["gc"], dict)
-            assert "collect0" in python_plugin["data"]["metrics"]["gc"]
-            assert type(python_plugin["data"]["metrics"]["gc"]["collect0"]) in [
-                float,
-                int,
-            ]
-            assert "collect1" in python_plugin["data"]["metrics"]["gc"]
-            assert type(python_plugin["data"]["metrics"]["gc"]["collect1"]) in [
-                float,
-                int,
-            ]
-            assert "collect2" in python_plugin["data"]["metrics"]["gc"]
-            assert type(python_plugin["data"]["metrics"]["gc"]["collect2"]) in [
-                float,
-                int,
-            ]
-            assert "threshold0" in python_plugin["data"]["metrics"]["gc"]
-            assert type(python_plugin["data"]["metrics"]["gc"]["threshold0"]) in [
-                float,
-                int,
-            ]
-            assert "threshold1" in python_plugin["data"]["metrics"]["gc"]
-            assert type(python_plugin["data"]["metrics"]["gc"]["threshold1"]) in [
-                float,
-                int,
-            ]
-            assert "threshold2" in python_plugin["data"]["metrics"]["gc"]
-            assert type(python_plugin["data"]["metrics"]["gc"]["threshold2"]) in [
-                float,
-                int,
-            ]
+            for i in range(3):
+                for key in ("collections", "collected", "uncollectable"):
+                    metric_key = f"{key}{i}"
+                    assert metric_key in python_plugin["data"]["metrics"]["gc"]
+                    assert type(python_plugin["data"]["metrics"]["gc"][metric_key]) in [
+                        float,
+                        int,
+                    ]
 
     def test_prepare_payload_basics_disable_runtime_metrics(self) -> None:
         os.environ["INSTANA_DISABLE_METRICS_COLLECTION"] = "TRUE"
@@ -521,3 +510,192 @@ class TestHostCollector:
             self.agent.collector.prepare_and_report_data()
             # The second lock acquisition should see the new state
             assert self.agent.collector.agent.machine.fsm.current == "good2go"
+
+
+class TestHostAgentHeartbeat:
+    """Tests for _send_heartbeat() and related poll_rate-aware timeout logic."""
+
+    @pytest.fixture(autouse=True)
+    def _resource(self) -> Generator[None, None, None]:
+        from instana.collector.host import HostCollector
+        from instana.singletons import get_agent
+
+        self.agent = get_agent()
+        self.agent.collector = HostCollector(self.agent)
+        yield
+        self.agent.collector.shutdown(report_final=False)
+
+    # ------------------------------------------------------------------
+    # _send_heartbeat
+    # ------------------------------------------------------------------
+
+    def test_heartbeat_updates_last_seen_on_success(self) -> None:
+        """HEAD 200 → last_seen must be updated."""
+        from unittest.mock import MagicMock
+
+        from instana.agent.host import AnnounceData
+
+        self.agent.announce_data = AnnounceData(pid=12345, agent_uuid="uuid-1")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch.object(self.agent.machine.fsm, "current", "good2go"), \
+             patch.object(self.agent.client, "head", return_value=mock_response):
+            self.agent._send_heartbeat()
+
+        assert self.agent.last_seen is not None
+
+    def test_heartbeat_skipped_when_announce_data_is_none(self) -> None:
+        """announce_data=None (pre-announce) → HEAD must NOT be called."""
+        self.agent.announce_data = None
+        self.agent.last_seen = None
+
+        with patch.object(self.agent.client, "head") as mock_head:
+            self.agent._send_heartbeat()
+            mock_head.assert_not_called()
+
+        assert self.agent.last_seen is None
+
+    def test_heartbeat_skipped_when_not_in_good2go_state(self) -> None:
+        """FSM state != good2go (e.g. wait4init) → HEAD must NOT be called."""
+        from instana.agent.host import AnnounceData
+
+        self.agent.announce_data = AnnounceData(pid=12345, agent_uuid="uuid-1")
+        self.agent.last_seen = None
+        self.agent.machine.fsm.current = "wait4init"
+
+        with patch.object(self.agent.client, "head") as mock_head:
+            self.agent._send_heartbeat()
+            mock_head.assert_not_called()
+
+        assert self.agent.last_seen is None
+
+    def test_heartbeat_does_not_update_last_seen_on_failure(self) -> None:
+        """HEAD 500 → last_seen must NOT be updated."""
+        from unittest.mock import MagicMock
+
+        from instana.agent.host import AnnounceData
+
+        self.agent.announce_data = AnnounceData(pid=12345, agent_uuid="uuid-1")
+        self.agent.last_seen = None
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+
+        with patch.object(self.agent.client, "head", return_value=mock_response):
+            self.agent._send_heartbeat()
+
+        assert self.agent.last_seen is None
+
+    def test_heartbeat_handles_connection_error_silently(self) -> None:
+        """ConnectionError → no exception propagated, last_seen unchanged."""
+        import requests
+
+        from instana.agent.host import AnnounceData
+
+        self.agent.announce_data = AnnounceData(pid=12345, agent_uuid="uuid-1")
+        self.agent.last_seen = None
+
+        with patch.object(
+            self.agent.client, "head",
+            side_effect=requests.exceptions.ConnectionError
+        ):
+            self.agent._send_heartbeat()  # must not raise
+
+        assert self.agent.last_seen is None
+
+    # ------------------------------------------------------------------
+    # report_data_payload → heartbeat integration
+    # ------------------------------------------------------------------
+
+    def test_heartbeat_called_when_no_data_sent(self) -> None:
+        """Empty payload (no spans/profiles/metrics) → _send_heartbeat is called."""
+        from instana.util import DictionaryOfStan
+
+        empty_payload = DictionaryOfStan()
+        empty_payload["spans"] = []
+        empty_payload["profiles"] = []
+        empty_payload["metrics"]["plugins"] = []
+
+        with patch.object(self.agent, "_send_heartbeat") as mock_hb:
+            self.agent.report_data_payload(empty_payload)
+            mock_hb.assert_called_once()
+
+    def test_heartbeat_not_called_when_metrics_sent(self) -> None:
+        """Metrics present and successfully sent → _send_heartbeat must NOT be called."""
+        from unittest.mock import MagicMock
+
+        from instana.agent.host import AnnounceData
+        from instana.util import DictionaryOfStan
+
+        self.agent.announce_data = AnnounceData(pid=12345, agent_uuid="uuid-1")
+
+        payload = DictionaryOfStan()
+        payload["spans"] = []
+        payload["profiles"] = []
+        payload["metrics"]["plugins"] = [{"data": {"ru_utime": 0.1}}]
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"{}"
+
+        with patch.object(self.agent.client, "post", return_value=mock_response), \
+            patch.object(self.agent, "_send_heartbeat") as mock_hb:
+            self.agent.report_data_payload(payload)
+            mock_hb.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # is_timed_out — poll_rate-aware threshold
+    # ------------------------------------------------------------------
+
+    def test_is_timed_out_default_threshold_60s(self) -> None:
+        """Default poll_rate=1 → timeout threshold is 60 s."""
+        from datetime import datetime, timedelta
+
+        from instana.options import StandardOptions
+
+        self.agent.options = StandardOptions()
+        self.agent.options.poll_rate = 1
+        self.agent.last_seen = datetime.now() - timedelta(seconds=61)
+
+        with patch.object(self.agent.machine.fsm, "current", "good2go"):
+            assert self.agent.is_timed_out()
+
+    def test_is_timed_out_not_triggered_before_threshold(self) -> None:
+        """last_seen 59 s ago with poll_rate=1 → not timed out."""
+        from datetime import datetime, timedelta
+
+        from instana.options import StandardOptions
+
+        self.agent.options = StandardOptions()
+        self.agent.options.poll_rate = 1
+        self.agent.last_seen = datetime.now() - timedelta(seconds=59)
+
+        with patch.object(self.agent.machine.fsm, "current", "good2go"):
+            assert not self.agent.is_timed_out()
+
+    def test_is_timed_out_uses_poll_rate_times_two_when_larger(self) -> None:
+        """poll_rate=120 → threshold becomes 240 s, not 60 s."""
+        from datetime import datetime, timedelta
+
+        from instana.options import StandardOptions
+
+        self.agent.options = StandardOptions()
+        self.agent.options.poll_rate = 120
+        # 61 s ago — would fire with old 60 s threshold, must NOT fire now
+        self.agent.last_seen = datetime.now() - timedelta(seconds=61)
+
+        with patch.object(self.agent.machine.fsm, "current", "good2go"):
+            assert not self.agent.is_timed_out()
+
+        # 241 s ago — exceeds poll_rate*2=240, must fire
+        self.agent.last_seen = datetime.now() - timedelta(seconds=241)
+        with patch.object(self.agent.machine.fsm, "current", "good2go"):
+            assert self.agent.is_timed_out()
+
+    def test_is_timed_out_false_when_last_seen_is_none(self) -> None:
+        """last_seen=None (never connected) → not timed out."""
+        self.agent.last_seen = None
+        with patch.object(self.agent.machine.fsm, "current", "good2go"):
+            assert not self.agent.is_timed_out()

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -2,7 +2,8 @@
 
 import logging
 import os
-from typing import Generator, Optional
+from collections.abc import Generator
+from typing import Optional
 
 import pytest
 from mock import patch
@@ -1093,14 +1094,14 @@ class TestStandardOptions:
 
     @pytest.mark.parametrize(
         "poll_rate_value",
-        [1, 5],
+        [1, 5, 10, 60, 600],
     )
     def test_set_from_with_valid_poll_rate(
         self,
         poll_rate_value: int,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Test setting poll_rate from announce response - affects metrics only"""
+        """Test setting poll_rate from announce response — exact valid values are accepted as-is."""
         caplog.set_level(logging.DEBUG, logger="instana")
         caplog.clear()
 
@@ -1115,24 +1116,57 @@ class TestStandardOptions:
         )
 
     @pytest.mark.parametrize(
-        "invalid_value",
-        [10, 0, -5, 3],
+        "invalid_value,expected",
+        [
+            (0, 1),   # zero → default
+            (-5, 1),  # negative → default
+        ],
     )
     def test_set_from_with_invalid_poll_rate_defaults_to_1(
         self,
         invalid_value: int,
+        expected: int,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Test that invalid poll_rate values default to 1"""
+        """Test that zero and negative poll_rate values default to 1."""
         caplog.set_level(logging.DEBUG, logger="instana")
         caplog.clear()
 
         self.standart_options = StandardOptions()
         test_res_data = {"plugin": {"python": {"poll_rate": invalid_value}}}
         self.standart_options.set_from(test_res_data)
-        assert self.standart_options.poll_rate == 1
+        assert self.standart_options.poll_rate == expected
         assert (
             f"Invalid poll_rate value {invalid_value}, defaulting to 1"
+            in caplog.messages
+        )
+
+    @pytest.mark.parametrize(
+        "input_value,expected",
+        [
+            (3, 1),  # nearest to 1
+            (7, 5),  # nearest to 5 (|7-5|=2 < |7-10|=3)
+            (8, 10),  # nearest to 10
+            (100, 120),  # nearest to 120 (|100-60|=40 > |100-120|=20)
+            (700, 600),  # above max → clamp to 600
+        ],
+    )
+    def test_set_from_with_non_exact_poll_rate_rounds_to_nearest(
+        self,
+        input_value: int,
+        expected: int,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Test that non-exact values are rounded to the nearest valid poll rate."""
+        caplog.set_level(logging.DEBUG, logger="instana")
+        caplog.clear()
+
+        self.standart_options = StandardOptions()
+        test_res_data = {"plugin": {"python": {"poll_rate": input_value}}}
+        self.standart_options.set_from(test_res_data)
+        assert self.standart_options.poll_rate == expected
+        assert (
+            f"Poll rate set to {expected} seconds from agent configuration"
             in caplog.messages
         )
 


### PR DESCRIPTION
## Why

The tracer previously capped `poll_rate` to a maximum of `5` seconds,
silently resetting any higher value back to `1`. This prevented customers
from benefiting from coarser poll rates (e.g. `60 s`, `120 s`) to reduce
observability cost.

Additionally, GC metrics were collected using `gc.get_count()` and
`gc.get_threshold()`, which do not reflect actual GC activity. The correct
source is `gc.get_stats()`, which tracks cumulative `collections`,
`collected`, and `uncollectable` counters per generation — consistent with
the [OpenTelemetry CPython semantic conventions](https://opentelemetry.io/docs/specs/semconv/runtime/cpython-metrics/)
(`cpython.gc.collections`, `cpython.gc.collected_objects`,
`cpython.gc.uncollectable_objects`) and the
[OpenTelemetry Python contrib `system_metrics` instrumentation](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/system_metrics/system_metrics.html),
both of which source these metrics from `gc.get_stats()`.

Finally, the host agent timeout detection used a fixed 60-second window,
causing spurious disconnects when `poll_rate` exceeded 30 seconds.

## What

- **`options.py`**: Replaced `MAX_POLL_RATE = 5` with a `VALID_POLL_RATES`
  list `[1, 5, 10, 20, 30, 60, 120, 180, 240, 300, 360, 420, 480, 540, 600]`.
  `set_poll_rate()` now rounds to the nearest valid value instead of
  rejecting anything outside `{1, 5}`.

- **`runtime.py`**: Switched GC collection from `gc.get_count()` /
  `gc.get_threshold()` to `gc.get_stats()`. Reports per-generation deltas
  for `collections`, `collected`, and `uncollectable` (keys
  `gc.collections0-2`, `gc.collected0-2`, `gc.uncollectable0-2`).

- **`host.py`**: Timeout window is now `max(60, poll_rate * 2)` seconds to
  avoid false resets at high poll rates. Added `_send_heartbeat()` — a
  lightweight `HEAD` request sent when no metrics/spans/profiles are
  produced in a cycle, keeping `last_seen` current between polls.

## Testing

Unit tests are included for all changed behaviours in:
`tests/test_options.py`, `tests/collector/helpers/test_collector_runtime.py`,
`tests/collector/test_host_collector.py`, `tests/agent/test_host.py`