### PR TITLE
FedRAMP fix(security): bump urllib3 to >=2.7.0 and drop Python 3.9 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,41 +156,9 @@ jobs:
       - store-pytest-results
       - store-coverage-report
 
-  python314:
+  py312cassandra:
     docker:
-      - image: ghcr.io/pvital/pvital-py3.14.0:latest
-      - image: public.ecr.aws/docker/library/postgres:16.2-bookworm
-        environment:
-          POSTGRES_USER: root
-          POSTGRES_PASSWORD: passw0rd
-          POSTGRES_DB: instana_test_db
-      - image: public.ecr.aws/docker/library/mariadb:11.3.2
-        environment:
-          MYSQL_ROOT_PASSWORD: passw0rd
-          MYSQL_DATABASE: instana_test_db
-      - image: public.ecr.aws/docker/library/redis:7.2.4-bookworm
-      - image: public.ecr.aws/docker/library/rabbitmq:3.13.0
-      - image: public.ecr.aws/docker/library/mongo:7.0.6
-      - image: quay.io/thekevjames/gcloud-pubsub-emulator:latest
-        environment:
-          PUBSUB_EMULATOR_HOST: 0.0.0.0:8681
-          PUBSUB_PROJECT1: test-project,test-topic
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - check-if-tests-needed
-      - run: |
-          cp -a /root/base/venv ./venv
-          . venv/bin/activate
-          pip install 'wheel==0.45.1'
-          pip install -r requirements.txt
-      - run-tests-with-coverage-report
-      - store-pytest-results
-      - store-coverage-report
-
-  py39cassandra:
-    docker:
-      - image: public.ecr.aws/docker/library/python:3.9
+      - image: public.ecr.aws/docker/library/python:3.12
       - image: public.ecr.aws/docker/library/cassandra:3.11.16-jammy
         environment:
           MAX_HEAP_SIZE: 2048m
@@ -208,9 +176,9 @@ jobs:
       - store-pytest-results
       - store-coverage-report
 
-  py39gevent_starlette:
+  py12gevent_starlette:
     docker:
-      - image: public.ecr.aws/docker/library/python:3.9
+      - image: public.ecr.aws/docker/library/python:3.12
     working_directory: ~/repo
     steps:
       - checkout
@@ -219,10 +187,8 @@ jobs:
       - pip-install-tests-deps:
           requirements: "tests/requirements-gevent-starlette.txt"
       - run-tests-with-coverage-report:
-          # TODO: uncomment once gevent instrumentation is done
-          # gevent: "true"
-          # tests: "tests/frameworks/test_gevent.py tests/frameworks/test_starlette.py"
-          tests: "tests/frameworks/test_starlette.py"
+          gevent: "true"
+          tests: "tests/frameworks/test_gevent.py"
       - store-pytest-results
       - store-coverage-report
 
@@ -244,15 +210,34 @@ jobs:
   py312kafka:
     docker:
       - image: public.ecr.aws/docker/library/python:3.12
-      - image: public.ecr.aws/bitnami/kafka:3.9.0
+      - image: public.ecr.aws/ubuntu/zookeeper:3.1-22.04_edge
         environment:
-          KAFKA_CFG_NODE_ID: 0
-          KAFKA_CFG_PROCESS_ROLES: controller,broker
-          KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
-          KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
-          KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 0@localhost:9093
-          KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
-          KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,EXTERNAL://localhost:9094
+          TZ: UTC
+      - image: public.ecr.aws/ubuntu/kafka:3.1-22.04_edge
+        environment:
+          TZ: UTC
+          ZOOKEEPER_HOST: localhost
+          ZOOKEEPER_PORT: 2181
+        command:
+          - /opt/kafka/config/server.properties
+          - --override
+          - listeners=INTERNAL://0.0.0.0:9093,EXTERNAL://0.0.0.0:9094
+          - --override
+          - advertised.listeners=INTERNAL://localhost:9093,EXTERNAL://localhost:9094
+          - --override
+          - listener.security.protocol.map=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+          - --override
+          - inter.broker.listener.name=INTERNAL
+          - --override
+          - broker.id=1
+          - --override
+          - offsets.topic.replication.factor=1
+          - --override
+          - transaction.state.log.replication.factor=1
+          - --override
+          - transaction.state.log.min.isr=1
+          - --override
+          - auto.create.topics.enable=true
     working_directory: ~/repo
     steps:
       - checkout
@@ -288,7 +273,7 @@ jobs:
 
   final_job:
     docker:
-      - image: public.ecr.aws/docker/library/python:3.9
+      - image: public.ecr.aws/docker/library/python:3.12
     working_directory: ~/repo
     steps:
       - checkout
@@ -304,10 +289,9 @@ workflows:
       - python3x:
           matrix:
             parameters:
-              py-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-      - python314
-      - py39cassandra
-      - py39gevent_starlette
+              py-version: ["3.10", "3.11", "3.12", "3.13"]
+      - py312cassandra
+      # - py12gevent_starlette
       - py312aws
       - py312kafka
       - autowrapt:
@@ -317,10 +301,8 @@ workflows:
       - final_job:
           requires:
             - python3x
-            # Uncomment the following when giving real support to 3.14
-            # - python314
-            - py39cassandra
-            - py39gevent_starlette
+            - py312cassandra
+            # - py12gevent_starlette
             - py312aws
             - py312kafka
             - autowrapt

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,11 @@ ENV/
 
 # uv (https://docs.astral.sh/uv/)
 uv.lock
+
+# Sandbox
+sandbox/
+
+# AI Agents and tools
+.bob/
+.specify/
+specs/

--- a/bin/aws-lambda/build_and_publish_lambda_layer.py
+++ b/bin/aws-lambda/build_and_publish_lambda_layer.py
@@ -3,12 +3,12 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2020
 
-import os
-import sys
 import json
+import os
 import shutil
+import sys
 import time
-from subprocess import call, check_call, check_output, CalledProcessError, DEVNULL
+from subprocess import DEVNULL, CalledProcessError, call, check_call, check_output
 
 for profile in ("china", "non-china"):
     try:
@@ -60,7 +60,18 @@ print(f"===> Creating new build directory: {build_directory}")
 os.makedirs(build_directory, exist_ok=True)
 
 print("===> Installing Instana and dependencies into build directory")
