### PR TITLE
chore: Update prod regions for AWS Lambda layer publishing script.

### DIFF
--- a/bin/aws-lambda/build_and_publish_lambda_layer.py
+++ b/bin/aws-lambda/build_and_publish_lambda_layer.py
@@ -8,7 +8,8 @@ import os
 import shutil
 import sys
 import time
-from subprocess import DEVNULL, CalledProcessError, call, check_call, check_output
+from subprocess import (DEVNULL, CalledProcessError, call, check_call,
+                        check_output)
 
 for profile in ("china", "non-china"):
     try:
@@ -127,8 +128,6 @@ else:
         "ap-southeast-7",
         "ca-central-1",
         "ca-west-1",
-        "cn-north-1",
-        "cn-northwest-1",
         "eu-central-1",
         "eu-central-2",
         "eu-north-1",
@@ -139,13 +138,16 @@ else:
         "eu-west-3",
         "il-central-1",
         "me-central-1",
-        "me-south-1",
+        # "me-south-1",     # https://health.aws.amazon.com/health/status 
         "sa-east-1",
         "us-east-1",
         "us-east-2",
         "us-west-1",
         "us-west-2",
     ]
+
+    target_regions += cn_regions
+
     LAYER_NAME = "instana-python"
 
 published = dict()


### PR DESCRIPTION
# Summary

This pull request updates the AWS Lambda layer publishing script to refine the list of target production regions.

**Changes include:**
- **Extracted China regions** (`cn-north-1`, `cn-northwest-1`) into a dedicated `cn_regions` list and appended them to the `target_regions` list at runtime, instead of embedding them inline. 
- **Commented out `me-south-1`** from the production target regions with a reference to the AWS Health status page (`https://health.aws.amazon.com/health/status`), indicating a temporary availability issue.
- **Minor formatting fix** to the `subprocess` imports, wrapping them across multiple lines for readability.

# Files Changed

- [`bin/aws-lambda/build_and_publish_lambda_layer.py`](bin/aws-lambda/build_and_publish_lambda_layer.py) — Updated production region list and refactored China region handling.