### PR TITLE
fix(sqlalchemy): use connection span in after cursor execute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,4 +106,3 @@ uv.lock
 # Sandbox
 sandbox/
 .bob/
-.serena/

--- a/src/instana/instrumentation/sqlalchemy.py
+++ b/src/instana/instrumentation/sqlalchemy.py
@@ -9,7 +9,7 @@ from opentelemetry import context, trace
 from opentelemetry.context import get_current
 
 from instana.log import logger
-from instana.span.span import InstanaSpan, get_current_span
+from instana.span.span import InstanaSpan
 from instana.span_context import SpanContext
 from instana.util.traceutils import get_tracer_tuple
 
@@ -56,15 +56,15 @@ try:
         **kw: Dict[str, Any],
     ) -> None:
         try:
-            tracer = get_tracer_tuple()
-            # If we're not tracing, just return
-            if not tracer:
+            conn = kw["conn"]
+            span = getattr(conn, "span", None)
+            if span is None:
                 return
 
-            current_span = get_current_span()
-            conn = kw["conn"]
-            if current_span.is_recording():
-                current_span.end()
+            if span.is_recording():
+                span.end()
+            conn.span = None
+
             if hasattr(conn, "token"):
                 context.detach(conn.token)
                 conn.token = None

--- a/tests/clients/test_sqlalchemy.py
+++ b/tests/clients/test_sqlalchemy.py
@@ -292,5 +292,39 @@ class TestSQLAlchemy:
                 )
             )
 
+        # No active trace context → after_cursor_execute should skip via conn.span is None
+        spans = self.recorder.queued_spans()
+        assert len(spans) == 0
+
+        current_span = get_current_span()
+        assert not current_span.is_recording()
+
+    def test_context_restored_after_query(self) -> None:
+        """After a sqlalchemy span completes, the OTel context must be restored to
+        the parent span so that subsequent instrumentation (e.g. redis) can still
+        find the correct parent.  This validates the fix for the bug where
+        after_cursor_execute used get_current_span() instead of conn.span, which
+        could corrupt the context stack and cause child spans to be dropped."""
+        with self.tracer.start_as_current_span("test") as parent_span:
+            with engine.begin() as connection:
+                connection.execute(text("select 1"))
+
+            # After the sqlalchemy span ends, the active span must be back to
+            # the parent — not INVALID_SPAN and not the (now-ended) sqlalchemy span.
+            active_after = get_current_span()
+            assert active_after.is_recording()
+            assert active_after.name == "test"
+
+        spans = self.recorder.queued_spans()
+        # 1 sqlalchemy span + 1 test span
+        assert len(spans) == 2
+
+        sql_span = spans[0]
+        test_span = spans[1]
+
+        assert sql_span.n == "sqlalchemy"
+        assert sql_span.t == test_span.t
+        assert sql_span.p == test_span.s
+
         current_span = get_current_span()
         assert not current_span.is_recording()


### PR DESCRIPTION
### What changed

`receive_after_cursor_execute` in `sqlalchemy.py` had two bugs:

1. **Guard check was dead code.** `get_tracer_tuple()` returns a tuple, so `if not tracer:` was always `False` — the early-return path never ran.

2. **Wrong span was closed.** `get_current_span()` reads from the global OTel context, which could be a different span than the one opened in `before_cursor_execute`. This corrupted the context stack and caused subsequent child spans (e.g. Redis) to be silently dropped.

**Fix:** close `conn.span` directly — the span stored on the connection object by `before_cursor_execute` — instead of reading from global context.

### Tests

- `test_if_not_tracing`: added `assert len(spans) == 0`
- `test_context_restored_after_query`: new test asserting the parent span is active again after a SQL query completes