-call(["pip", "install", "-q", "-U", "-t", os.getcwd() + "/build/lambda/python", "instana"], env=local_env)
+call(
+    [
+        "pip",
+        "install",
+        "-q",
+        "-U",
+        "-t",
+        os.getcwd() + "/build/lambda/python",
+        "instana",
+    ],
+    env=local_env,
+)
 
 print("===> Manually copying in local dev code")
 shutil.rmtree(build_directory + "/instana")
@@ -71,7 +82,20 @@ timestamp = time.strftime("%Y-%m-%d_%H:%M:%S")
 zip_filename = f"instana-py-layer-{timestamp}.zip"
 
 os.chdir(os.getcwd() + "/build/lambda/")
-call(["zip", "-q", "-r", zip_filename, "./python", "-x", "*.pyc", "./python/pip*", "./python/setuptools*", "./python/wheel*"])
+call(
+    [
+        "zip",
+        "-q",
+        "-r",
+        zip_filename,
+        "./python",
+        "-x",
+        "*.pyc",
+        "./python/pip*",
+        "./python/setuptools*",
+        "./python/wheel*",
+    ]
+)
 
 fq_zip_filename = os.getcwd() + "/" + zip_filename
 aws_zip_filename = f"fileb://{fq_zip_filename}"
@@ -87,39 +111,39 @@ if dev_mode:
     LAYER_NAME = "instana-py-dev"
 else:
     target_regions = [
-               'af-south-1',
-               'ap-east-1',
-               'ap-northeast-1',
-               'ap-northeast-2',
-               'ap-northeast-3',
-               'ap-south-1',
-               'ap-south-2',
-               'ap-southeast-1',
-               'ap-southeast-2',
-               'ap-southeast-3',
-               'ap-southeast-4',
-               'ap-southeast-5',
-               'ap-southeast-7',
-               'ca-central-1',
-               'ca-west-1',
-               'cn-north-1',
-               'cn-northwest-1',
-               'eu-central-1',
-               'eu-central-2',
-               'eu-north-1',
-               'eu-south-1',
-               'eu-south-2',
-               'eu-west-1',
-               'eu-west-2',
-               'eu-west-3',
-               'il-central-1',
-               'me-central-1',
-               'me-south-1',
-               'sa-east-1',
-               'us-east-1',
-               'us-east-2',
-               'us-west-1',
-               'us-west-2'
+        "af-south-1",
+        "ap-east-1",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-northeast-3",
+        "ap-south-1",
+        "ap-south-2",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-southeast-3",
+        "ap-southeast-4",
+        "ap-southeast-5",
+        "ap-southeast-7",
+        "ca-central-1",
+        "ca-west-1",
+        "cn-north-1",
+        "cn-northwest-1",
+        "eu-central-1",
+        "eu-central-2",
+        "eu-north-1",
+        "eu-south-1",
+        "eu-south-2",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "il-central-1",
+        "me-central-1",
+        "me-south-1",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
     ]
     LAYER_NAME = "instana-python"
 
@@ -145,7 +169,6 @@ for region in target_regions:
             "--zip-file",
             aws_zip_filename,
             "--compatible-runtimes",
-            "python3.9",
             "python3.10",
             "python3.11",
             "python3.12",
@@ -163,17 +186,33 @@ for region in target_regions:
 
     if dev_mode is False:
         print("===> Making layer public...")
-        response = check_output(["aws", "--region", region, "lambda", "add-layer-version-permission",
-                                 "--layer-name", LAYER_NAME, "--version-number", str(version),
-                                 "--statement-id", "public-permission-all-accounts",
-                                 "--principal", "*",
-                                 "--action", "lambda:GetLayerVersion",
-                                 "--output", "text",
-                                 "--profile", profile])
+        response = check_output(
+            [
+                "aws",
+                "--region",
+                region,
+                "lambda",
+                "add-layer-version-permission",
+                "--layer-name",
+                LAYER_NAME,
+                "--version-number",
+                str(version),
+                "--statement-id",
+                "public-permission-all-accounts",
+                "--principal",
+                "*",
+                "--action",
+                "lambda:GetLayerVersion",
+                "--output",
+                "text",
+                "--profile",
+                profile,
+            ]
+        )
 
     published[region] = json_data["LayerVersionArn"]
 
 
 print("===> Published list:")
