### PR TITLE
fix: Set default value for asyncio context propagation as True.

### DIFF
--- a/src/instana/configurator.py
+++ b/src/instana/configurator.py
@@ -14,4 +14,4 @@ config = DictionaryOfStan()
 
 # This option determines if tasks created via asyncio (with ensure_future or create_task) will
 # automatically carry existing context into the created task.
-config["asyncio_task_context_propagation"]["enabled"] = False
+config["asyncio_task_context_propagation"]["enabled"] = True


### PR DESCRIPTION
I propose setting the default value for this environment variable as True. Some popular LLM libraries and frameworks like OpenWebUI, LiteLLM and Strands use asyncio under the hood to make asynchronous calls. Defaulting it to True will not corrupt any existing instrumentation and will save time for users who use LLM libraries.