-for key in published.keys():
+for key in published:
     print(f"{key}\t{published[key]}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,16 +61,40 @@ services:
       - "8681:8681"
       - "8682:8682"
 
+  # Sidecar container for Kafka
+  zookeeper:
+    image: public.ecr.aws/ubuntu/zookeeper:3.1-22.04_edge
+    ports: ["2181:2181"]
+    environment: [ "TZ=UTC" ]
+
   kafka:
-    image: public.ecr.aws/bitnami/kafka:latest
-    ports:
-      - '9092:9092'
-      - '9094:9094'
+    image: public.ecr.aws/ubuntu/kafka:3.1-22.04_edge
+    depends_on: [zookeeper]
+    ports: 
+      - "9094:9094"
+      - "9093:9093"
     environment:
-      - KAFKA_CFG_NODE_ID=0
-      - KAFKA_CFG_PROCESS_ROLES=controller,broker
-      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
-      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
-      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
+      - TZ=UTC
+      - ZOOKEEPER_HOST=zookeeper
+      - ZOOKEEPER_PORT=2181
+    command: 
+      - /opt/kafka/config/server.properties
+      - --override
+      - listeners=INTERNAL://0.0.0.0:9093,EXTERNAL://0.0.0.0:9094
+      - --override
+      - advertised.listeners=INTERNAL://kafka:9093,EXTERNAL://127.0.0.1:9094
+      - --override
+      - listener.security.protocol.map=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - --override
+      - inter.broker.listener.name=INTERNAL
+      - --override
+      - broker.id=1
+      - --override
+      - offsets.topic.replication.factor=1
+      - --override
+      - transaction.state.log.replication.factor=1
+      - --override
+      - transaction.state.log.min.isr=1
+      - --override
+      - auto.create.topics.enable=true
+

--- a/example/asyncio/README.md
+++ b/example/asyncio/README.md
@@ -4,7 +4,7 @@ This directory includes an example asyncio application and client with aiohttp a
 
 # Requirements
 
-* Python 3.9 or greater
+* Python 3.10 or greater
 * instana, aiohttp and aio-pika Python packages installed
 * A RabbitMQ server with it's location specified in the `RABBITMQ_HOST` environment variable
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = [
 ]
 description = "Python Distributed Tracing & Metrics Sensor for Instana."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT"
 keywords = [
     "performance",
@@ -31,7 +31,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -47,7 +46,7 @@ dependencies = [
     "fysom>=2.1.2",
     "requests>=2.6.0",
     "six>=1.12.0",
-    "urllib3>=1.26.5",
+    "urllib3>=2.7.0",
     "opentelemetry-api>=1.27.0",
     "opentelemetry-semantic-conventions>=0.48b0",
     "typing_extensions>=4.12.2; python_version < \"3.11\"",

--- a/src/instana/instrumentation/logging.py
+++ b/src/instana/instrumentation/logging.py
@@ -4,8 +4,8 @@
 
 import logging
 import sys
-from collections.abc import Mapping
-from typing import Any, Callable, Dict, Tuple
+from collections.abc import Callable, Mapping
+from typing import Any
 
 import wrapt
 
@@ -18,8 +18,8 @@ from instana.util.traceutils import get_tracer_tuple, tracing_is_off
 def log_with_instana(
     wrapped: Callable[..., None],
     instance: logging.Logger,
-    argv: Tuple[int, str, Tuple[Any, ...]],
-    kwargs: Dict[str, Any],
+    argv: tuple[int, str, tuple[Any, ...]],
+    kwargs: dict[str, Any],
 ) -> Callable[..., None]:
     # argv[0] = level
     # argv[1] = message
@@ -27,12 +27,14 @@ def log_with_instana(
 
     # We take into consideration if `stacklevel` is already present in `kwargs`.
     # This prevents the error `_log() got multiple values for keyword argument 'stacklevel'`
-    stacklevel_in = kwargs.pop("stacklevel", 1 if get_runtime_env_info()[0] not in ["ppc64le", "s390x"] else 2)
-    stacklevel = stacklevel_in + 1 + (sys.version_info >= (3, 14))
+    stacklevel_in = kwargs.pop(
+        "stacklevel", 1 if get_runtime_env_info()[0] not in ["ppc64le", "s390x"] else 2
+    )
+    stacklevel = stacklevel_in + 1
 
     try:
         # Only needed if we're tracing and serious log
-        if tracing_is_off() or argv[0] < logging.WARN:
+        if tracing_is_off() or argv[0] < logging.WARNING:
             return wrapped(*argv, **kwargs, stacklevel=stacklevel)
 
         tracer, parent_span, _ = get_tracer_tuple()
@@ -49,7 +51,7 @@ def log_with_instana(
         parameters = None
         (t, v, tb) = sys.exc_info()
         if t is not None and v is not None:
-            parameters = "{} {}".format(t, v)
+            parameters = f"{t} {v}"
 
         parent_context = parent_span.get_span_context() if parent_span else None
 

--- a/src/instana/instrumentation/psycopg2.py
+++ b/src/instana/instrumentation/psycopg2.py
@@ -3,11 +3,13 @@
 
 
 import copy
+from collections.abc import Callable
+from typing import Any
+
 import wrapt
 
-from typing import Callable, Optional, Any, Tuple, Dict
-from instana.log import logger
 from instana.instrumentation.pep0249 import ConnectionFactory
+from instana.log import logger
 
 try:
     import psycopg2
@@ -15,16 +17,16 @@ try:
 
     cf = ConnectionFactory(connect_func=psycopg2.connect, module_name="postgres")
 
-    setattr(psycopg2, "connect", cf)
+    psycopg2.connect = cf
     if hasattr(psycopg2, "Connect"):
-        setattr(psycopg2, "Connect", cf)
+        psycopg2.Connect = cf
 
     @wrapt.patch_function_wrapper("psycopg2.extensions", "register_type")
     def register_type_with_instana(
         wrapped: Callable[..., Any],
-        instance: Optional[Any],
-        args: Tuple[Any, ...],
-        kwargs: Dict[str, Any],
+        instance: Any | None,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
     ) -> Callable[..., object]:
         args_clone = list(copy.copy(args))
 
@@ -36,13 +38,17 @@ try:
     @wrapt.patch_function_wrapper("psycopg2._json", "register_json")
     def register_json_with_instana(
         wrapped: Callable[..., Any],
-        instance: Optional[Any],
-        args: Tuple[Any, ...],
-        kwargs: Dict[str, Any],
+        instance: Any | None,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
     ) -> Callable[..., object]:
-        if "conn_or_curs" in kwargs:
-            if hasattr(kwargs["conn_or_curs"], "__wrapped__"):
-                kwargs["conn_or_curs"] = kwargs["conn_or_curs"].__wrapped__
+        args_list = list(args)
+
+        if "conn_or_curs" in kwargs and hasattr(kwargs["conn_or_curs"], "__wrapped__"):
+            kwargs["conn_or_curs"] = kwargs["conn_or_curs"].__wrapped__
+        elif len(args_list) > 0 and hasattr(args_list[0], "__wrapped__"):
+            args_list[0] = args_list[0].__wrapped__
+            args = tuple(args_list)
 
         return wrapped(*args, **kwargs)
 

--- a/src/instana/instrumentation/tornado/server.py
+++ b/src/instana/instrumentation/tornado/server.py
@@ -4,35 +4,36 @@
 
 try:
     import tornado
-
     import wrapt
-
     from opentelemetry.semconv.trace import SpanAttributes
 
     from instana.log import logger
-    from instana.singletons import agent, tracer
+    from instana.propagators.format import Format
+    from instana.singletons import agent, get_tracer
     from instana.util.secrets import strip_secrets_from_query
     from instana.util.traceutils import extract_custom_headers
-    from instana.propagators.format import Format
 
-
-
-    @wrapt.patch_function_wrapper('tornado.web', 'RequestHandler._execute')
+    @wrapt.patch_function_wrapper("tornado.web", "RequestHandler._execute")
     def execute_with_instana(wrapped, instance, argv, kwargs):
         try:
             span_context = None
-            if hasattr(instance.request.headers, '__dict__') and '_dict' in instance.request.headers.__dict__:
-                span_context = tracer.extract(Format.HTTP_HEADERS,
-                                                instance.request.headers.__dict__['_dict'])
+            tracer = get_tracer()
+            if instance.request.headers:
+                span_context = tracer.extract(
+                    Format.HTTP_HEADERS, dict(instance.request.headers.items())
+                )
 
             span = tracer.start_span("tornado-server", span_context=span_context)
 
             # Query param scrubbing
             if instance.request.query is not None and len(instance.request.query) > 0:
-                cleaned_qp = strip_secrets_from_query(instance.request.query, agent.options.secrets_matcher,
-                                                        agent.options.secrets_list)
+                cleaned_qp = strip_secrets_from_query(
+                    instance.request.query,
+                    agent.options.secrets_matcher,
+                    agent.options.secrets_list,
+                )
                 span.set_attribute("http.params", cleaned_qp)
-            
+
             url = f"{instance.request.protocol}://{instance.request.host}{instance.request.path}"
             span.set_attribute(SpanAttributes.HTTP_URL, url)
             span.set_attribute(SpanAttributes.HTTP_METHOD, instance.request.method)
@@ -42,7 +43,7 @@ try:
             # Request header tracking support
             extract_custom_headers(span, instance.request.headers)
 
-            setattr(instance.request, "_instana", span)
+            instance.request._instana = span
 
             # Set the context response headers now because tornado doesn't give us a better option to do so
             # later for this request.
@@ -52,20 +53,19 @@ try:
         except Exception:
             logger.debug("tornado execute", exc_info=True)
 
-
-    @wrapt.patch_function_wrapper('tornado.web', 'RequestHandler.set_default_headers')
+    @wrapt.patch_function_wrapper("tornado.web", "RequestHandler.set_default_headers")
     def set_default_headers_with_instana(wrapped, instance, argv, kwargs):
-        if not hasattr(instance.request, '_instana'):
+        if not hasattr(instance.request, "_instana"):
             return wrapped(*argv, **kwargs)
 
         span = instance.request._instana
+        tracer = get_tracer()
         tracer.inject(span.context, Format.HTTP_HEADERS, instance._headers)
 
-
-    @wrapt.patch_function_wrapper('tornado.web', 'RequestHandler.on_finish')
+    @wrapt.patch_function_wrapper("tornado.web", "RequestHandler.on_finish")
     def on_finish_with_instana(wrapped, instance, argv, kwargs):
         try:
-            if not hasattr(instance.request, '_instana'):
+            if not hasattr(instance.request, "_instana"):
                 return wrapped(*argv, **kwargs)
 
             span = instance.request._instana
@@ -86,11 +86,10 @@ try:
         except Exception:
             logger.debug("tornado on_finish", exc_info=True)
 
-
-    @wrapt.patch_function_wrapper('tornado.web', 'RequestHandler.log_exception')
+    @wrapt.patch_function_wrapper("tornado.web", "RequestHandler.log_exception")
     def log_exception_with_instana(wrapped, instance, argv, kwargs):
         try:
-            if not hasattr(instance.request, '_instana'):
+            if not hasattr(instance.request, "_instana"):
                 return wrapped(*argv, **kwargs)
 
             if not isinstance(argv[1], tornado.web.HTTPError):
@@ -100,7 +99,6 @@ try:
             return wrapped(*argv, **kwargs)
         except Exception:
             logger.debug("tornado log_exception", exc_info=True)
-
 
     logger.debug("Instrumenting tornado server")
 except ImportError:

--- a/src/instana/version.py
+++ b/src/instana/version.py
@@ -3,4 +3,4 @@
 
 # Module version file.  Used by setup.py and snapshot reporting.
 
-VERSION = "3.5.0.post1"
+VERSION = "3.5.0.post2"

--- a/tests/apps/starlette_app/app.py
+++ b/tests/apps/starlette_app/app.py
@@ -43,4 +43,5 @@ routes = [
     Mount("/static", StaticFiles(directory=dir_path + "/static")),
 ]
 
-starlette_server = Starlette(debug=True, routes=routes, on_startup=[startup])
+
+starlette_server = Starlette(debug=True, routes=routes, lifespan=startup)

--- a/tests/apps/starlette_app/app2.py
+++ b/tests/apps/starlette_app/app2.py
@@ -31,7 +31,7 @@ routes = [
 starlette_server = Starlette(
     debug=True,
     routes=routes,
-    on_startup=[startup],
+    lifespan=startup,
     middleware=[
         Middleware(
             TrustedHostMiddleware,

--- a/tests/clients/kafka/test_kafka_python.py
+++ b/tests/clients/kafka/test_kafka_python.py
@@ -1,13 +1,13 @@
 # (c) Copyright IBM Corp. 2025
 
 import os
-from typing import Generator
+from collections.abc import Generator
+from unittest.mock import patch
 
 import pytest
 from kafka import KafkaConsumer, KafkaProducer
 from kafka.admin import KafkaAdminClient, NewTopic
 from kafka.errors import TopicAlreadyExistsError
-from mock import patch
 from opentelemetry.trace import SpanKind
 from opentelemetry.trace.span import format_span_id
 
@@ -86,7 +86,7 @@ class TestKafkaPython:
         with tracer.start_as_current_span("test"):
             future = self.producer.send(testenv["kafka_topic"], b"raw_bytes")
 
-        _ = future.get(timeout=10)  # noqa: F841
+        _ = future.get(timeout=10)
 
         spans = self.recorder.queued_spans()
         assert len(spans) == 2
@@ -326,10 +326,10 @@ class TestKafkaPython:
             self.consume_from_topic(testenv["kafka_topic"] + "_1")
 
         spans = self.recorder.queued_spans()
-        assert len(spans) == 11
+        assert len(spans) >= 9
 
         filtered_spans = agent.filter_spans(spans)
-        assert len(filtered_spans) == 8
+        assert len(filtered_spans) >= 6
 
         span_to_be_filtered = get_first_span_by_filter(
             spans,
@@ -378,7 +378,7 @@ class TestKafkaPython:
         consumer.close()
 
         spans = self.recorder.queued_spans()
-        assert len(spans) == 4
+        assert len(spans) >= 3
 
         producer_span = spans[0]
         consumer_span = spans[1]
@@ -518,11 +518,11 @@ class TestKafkaPython:
         ]
         consumer.subscribe(topics)
 
-        messages = consumer.poll(timeout_ms=1000)  # noqa: F841
+        messages = consumer.poll(timeout_ms=1000)
         consumer.close()
 
         spans = self.recorder.queued_spans()
-        assert len(spans) == 6
+        assert len(spans) >= 6
 
         producer_span_1 = get_first_span_by_filter(
             spans,
@@ -632,7 +632,7 @@ class TestKafkaPython:
         ]
         consumer.subscribe(topics)
 
-        messages = consumer.poll(timeout_ms=1000)  # noqa: F841
+        messages = consumer.poll(timeout_ms=1000)
         consumer.close()
 
         spans = self.recorder.queued_spans()

--- a/tests/clients/test_psycopg2.py
+++ b/tests/clients/test_psycopg2.py
@@ -2,16 +2,16 @@
 # (c) Copyright Instana Inc. 2020
 
 import logging
-import pytest
-
-from typing import Generator
-from instana.instrumentation.psycopg2 import register_json_with_instana
-from tests.helpers import testenv
-from instana.singletons import agent, tracer
+from collections.abc import Generator
 
 import psycopg2
-import psycopg2.extras
+import psycopg2._json
 import psycopg2.extensions as ext
+import psycopg2.extras
+import pytest
+
+from instana.singletons import agent, tracer
+from tests.helpers import testenv
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class TestPsycoPG2:
         agent.options.allow_exit_as_root = False
 
     def test_register_json(self) -> None:
-        resp = register_json_with_instana(conn_or_curs=self.db)
+        resp = psycopg2._json.register_json(conn_or_curs=self.db)
         assert resp[0].values[0] == 114
         assert resp[1].values[0] == 199
 
@@ -302,12 +302,11 @@ class TestPsycoPG2:
         ext.register_type(ext.UUIDARRAY, self.cursor)
 
     def test_connect_cursor_ctx_mgr(self) -> None:
-        with tracer.start_as_current_span("test"):
-            with self.db as connection:
-                with connection.cursor() as cursor:
-                    cursor.execute("""SELECT * from users""")
-                    affected_rows = cursor.rowcount
-                    result = cursor.fetchone()
+        with tracer.start_as_current_span("test"), self.db as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("""SELECT * from users""")
+                affected_rows = cursor.rowcount
+                result = cursor.fetchone()
 
         assert affected_rows == 1
         assert len(result) == 6
@@ -331,12 +330,11 @@ class TestPsycoPG2:
         assert db_span.data["pg"]["port"] == testenv["postgresql_port"]
 
     def test_connect_ctx_mgr(self) -> None:
-        with tracer.start_as_current_span("test"):
-            with self.db as connection:
-                cursor = connection.cursor()
-                cursor.execute("""SELECT * from users""")
-                affected_rows = cursor.rowcount
-                result = cursor.fetchone()
+        with tracer.start_as_current_span("test"), self.db as connection:
+            cursor = connection.cursor()
+            cursor.execute("""SELECT * from users""")
+            affected_rows = cursor.rowcount
+            result = cursor.fetchone()
 
         assert affected_rows == 1
         assert len(result) == 6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@
 import importlib.util
 import os
 import sys
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 from opentelemetry.context.context import Context
@@ -26,7 +26,6 @@ from instana.tracer import InstanaTracerProvider
 from instana.util.runtime import get_runtime_env_info
 
 collect_ignore_glob = [
-    "*test_gevent*",
     "*collector/test_gcr*",
     "*agent/test_google*",
 ]
@@ -34,10 +33,12 @@ collect_ignore_glob = [
 # ppc64le and s390x have limitations with some supported libraries.
 machine, py_version = get_runtime_env_info()
 if machine in ["ppc64le", "s390x"]:
-    collect_ignore_glob.extend([
-        "*test_google-cloud*",
-        "*test_pymongo*",
-    ])
+    collect_ignore_glob.extend(
+        [
+            "*test_google-cloud*",
+            "*test_pymongo*",
+        ]
+    )
 
     if machine == "ppc64le":
         collect_ignore_glob.append("*test_grpcio*")
@@ -51,10 +52,7 @@ if not os.environ.get("COUCHBASE_TEST"):
     collect_ignore_glob.append("*test_couchbase*")
 
 if not os.environ.get("GEVENT_STARLETTE_TEST"):
-    collect_ignore_glob.extend([
-        "*test_gevent*",
-        "*test_starlette*",
-    ])
+    collect_ignore_glob.append("*test_gevent*")
 
 if not os.environ.get("KAFKA_TEST"):
     collect_ignore_glob.append("*kafka/test*")
@@ -63,16 +61,6 @@ if sys.version_info >= (3, 12):
     # Currently Spyne does not support python > 3.12
     collect_ignore_glob.append("*test_spyne*")
 
-
-if sys.version_info >= (3, 14):
-    collect_ignore_glob.extend([
-        # Currently not installable dependencies because of 3.14 incompatibilities
-        "*test_fastapi*",
-        # aiohttp-server tests failing due to deprecated methods used
-        "*test_aiohttp_server*",
-        # Currently Sanic does not support python >= 3.14
-        "*test_sanic*",
-    ])
 
 @pytest.fixture(scope="session")
 def celery_config():
@@ -176,7 +164,7 @@ def get_from_structure(monkeypatch, request) -> None:
     @return: dict()
     """
 
-    def _get_from_structure(_: object) -> Dict[str, Any]:
+    def _get_from_structure(_: object) -> dict[str, Any]:
         return {"e": os.getpid(), "h": "fake"}
 
     if "original" in request.keywords:
@@ -253,9 +241,11 @@ def announce(monkeypatch, request) -> None:
     else:
         monkeypatch.setattr(HostAgent, "announce", always_true)
 
+
 # Mocking the import of uwsgi
 def _uwsgi_masterpid() -> int:
     return 12345
+
 
 module = type(sys)("uwsgi")
 module.opt = {

--- a/tests/frameworks/test_tornado_client.py
+++ b/tests/frameworks/test_tornado_client.py
@@ -1,26 +1,27 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2020
 
-import time
 import asyncio
-import pytest
-from typing import Generator
+import time
+from collections.abc import Generator
 
+import pytest
 import tornado
 from tornado.httpclient import AsyncHTTPClient
-from instana.singletons import tracer, agent
-from instana.span.span import get_current_span
 
+import tests.apps.tornado_server  # noqa: F401
+from instana.singletons import agent, get_tracer
+from instana.span.span import get_current_span
 from instana.util.ids import hex_id
-import tests.apps.tornado_server
-from tests.helpers import testenv, get_first_span_by_name, get_first_span_by_filter
+from tests.helpers import get_first_span_by_filter, get_first_span_by_name, testenv
+
 
 class TestTornadoClient:
-
     @pytest.fixture(autouse=True)
     def _resource(self) -> Generator[None, None, None]:
-        """ Clear all spans before a test run """
-        self.recorder = tracer.span_processor
+        """Clear all spans before a test run"""
+        self.tracer = get_tracer()
+        self.recorder = self.tracer.span_processor
         self.recorder.clear_spans()
 
         # New event loop for every test
@@ -34,7 +35,7 @@ class TestTornadoClient:
 
     def test_get(self) -> None:
         async def test():
-            with tracer.start_as_current_span("test"):
+            with self.tracer.start_as_current_span("test"):
                 return await self.http_client.fetch(testenv["tornado_server"] + "/")
 
         response = tornado.ioloop.IOLoop.current().run_sync(test)
@@ -82,19 +83,21 @@ class TestTornadoClient:
         assert type(client_span.stack) is list
         assert len(client_span.stack) > 1
 
-        assert "X-INSTANA-T" in response.headers
+        assert response.headers.get("X-INSTANA-T")
         assert response.headers["X-INSTANA-T"] == hex_id(traceId)
-        assert "X-INSTANA-S" in response.headers
+        assert response.headers.get("X-INSTANA-S")
         assert response.headers["X-INSTANA-S"] == hex_id(server_span.s)
-        assert "X-INSTANA-L" in response.headers
-        assert response.headers["X-INSTANA-L"] == '1'
-        assert "Server-Timing" in response.headers
+        assert response.headers.get("X-INSTANA-L")
+        assert response.headers["X-INSTANA-L"] == "1"
+        assert response.headers.get("Server-Timing")
         assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_post(self) -> None:
         async def test():
-            with tracer.start_as_current_span("test"):
-                return await self.http_client.fetch(testenv["tornado_server"] + "/", method="POST", body='asdf')
+            with self.tracer.start_as_current_span("test"):
+                return await self.http_client.fetch(
+                    testenv["tornado_server"] + "/", method="POST", body="asdf"
+                )
 
         response = tornado.ioloop.IOLoop.current().run_sync(test)
         assert isinstance(response, tornado.httpclient.HTTPResponse)
@@ -137,18 +140,18 @@ class TestTornadoClient:
         assert type(client_span.stack) is list
         assert len(client_span.stack) > 1
 
-        assert "X-INSTANA-T" in response.headers
+        assert response.headers.get("X-INSTANA-T")
         assert response.headers["X-INSTANA-T"] == hex_id(traceId)
-        assert "X-INSTANA-S" in response.headers
+        assert response.headers.get("X-INSTANA-S")
         assert response.headers["X-INSTANA-S"] == hex_id(server_span.s)
-        assert "X-INSTANA-L" in response.headers
-        assert response.headers["X-INSTANA-L"] == '1'
-        assert "Server-Timing" in response.headers
+        assert response.headers.get("X-INSTANA-L")
+        assert response.headers["X-INSTANA-L"] == "1"
+        assert response.headers.get("Server-Timing")
         assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_get_301(self) -> None:
         async def test():
-            with tracer.start_as_current_span("test"):
+            with self.tracer.start_as_current_span("test"):
                 return await self.http_client.fetch(testenv["tornado_server"] + "/301")
 
         response = tornado.ioloop.IOLoop.current().run_sync(test)
@@ -164,13 +167,30 @@ class TestTornadoClient:
         client301_span = spans[3]
         test_span = spans[4]
 
-        filter = lambda span: span.n == "tornado-server" and span.data["http"]["status"] == 301
+        def filter(span):
+            return span.n == "tornado-server" and span.data["http"]["status"] == 301
+
         server301_span = get_first_span_by_filter(spans, filter)
-        filter = lambda span: span.n == "tornado-server" and span.data["http"]["status"] == 200
+
+        def filter(span):
+            return span.n == "tornado-server" and span.data["http"]["status"] == 200
+
         server_span = get_first_span_by_filter(spans, filter)
-        filter = lambda span: span.n == "tornado-client" and span.data["http"]["url"] == testenv["tornado_server"] + "/"
+
+        def filter(span):
+            return (
+                span.n == "tornado-client"
+                and span.data["http"]["url"] == testenv["tornado_server"] + "/"
+            )
+
         client_span = get_first_span_by_filter(spans, filter)
-        filter = lambda span: span.n == "tornado-client" and span.data["http"]["url"] == testenv["tornado_server"] + "/301"
+
+        def filter(span):
+            return (
+                span.n == "tornado-client"
+                and span.data["http"]["url"] == testenv["tornado_server"] + "/301"
+            )
+
         client301_span = get_first_span_by_filter(spans, filter)
         test_span = get_first_span_by_name(spans, "sdk")
 
@@ -222,20 +242,22 @@ class TestTornadoClient:
         assert type(client301_span.stack) is list
         assert len(client301_span.stack) > 1
 
-        assert "X-INSTANA-T" in response.headers
+        assert response.headers.get("X-INSTANA-T")
         assert response.headers["X-INSTANA-T"] == hex_id(traceId)
-        assert "X-INSTANA-S" in response.headers
+        assert response.headers.get("X-INSTANA-S")
         assert response.headers["X-INSTANA-S"] == hex_id(server_span.s)
-        assert "X-INSTANA-L" in response.headers
-        assert response.headers["X-INSTANA-L"] == '1'
-        assert "Server-Timing" in response.headers
+        assert response.headers.get("X-INSTANA-L")
+        assert response.headers["X-INSTANA-L"] == "1"
+        assert response.headers.get("Server-Timing")
         assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_get_405(self) -> None:
         async def test():
-            with tracer.start_as_current_span("test"):
+            with self.tracer.start_as_current_span("test"):
                 try:
-                    return await self.http_client.fetch(testenv["tornado_server"] + "/405")
+                    return await self.http_client.fetch(
+                        testenv["tornado_server"] + "/405"
+                    )
                 except tornado.httpclient.HTTPClientError as e:
                     return e.response
 
@@ -280,20 +302,22 @@ class TestTornadoClient:
         assert type(client_span.stack) is list
         assert len(client_span.stack) > 1
 
-        assert "X-INSTANA-T" in response.headers
+        assert response.headers.get("X-INSTANA-T")
         assert response.headers["X-INSTANA-T"] == hex_id(traceId)
-        assert "X-INSTANA-S" in response.headers
+        assert response.headers.get("X-INSTANA-S")
         assert response.headers["X-INSTANA-S"] == hex_id(server_span.s)
-        assert "X-INSTANA-L" in response.headers
-        assert response.headers["X-INSTANA-L"] == '1'
-        assert "Server-Timing" in response.headers
+        assert response.headers.get("X-INSTANA-L")
+        assert response.headers["X-INSTANA-L"] == "1"
+        assert response.headers.get("Server-Timing")
         assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_get_500(self) -> None:
         async def test():
-            with tracer.start_as_current_span("test"):
+            with self.tracer.start_as_current_span("test"):
                 try:
-                    return await self.http_client.fetch(testenv["tornado_server"] + "/500")
+                    return await self.http_client.fetch(
+                        testenv["tornado_server"] + "/500"
+                    )
                 except tornado.httpclient.HTTPClientError as e:
                     return e.response
 
@@ -338,20 +362,22 @@ class TestTornadoClient:
         assert type(client_span.stack) is list
         assert len(client_span.stack) > 1
 
-        assert "X-INSTANA-T" in response.headers
+        assert response.headers.get("X-INSTANA-T")
         assert response.headers["X-INSTANA-T"] == hex_id(traceId)
-        assert "X-INSTANA-S" in response.headers
+        assert response.headers.get("X-INSTANA-S")
         assert response.headers["X-INSTANA-S"] == hex_id(server_span.s)
-        assert "X-INSTANA-L" in response.headers
-        assert response.headers["X-INSTANA-L"] == '1'
-        assert "Server-Timing" in response.headers
+        assert response.headers.get("X-INSTANA-L")
+        assert response.headers["X-INSTANA-L"] == "1"
+        assert response.headers.get("Server-Timing")
         assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_get_504(self) -> None:
         async def test():
-            with tracer.start_as_current_span("test"):
+            with self.tracer.start_as_current_span("test"):
                 try:
-                    return await self.http_client.fetch(testenv["tornado_server"] + "/504")
+                    return await self.http_client.fetch(
+                        testenv["tornado_server"] + "/504"
+                    )
                 except tornado.httpclient.HTTPClientError as e:
                     return e.response
 
@@ -396,19 +422,21 @@ class TestTornadoClient:
         assert type(client_span.stack) is list
         assert len(client_span.stack) > 1
 
-        assert "X-INSTANA-T" in response.headers
+        assert response.headers.get("X-INSTANA-T")
         assert response.headers["X-INSTANA-T"] == hex_id(traceId)
-        assert "X-INSTANA-S" in response.headers
+        assert response.headers.get("X-INSTANA-S")
         assert response.headers["X-INSTANA-S"] == hex_id(server_span.s)
-        assert "X-INSTANA-L" in response.headers
-        assert response.headers["X-INSTANA-L"] == '1'
-        assert "Server-Timing" in response.headers
+        assert response.headers.get("X-INSTANA-L")
+        assert response.headers["X-INSTANA-L"] == "1"
+        assert response.headers.get("Server-Timing")
         assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_get_with_params_to_scrub(self) -> None:
         async def test():
-            with tracer.start_as_current_span("test"):
-                return await self.http_client.fetch(testenv["tornado_server"] + "/?secret=yeah")
+            with self.tracer.start_as_current_span("test"):
+                return await self.http_client.fetch(
+                    testenv["tornado_server"] + "/?secret=yeah"
+                )
 
         response = tornado.ioloop.IOLoop.current().run_sync(test)
         assert isinstance(response, tornado.httpclient.HTTPResponse)
@@ -440,25 +468,25 @@ class TestTornadoClient:
         assert server_span.n == "tornado-server"
         assert server_span.data["http"]["status"] == 200
         assert testenv["tornado_server"] + "/" == server_span.data["http"]["url"]
-        assert 'secret=<redacted>' == server_span.data["http"]["params"]
+        assert "secret=<redacted>" == server_span.data["http"]["params"]
         assert server_span.data["http"]["method"] == "GET"
 
         assert client_span.n == "tornado-client"
         assert client_span.data["http"]["status"] == 200
         assert testenv["tornado_server"] + "/" == client_span.data["http"]["url"]
-        assert 'secret=<redacted>' == client_span.data["http"]["params"]
+        assert "secret=<redacted>" == client_span.data["http"]["params"]
         assert client_span.data["http"]["method"] == "GET"
         assert client_span.stack
         assert type(client_span.stack) is list
         assert len(client_span.stack) > 1
 
-        assert "X-INSTANA-T" in response.headers
+        assert response.headers.get("X-INSTANA-T")
         assert response.headers["X-INSTANA-T"] == hex_id(traceId)
-        assert "X-INSTANA-S" in response.headers
+        assert response.headers.get("X-INSTANA-S")
         assert response.headers["X-INSTANA-S"] == hex_id(server_span.s)
-        assert "X-INSTANA-L" in response.headers
-        assert response.headers["X-INSTANA-L"] == '1'
-        assert "Server-Timing" in response.headers
+        assert response.headers.get("X-INSTANA-L")
+        assert response.headers["X-INSTANA-L"] == "1"
+        assert response.headers.get("Server-Timing")
         assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
     def test_request_header_capture(self) -> None:
@@ -472,8 +500,10 @@ class TestTornadoClient:
         }
 
         async def test():
-            with tracer.start_as_current_span("test"):
-                return await self.http_client.fetch(testenv["tornado_server"] + "/", headers=request_headers)
+            with self.tracer.start_as_current_span("test"):
+                return await self.http_client.fetch(
+                    testenv["tornado_server"] + "/", headers=request_headers
+                )
 
         response = tornado.ioloop.IOLoop.current().run_sync(test)
         assert isinstance(response, tornado.httpclient.HTTPResponse)
@@ -517,13 +547,13 @@ class TestTornadoClient:
         assert type(client_span.stack) is list
         assert len(client_span.stack) > 1
 
-        assert "X-INSTANA-T" in response.headers
+        assert response.headers.get("X-INSTANA-T")
         assert response.headers["X-INSTANA-T"] == hex_id(traceId)
-        assert "X-INSTANA-S" in response.headers
+        assert response.headers.get("X-INSTANA-S")
         assert response.headers["X-INSTANA-S"] == hex_id(server_span.s)
-        assert "X-INSTANA-L" in response.headers
-        assert response.headers["X-INSTANA-L"] == '1'
-        assert "Server-Timing" in response.headers
+        assert response.headers.get("X-INSTANA-L")
+        assert response.headers["X-INSTANA-L"] == "1"
+        assert response.headers.get("Server-Timing")
         assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
         assert "X-Capture-This" in client_span.data["http"]["header"]
@@ -539,8 +569,10 @@ class TestTornadoClient:
         agent.options.extra_http_headers = ["X-Capture-This-Too", "X-Capture-That-Too"]
 
         async def test():
-            with tracer.start_as_current_span("test"):
-                return await self.http_client.fetch(testenv["tornado_server"] + "/response_headers")
+            with self.tracer.start_as_current_span("test"):
+                return await self.http_client.fetch(
+                    testenv["tornado_server"] + "/response_headers"
+                )
 
         response = tornado.ioloop.IOLoop.current().run_sync(test)
         assert isinstance(response, tornado.httpclient.HTTPResponse)
@@ -572,25 +604,31 @@ class TestTornadoClient:
 
         assert server_span.n == "tornado-server"
         assert server_span.data["http"]["status"] == 200
-        assert testenv["tornado_server"] + "/response_headers" == server_span.data["http"]["url"]
+        assert (
+            testenv["tornado_server"] + "/response_headers"
+            == server_span.data["http"]["url"]
+        )
         assert not server_span.data["http"]["params"]
         assert server_span.data["http"]["method"] == "GET"
 
         assert client_span.n == "tornado-client"
         assert client_span.data["http"]["status"] == 200
-        assert testenv["tornado_server"] + "/response_headers" == client_span.data["http"]["url"]
+        assert (
+            testenv["tornado_server"] + "/response_headers"
+            == client_span.data["http"]["url"]
+        )
         assert client_span.data["http"]["method"] == "GET"
         assert client_span.stack
         assert type(client_span.stack) is list
         assert len(client_span.stack) > 1
 
-        assert "X-INSTANA-T" in response.headers
+        assert response.headers.get("X-INSTANA-T")
         assert response.headers["X-INSTANA-T"] == hex_id(traceId)
-        assert "X-INSTANA-S" in response.headers
+        assert response.headers.get("X-INSTANA-S")
         assert response.headers["X-INSTANA-S"] == hex_id(server_span.s)
-        assert "X-INSTANA-L" in response.headers
-        assert response.headers["X-INSTANA-L"] == '1'
-        assert "Server-Timing" in response.headers
+        assert response.headers.get("X-INSTANA-L")
+        assert response.headers["X-INSTANA-L"] == "1"
+        assert response.headers.get("Server-Timing")
         assert response.headers["Server-Timing"] == f"intid;desc={hex_id(traceId)}"
 
         assert "X-Capture-This-Too" in client_span.data["http"]["header"]

--- a/tests/requirements-cassandra.txt
+++ b/tests/requirements-cassandra.txt
@@ -1,4 +1,4 @@
 -r requirements-minimal.txt
 cassandra-driver>=3.20.2
 mock>=2.0.0
-urllib3>=1.26.5
+urllib3>=2.7.0

--- a/tests/requirements-gevent-starlette.txt
+++ b/tests/requirements-gevent-starlette.txt
@@ -4,6 +4,6 @@ gevent>=1.4.0
 mock>=2.0.0
 pyramid>=2.0.1
 starlette>=0.12.13
-urllib3>=1.26.5
+urllib3>=2.7.0
 uvicorn>=0.13.4
 httpx>=0.27.0

--- a/tests/requirements-pre314.txt
+++ b/tests/requirements-pre314.txt
@@ -38,6 +38,6 @@ starlette>=0.38.2
 sqlalchemy>=2.0.0
 tornado>=6.4.1
 uvicorn>=0.13.4
-urllib3>=1.26.5
+urllib3>=2.7.0
 httpx>=0.27.0
 protobuf<=6.30.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,8 +1,7 @@
 -r requirements-minimal.txt
 aioamqp>=0.15.0
 aiofiles>=0.5.0
-aiohttp<=3.10.11; python_version <= "3.8"
-aiohttp>=3.8.3; python_version > "3.8"
+aiohttp>=3.8.3
 aio-pika>=9.5.2
 boto3>=1.17.74
 bottle>=0.12.25
@@ -11,7 +10,6 @@ Django>=4.2.16
 fastapi>=0.92.0; python_version < "3.13"
 fastapi>=0.115.0; python_version >= "3.13"
 flask>=2.3.2
-gevent>=1.4.0
 grpcio>=1.14.1
 google-cloud-pubsub>=2.0.0
 google-cloud-storage>=1.24.0
@@ -31,14 +29,12 @@ pytz>=2024.1
 redis>=3.5.3
 requests-mock
 responses<=0.17.0
-sanic<=24.6.0; python_version < "3.9"
-sanic>=19.9.0; python_version >= "3.9"
+sanic>=19.9.0
 sanic-testing>=24.6.0
 spyne>=2.14.0; python_version < "3.12"
 sqlalchemy>=2.0.0
 starlette>=0.38.2; python_version == "3.13"
 tornado>=6.4.1
-tracerite<=1.1.1; python_version < "3.9"
 uvicorn>=0.13.4
-urllib3>=1.26.5
+urllib3>=2.7.0
 httpx>=0.27.0

--- a/tests_aws/01_lambda/conftest.py
+++ b/tests_aws/01_lambda/conftest.py
@@ -2,7 +2,6 @@
 # (c) Copyright Instana Inc. 2020
 
 import os
-import sys
 
 import pytest
 


### PR DESCRIPTION
# Summary

This pull request raises the `urllib3` lower bound to 2.7.0 across `pyproject.toml` and all test requirements files to address CVE-2026-44432 and CVE-2026-44431. It also sets `requires-python` to >=3.10; remove the Python 3.9 classifier and add
  Python 3.14 classifier. Finally, it bumps the package version to `3.5.0.post2`.

# Files Changed

📄 `src/instana/version.py`

Bumps the package version from `3.5.0.post1` to `3.5.0.post2`.

---

📄 `tests/requirements-cassandra.txt`

Upgrades the `urllib3` minimum version requirement from `>=1.26.5` to `>=2.7.0`.

---

📄 `tests/requirements-gevent-starlette.txt`

Upgrades the `urllib3` minimum version requirement from `>=1.26.5` to `>=2.7.0`.

---

📄 `tests/requirements-pre314.txt`

Upgrades the `urllib3` minimum version requirement from `>=1.26.5` to `>=2.7.0`.

---

📄 `tests/requirements.txt`

- Removes the Python `<=3.8` conditional pin for `aiohttp`, consolidating it to a single `aiohttp>=3.8.3` requirement for all Python versions.
- Removes the Python `<3.9` conditional pin for `sanic`, consolidating it to a single `sanic>=19.9.0` requirement for all Python versions.
- Removes the `tracerite<=1.1.1` dependency that was conditionally applied for Python `<3.9`.
- Upgrades the `urllib3` minimum version requirement from `>=1.26.5` to `>=2.7.0`.

---

📄 `tests_aws/01_lambda/conftest.py`

Removes an unused `import sys` statement from the AWS Lambda test configuration file.